### PR TITLE
Update iOS workflow actions for Node 24

### DIFF
--- a/.github/workflows/maui-ios.yml
+++ b/.github/workflows/maui-ios.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate workflow inputs
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_testflight && !inputs.build_release }}
@@ -62,7 +62,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Import signing certificate
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_release }}
-        uses: apple-actions/import-codesign-certs@v4
+        uses: apple-actions/import-codesign-certs@v7
         with:
           create-keychain: true
           keychain-password: ${{ secrets.APPSTORE_CERTIFICATE_P12_PASSWORD }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Upload to TestFlight
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_release && inputs.upload_testflight }}
-        uses: apple-actions/upload-testflight-build@v1
+        uses: apple-actions/upload-testflight-build@v5
         with:
           app-type: ios
           app-path: ${{ steps.ios-artifact.outputs.path }}
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload iOS archive
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_release }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: myfirenumber-ios-ipa
           path: ${{ steps.ios-artifact.outputs.path }}


### PR DESCRIPTION
GitHub Actions is retiring Node.js 20, causing the iOS workflow actions to be forced onto Node 24 and emit deprecation warnings.

Updates the checkout, .NET setup, artifact upload, code-signing certificate, and TestFlight upload actions to their Node 24-compatible major versions. The existing environment-file output handling remains unchanged.