### PR TITLE
Add fiery ember glow to app icon and splash screen

### DIFF
--- a/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
+++ b/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
@@ -7,15 +7,17 @@
             <stop offset="1" stop-color="#FDE68A" />
         </linearGradient>
         <radialGradient id="emberGlow" cx="0.5" cy="0.5" r="0.5">
-            <stop offset="0" stop-color="#FB923C" stop-opacity="0.38" />
-            <stop offset="0.45" stop-color="#F97316" stop-opacity="0.14" />
+            <stop offset="0" stop-color="#FB923C" stop-opacity="0.4" />
+            <stop offset="0.22" stop-color="#F97316" stop-opacity="0.2" />
+            <stop offset="0.5" stop-color="#F97316" stop-opacity="0.1" />
+            <stop offset="0.78" stop-color="#F97316" stop-opacity="0.04" />
             <stop offset="1" stop-color="#F97316" stop-opacity="0" />
         </radialGradient>
     </defs>
     <!-- The highlighted center cell represents "your number" - the single figure the app solves for.
          A soft ember glow spills into the surrounding cells so the whole grid feels lit by it. -->
     <g transform="skewX(-5.81)">
-        <ellipse cx="259.6" cy="232" rx="118" ry="108" fill="url(#emberGlow)" />
+        <ellipse cx="259.6" cy="232" rx="205" ry="195" fill="url(#emberGlow)" />
         <rect x="233.6" y="206" width="52" height="52" fill="url(#ember)" />
     </g>
     <g fill="none" stroke="#FFF3D6" stroke-width="40" stroke-linecap="round">

--- a/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
+++ b/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
@@ -6,18 +6,33 @@
             <stop offset="0.55" stop-color="#FBBF24" />
             <stop offset="1" stop-color="#FDE68A" />
         </linearGradient>
+        <linearGradient id="emberSoft" x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0" stop-color="#EA580C" />
+            <stop offset="1" stop-color="#F97316" />
+        </linearGradient>
         <radialGradient id="emberGlow" cx="0.5" cy="0.5" r="0.5">
-            <stop offset="0" stop-color="#FB923C" stop-opacity="0.4" />
-            <stop offset="0.22" stop-color="#F97316" stop-opacity="0.2" />
+            <stop offset="0" stop-color="#FB923C" stop-opacity="0.3" />
+            <stop offset="0.22" stop-color="#F97316" stop-opacity="0.15" />
             <stop offset="0.5" stop-color="#F97316" stop-opacity="0.1" />
             <stop offset="0.78" stop-color="#F97316" stop-opacity="0.04" />
             <stop offset="1" stop-color="#F97316" stop-opacity="0" />
         </radialGradient>
     </defs>
     <!-- The highlighted center cell represents "your number" - the single figure the app solves for.
-         A soft ember glow spills into the surrounding cells so the whole grid feels lit by it. -->
+         The surrounding eight cells carry the same ember at low opacity so the fire reads across
+         the whole grid without competing with the numeral. -->
     <g transform="skewX(-5.81)">
         <ellipse cx="259.6" cy="232" rx="205" ry="195" fill="url(#emberGlow)" />
+        <g fill="url(#emberSoft)">
+            <rect x="141.6" y="114" width="52" height="52" rx="9" ry="9" opacity="0.08" />
+            <rect x="233.6" y="114" width="52" height="52" rx="9" ry="9" opacity="0.17" />
+            <rect x="325.6" y="114" width="52" height="52" rx="9" ry="9" opacity="0.08" />
+            <rect x="141.6" y="206" width="52" height="52" rx="9" ry="9" opacity="0.17" />
+            <rect x="325.6" y="206" width="52" height="52" rx="9" ry="9" opacity="0.17" />
+            <rect x="141.6" y="298" width="52" height="52" rx="9" ry="9" opacity="0.08" />
+            <rect x="233.6" y="298" width="52" height="52" rx="9" ry="9" opacity="0.17" />
+            <rect x="325.6" y="298" width="52" height="52" rx="9" ry="9" opacity="0.08" />
+        </g>
         <rect x="233.6" y="206" width="52" height="52" fill="url(#ember)" />
     </g>
     <g fill="none" stroke="#FFF3D6" stroke-width="40" stroke-linecap="round">

--- a/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
+++ b/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
@@ -6,35 +6,19 @@
             <stop offset="0.55" stop-color="#FBBF24" />
             <stop offset="1" stop-color="#FDE68A" />
         </linearGradient>
-        <linearGradient id="emberSoft" x1="0" y1="1" x2="0" y2="0">
-            <stop offset="0" stop-color="#EA580C" />
-            <stop offset="1" stop-color="#F97316" />
-        </linearGradient>
         <radialGradient id="emberGlow" cx="0.5" cy="0.5" r="0.5">
