### PR TITLE
Add first-run welcome experience

### DIFF
--- a/app/MyFireNumber/AppShell.xaml.cs
+++ b/app/MyFireNumber/AppShell.xaml.cs
@@ -27,6 +27,7 @@ public partial class AppShell : Shell
 		Items.Add(CreateTab("Settings", "settings", "tab_settings.png", settingsPage));
 
 		Routing.RegisterRoute("quiz", typeof(QuizPage));
+		Routing.RegisterRoute("welcome", typeof(WelcomePage));
 		Routing.RegisterRoute("onboarding-defaults", typeof(DefaultsOnboardingPage));
 		Routing.RegisterRoute("calculator", typeof(CalculatorDetailPage));
 		Routing.RegisterRoute("retirement-annual-details", typeof(RetirementAnnualDetailsPage));
@@ -61,7 +62,9 @@ public partial class AppShell : Shell
 		hasPresentedOnboarding = true;
 		if (!onboardingService.IsComplete)
 		{
-			await GoToAsync("onboarding-defaults");
+			await GoToAsync(onboardingService.HasSeenWelcome
+				? "onboarding-defaults"
+				: "welcome");
 			return;
 		}
 

--- a/app/MyFireNumber/MauiProgram.cs
+++ b/app/MyFireNumber/MauiProgram.cs
@@ -10,7 +10,7 @@ using SkiaSharp.Views.Maui.Controls.Hosting;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 #endif
-#if MAUI_DEVFLOW
+#if MAUI_DEVFLOW && !IOS
 using Microsoft.Maui.DevFlow.Agent;
 #endif
 
@@ -85,6 +85,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<SettingsPage>();
 		builder.Services.AddTransient<CalculatorDetailPage>();
 		builder.Services.AddTransient<QuizPage>();
+		builder.Services.AddTransient<WelcomePage>();
 		builder.Services.AddTransient<DefaultsOnboardingPage>();
 		builder.Services.AddTransient<RetirementAnnualDetailsPage>();
 		builder.Services.AddSingleton<HomeViewModel>();
@@ -93,10 +94,12 @@ public static class MauiProgram
 		builder.Services.AddSingleton<SettingsViewModel>();
 		builder.Services.AddTransient<CalculatorDetailViewModel>();
 		builder.Services.AddTransient<QuizViewModel>();
+		builder.Services.AddTransient<WelcomeViewModel>();
 		builder.Services.AddTransient<DefaultsOnboardingViewModel>();
 		builder.Services.AddTransient<RetirementAnnualDetailsViewModel>();
 
-#if MAUI_DEVFLOW
+#if MAUI_DEVFLOW && !IOS
+		// The current DevFlow preview fails MAUI native class registration on iOS at startup.
 		builder.AddMauiDevFlowAgent();
 #endif
 

