### PR TITLE
Reduce iOS release AOT time for OpenXML

### DIFF
--- a/app/MyFireNumber/MyFireNumber.csproj
+++ b/app/MyFireNumber/MyFireNumber.csproj
@@ -52,6 +52,11 @@
 		<RunAOTCompilation>false</RunAOTCompilation>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' and '$(Configuration)' == 'Release'">
+		<!-- Spreadsheet exports are infrequent, and interpreting OpenXML avoids its expensive iOS AOT compilation. -->
+		<MtouchInterpreter>DocumentFormat.OpenXml,DocumentFormat.OpenXml.Framework</MtouchInterpreter>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#17352C" />


### PR DESCRIPTION
The signed iOS archive timed out while `mono-aot-cross` was compiling dependencies after IL stripping. OpenXML is used only for occasional spreadsheet exports, so fully AOT-compiling its large generated assemblies adds substantial build cost without benefiting normal app execution.

This configures `DocumentFormat.OpenXml` and `DocumentFormat.OpenXml.Framework` to use the supported Mono interpreter for iOS Release builds. The app, charts, and remaining dependencies continue to be AOT-compiled, and Android behavior is unchanged.

Validated with a Release iOS simulator build and all 79 shared calculation, storage, and export tests.