-            <stop offset="0" stop-color="#FB923C" stop-opacity="0.3" />
-            <stop offset="0.22" stop-color="#F97316" stop-opacity="0.15" />
-            <stop offset="0.5" stop-color="#F97316" stop-opacity="0.1" />
-            <stop offset="0.78" stop-color="#F97316" stop-opacity="0.04" />
-            <stop offset="1" stop-color="#F97316" stop-opacity="0" />
+            <stop offset="0" stop-color="#FDBA74" stop-opacity="0.5" />
+            <stop offset="0.18" stop-color="#FB923C" stop-opacity="0.34" />
+            <stop offset="0.38" stop-color="#F97316" stop-opacity="0.19" />
+            <stop offset="0.62" stop-color="#F97316" stop-opacity="0.09" />
+            <stop offset="0.82" stop-color="#EA580C" stop-opacity="0.03" />
+            <stop offset="1" stop-color="#EA580C" stop-opacity="0" />
         </radialGradient>
     </defs>
     <!-- The highlighted center cell represents "your number" - the single figure the app solves for.
-         The surrounding eight cells carry the same ember at low opacity so the fire reads across
-         the whole grid without competing with the numeral. -->
-    <g transform="skewX(-5.81)">
-        <ellipse cx="259.6" cy="232" rx="205" ry="195" fill="url(#emberGlow)" />
-        <g fill="url(#emberSoft)">
-            <rect x="141.6" y="114" width="52" height="52" rx="9" ry="9" opacity="0.08" />
-            <rect x="233.6" y="114" width="52" height="52" rx="9" ry="9" opacity="0.17" />
-            <rect x="325.6" y="114" width="52" height="52" rx="9" ry="9" opacity="0.08" />
-            <rect x="141.6" y="206" width="52" height="52" rx="9" ry="9" opacity="0.17" />
-            <rect x="325.6" y="206" width="52" height="52" rx="9" ry="9" opacity="0.17" />
-            <rect x="141.6" y="298" width="52" height="52" rx="9" ry="9" opacity="0.08" />
-            <rect x="233.6" y="298" width="52" height="52" rx="9" ry="9" opacity="0.17" />
-            <rect x="325.6" y="298" width="52" height="52" rx="9" ry="9" opacity="0.08" />
-        </g>
-        <rect x="233.6" y="206" width="52" height="52" fill="url(#ember)" />
-    </g>
+         A circular ember radiates outward from it so the heat reaches every cell of the grid. -->
+    <circle cx="236" cy="232" r="220" fill="url(#emberGlow)" />
+    <rect x="233.6" y="206" width="52" height="52" transform="skewX(-5.81)" fill="url(#ember)" />
     <g fill="none" stroke="#FFF3D6" stroke-width="40" stroke-linecap="round">
         <path d="M118 186H338" />
         <path d="M118 278H338" />

--- a/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
+++ b/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
@@ -7,11 +7,11 @@
             <stop offset="1" stop-color="#FDE68A" />
         </linearGradient>
         <radialGradient id="emberGlow" cx="0.5" cy="0.5" r="0.5">
-            <stop offset="0" stop-color="#FDBA74" stop-opacity="0.5" />
-            <stop offset="0.18" stop-color="#FB923C" stop-opacity="0.34" />
-            <stop offset="0.38" stop-color="#F97316" stop-opacity="0.19" />
-            <stop offset="0.62" stop-color="#F97316" stop-opacity="0.09" />
-            <stop offset="0.82" stop-color="#EA580C" stop-opacity="0.03" />
+            <stop offset="0" stop-color="#FDBA74" stop-opacity="0.72" />
+            <stop offset="0.18" stop-color="#FB923C" stop-opacity="0.52" />
+            <stop offset="0.38" stop-color="#F97316" stop-opacity="0.3" />
+            <stop offset="0.62" stop-color="#F97316" stop-opacity="0.15" />
+            <stop offset="0.82" stop-color="#EA580C" stop-opacity="0.05" />
             <stop offset="1" stop-color="#EA580C" stop-opacity="0" />
         </radialGradient>
     </defs>

--- a/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
+++ b/app/MyFireNumber/Resources/AppIcon/appiconfg.svg
@@ -1,7 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <!-- The highlighted center cell represents "your number" - the single figure the app solves for. -->
-    <rect x="233.6" y="206" width="52" height="52" transform="skewX(-5.81)" fill="#FBBF24" />
+    <defs>
+        <linearGradient id="ember" x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0" stop-color="#F97316" />
+            <stop offset="0.55" stop-color="#FBBF24" />
+            <stop offset="1" stop-color="#FDE68A" />
+        </linearGradient>
+        <radialGradient id="emberGlow" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0" stop-color="#FB923C" stop-opacity="0.38" />
+            <stop offset="0.45" stop-color="#F97316" stop-opacity="0.14" />
+            <stop offset="1" stop-color="#F97316" stop-opacity="0" />
+        </radialGradient>
+    </defs>
+    <!-- The highlighted center cell represents "your number" - the single figure the app solves for.
+         A soft ember glow spills into the surrounding cells so the whole grid feels lit by it. -->
+    <g transform="skewX(-5.81)">
+        <ellipse cx="259.6" cy="232" rx="118" ry="108" fill="url(#emberGlow)" />
+        <rect x="233.6" y="206" width="52" height="52" fill="url(#ember)" />
+    </g>
     <g fill="none" stroke="#FFF3D6" stroke-width="40" stroke-linecap="round">
         <path d="M118 186H338" />
         <path d="M118 278H338" />