--- a/app/MyFireNumber/Platforms/iOS/Info.plist
+++ b/app/MyFireNumber/Platforms/iOS/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/app/MyFireNumber/Services/OnboardingService.cs
+++ b/app/MyFireNumber/Services/OnboardingService.cs
@@ -2,9 +2,11 @@ namespace MyFireNumber.Services;
 
 public interface IOnboardingService
 {
+    bool HasSeenWelcome { get; }
     bool IsComplete { get; }
     string? RecommendationCalculatorId { get; }
 
+    void MarkWelcomeSeen();
     void Complete();
     void SetRecommendation(string calculatorId);
 
@@ -13,11 +15,18 @@ public interface IOnboardingService
 
 public sealed class OnboardingService : IOnboardingService
 {
+    private const string WelcomeSeenKey = "onboarding-welcome-seen";
     private const string CompletionKey = "onboarding-completed";
     private const string RecommendationKey = "onboarding-recommendation-calculator";
 
+    public bool HasSeenWelcome => Preferences.Default.Get(WelcomeSeenKey, false);
     public bool IsComplete => Preferences.Default.Get(CompletionKey, false);
     public string? RecommendationCalculatorId => Preferences.Default.Get<string?>(RecommendationKey, null);
+
+    public void MarkWelcomeSeen()
+    {
+        Preferences.Default.Set(WelcomeSeenKey, true);
+    }
 
     public void Complete()
     {
@@ -31,6 +40,7 @@ public sealed class OnboardingService : IOnboardingService
 
     public void Reset()
     {
+        Preferences.Default.Remove(WelcomeSeenKey);
         Preferences.Default.Remove(CompletionKey);
         Preferences.Default.Remove(RecommendationKey);
     }

--- a/app/MyFireNumber/ViewModels/WelcomeViewModel.cs
+++ b/app/MyFireNumber/ViewModels/WelcomeViewModel.cs
@@ -1,0 +1,26 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using MyFireNumber.Services;
+
+namespace MyFireNumber.ViewModels;
+
+public partial class WelcomeViewModel : ObservableObject
+{
+    private readonly IOnboardingService onboardingService;
+    private readonly INavigationService navigationService;
+
+    public WelcomeViewModel(
+        IOnboardingService onboardingService,
+        INavigationService navigationService)
+    {
+        this.onboardingService = onboardingService;
+        this.navigationService = navigationService;
+    }
+
+    [RelayCommand]
+    private async Task GetStartedAsync()
+    {
+        onboardingService.MarkWelcomeSeen();
+        await navigationService.GoToAsync("../onboarding-defaults");
+    }
+}

--- a/app/MyFireNumber/Views/WelcomePage.xaml
+++ b/app/MyFireNumber/Views/WelcomePage.xaml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:MyFireNumber.Views.Controls"
+             xmlns:viewModels="clr-namespace:MyFireNumber.ViewModels"
+             x:Class="MyFireNumber.Views.WelcomePage"
+             x:DataType="viewModels:WelcomeViewModel"
+             Title="Welcome"
+             Shell.NavBarIsVisible="False"
+             Shell.TabBarIsVisible="False"
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+    <Grid Padding="24,32,24,24"
+          RowDefinitions="*,Auto">
+        <VerticalStackLayout Grid.Row="0"
+                             VerticalOptions="Center"
+                             Spacing="24">
+            <Border HorizontalOptions="Center"
+                    Padding="20"
+                    Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}"
+                    StrokeThickness="0"
+                    StrokeShape="RoundRectangle 48">
+                <Label Text="&#xf0d6;"
+                       FontFamily="FontAwesomeSolid"
+                       FontSize="48"
+                       TextColor="{AppThemeBinding Light=#2F6B57, Dark=#9ACCB3}"
+                       SemanticProperties.Description="A sprouting plant representing growth" />
+            </Border>
+
+            <VerticalStackLayout Spacing="12">
+                <Label Text="Welcome to My Fire Number"
+                       FontAttributes="Bold"
+                       FontSize="34"
+                       HorizontalTextAlignment="Center"
+                       LineHeight="1.08"
+                       TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
+                       SemanticProperties.HeadingLevel="Level1" />
+                <Label Text="Explore the choices that shape your path to financial independence."
+                       FontSize="18"
+                       HorizontalTextAlignment="Center"
+                       LineHeight="1.35"
+                       TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
+            </VerticalStackLayout>
+
+            <Border Padding="20"
+                    Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
+                    Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
+                    StrokeShape="RoundRectangle 16">
+                <VerticalStackLayout Spacing="14">
+                    <Label Text="Make your plan your own"
+                           FontAttributes="Bold"
+                           FontSize="18"
+                           TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />
+                    <Label Text="Set a few starting assumptions, discover the calculator that fits your goal, then revisit and adjust your plan whenever life changes."
+                           LineHeight="1.4"
+                           TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
+                    <Grid ColumnDefinitions="Auto,*"
+                          ColumnSpacing="10">
+                        <Label Text="&#xf023;"
+                               FontFamily="FontAwesomeSolid"
+                               FontSize="16"
+                               TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
+                               SemanticProperties.Description="Private" />
+                        <Label Grid.Column="1"
+                               Text="Your financial information stays on this device."
+                               FontSize="13"
+                               TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Grid.Row="1"
+                             Spacing="16">
+            <Button AutomationId="WelcomeGetStartedButton"
+                    Text="Get started"
+                    Command="{Binding GetStartedCommand}"
+                    Background="{AppThemeBinding Light=#2F6B57, Dark=#9ACCB3}"
+                    TextColor="{AppThemeBinding Light=#FFFFFF, Dark=#17352C}"
+                    SemanticProperties.Description="Get started with your starting assumptions." />
+            <controls:EducationalDisclaimerView />
+        </VerticalStackLayout>
+    </Grid>
+</ContentPage>

--- a/app/MyFireNumber/Views/WelcomePage.xaml.cs
+++ b/app/MyFireNumber/Views/WelcomePage.xaml.cs
@@ -1,0 +1,12 @@
+using MyFireNumber.ViewModels;
+
+namespace MyFireNumber.Views;
+
+public partial class WelcomePage : ContentPage
+{
+    public WelcomePage(WelcomeViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}


### PR DESCRIPTION
New users currently land directly in financial assumptions without context. This adds a concise first-run introduction so they understand the app, its local-data privacy model, and the next step before configuring assumptions.

## What changed
- Adds a themed, accessible welcome screen with a clear Get started action.
- Persists the welcome state separately from onboarding completion, so interrupted onboarding resumes at assumptions without replaying the welcome.
- Restores the welcome after a full app-data reset.
- Declares that the iOS app does not use non-exempt encryption.

## Implementation note
The current DevFlow preview triggers a MAUI native-class registration crash on iOS. Its agent registration is excluded only for iOS builds; Android DevFlow and all production app behavior remain unchanged.