--- a/app/MyFireNumber/Resources/Splash/splash.svg
+++ b/app/MyFireNumber/Resources/Splash/splash.svg
@@ -1,7 +1,24 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="128" height="128" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <!-- The highlighted center cell represents "your number" - the single figure the app solves for. -->
-    <rect x="233.6" y="206" width="52" height="52" transform="skewX(-5.81)" fill="#FBBF24" />
+    <defs>
+        <linearGradient id="ember" x1="0" y1="1" x2="0" y2="0">
+            <stop offset="0" stop-color="#F97316" />
+            <stop offset="0.55" stop-color="#FBBF24" />
+            <stop offset="1" stop-color="#FDE68A" />
+        </linearGradient>
+        <radialGradient id="emberGlow" cx="0.5" cy="0.5" r="0.5">
+            <stop offset="0" stop-color="#FDBA74" stop-opacity="0.72" />
+            <stop offset="0.18" stop-color="#FB923C" stop-opacity="0.52" />
+            <stop offset="0.38" stop-color="#F97316" stop-opacity="0.3" />
+            <stop offset="0.62" stop-color="#F97316" stop-opacity="0.15" />
+            <stop offset="0.82" stop-color="#EA580C" stop-opacity="0.05" />
+            <stop offset="1" stop-color="#EA580C" stop-opacity="0" />
+        </radialGradient>
+    </defs>
+    <!-- The highlighted center cell represents "your number" - the single figure the app solves for.
+         A circular ember radiates outward from it so the heat reaches every cell of the grid. -->
+    <circle cx="236" cy="232" r="220" fill="url(#emberGlow)" />
+    <rect x="233.6" y="206" width="52" height="52" transform="skewX(-5.81)" fill="url(#ember)" />
     <g fill="none" stroke="#FFF3D6" stroke-width="40" stroke-linecap="round">
         <path d="M118 186H338" />
         <path d="M118 278H338" />


### PR DESCRIPTION
The app icon's center cell, the one that represents "your FIRE number", was a flat yellow square. For an app called My FIRE Number, the mark did not read as fiery at all. This warms up the brand mark so the center cell actually looks like it is burning, while keeping it subtle enough not to compete with the hash numeral.

![Icon and splash before/after](https://github.com/user-attachments/assets/9d0e57b5-76e5-48f1-bdc7-9523e6abc64e)

## Approach

Two additions to the foreground SVG, both drawn beneath the existing hash strokes so the numeral stays crisp and unchanged:

- The center cell is now a vertical `linearGradient` (deep orange at the base, through amber, to pale gold at the top) instead of solid `#FBBF24`, giving it a flame-lit feel.
- A circular `radialGradient` burst radiates from that cell across the whole icon. Six stops give a bright core that tapers smoothly to fully transparent at the edge, so the heat spills through the gaps into the surrounding cells without any hard boundary.

The same artwork is now applied to `splash.svg`, which had drifted out of sync and was still using the old flat yellow square. Icon and splash now share identical gradient definitions.

## Notes for review

- Everything sits under the existing `skewX(-5.81)` geometry, so the ember rect still lines up exactly with the italic bars. The glow circle is unskewed on purpose, since a skewed radial burst reads as lopsided.
- The glow radius extends past the hash arms on all sides and fades to zero before the artboard edge, so it survives the iOS and Android icon mask crops and does not show a visible circle edge on the full screen splash.
- Outer cells are lit purely by the radial glow. An earlier attempt painted the eight surrounding cells with explicit rects, but pale gold over the dark green background turned olive and muddy, so that approach was dropped in favor of the circular gradient.
- No color, layout, or calculation code changed. This is artwork only, and the dark background layer (`appicon.svg`) is untouched.

## Validation

Verified through the real MAUI image pipeline rather than just a local SVG renderer: ran `dotnet build -f net10.0-maccatalyst -t:ResizetizeImages` and inspected the generated PNGs to confirm Resizetizer renders the multi stop gradients correctly at both large and small sizes. Worth noting that the first such run served a stale cached PNG, so the resizetizer obj folder has to be cleared to see changes. Both SVGs validate as well formed XML.