### PR TITLE
Improve onboarding and saved plan flows

### DIFF
--- a/app/MyFireNumber/ViewModels/CalculatorDetailViewModel.cs
+++ b/app/MyFireNumber/ViewModels/CalculatorDetailViewModel.cs
@@ -793,12 +793,21 @@ public partial class CalculatorDetailViewModel : ObservableObject
         await SavePlanCoreAsync(PlanNameText);
     }
 
-    private async Task SavePlanCoreAsync(string planName)
+    [RelayCommand]
+    private async Task SavePlanAndCloseAsync()
+    {
+        if (await SavePlanCoreAsync(PlanNameText))
+        {
+            await navigationService.GoToAsync("..");
+        }
+    }
+
+    private async Task<bool> SavePlanCoreAsync(string planName)
     {
         if (string.IsNullOrWhiteSpace(planName))
         {
             ValidationMessage = "Enter a name before saving this plan.";
-            return;
+            return false;
         }
 
         string calculatorId;
@@ -872,7 +881,7 @@ public partial class CalculatorDetailViewModel : ObservableObject
         }
         else
         {
-            return;
+            return false;
         }
 
         try
@@ -896,10 +905,12 @@ public partial class CalculatorDetailViewModel : ObservableObject
                 ? $"Updated \"{PlanNameText.Trim()}\" in Plans."
                 : $"Saved \"{PlanNameText.Trim()}\" to Plans.";
             behaviorPreferencesService.PerformHaptic();
+            return true;
         }
         catch (Exception)
         {
             PlanStatusMessage = "This plan could not be saved locally yet.";
+            return false;
         }
     }
 

--- a/app/MyFireNumber/ViewModels/HomeViewModel.cs
+++ b/app/MyFireNumber/ViewModels/HomeViewModel.cs
@@ -11,6 +11,13 @@ public sealed record RecentPlanItem(string Id, string CalculatorId, string Name,
 
 public partial class HomeViewModel : ObservableObject
 {
+    private static readonly string[] SuggestedCalculatorIds =
+    [
+        "standard-fire",
+        "coast-fire",
+        "savings-rate"
+    ];
+
     private readonly ICalculatorCatalog catalog;
     private readonly INavigationService navigationService;
     private readonly IOnboardingService onboardingService;
@@ -67,10 +74,16 @@ public partial class HomeViewModel : ObservableObject
             })
             .Where(item => item.Preference.IsVisible)
             .OrderBy(item => item.Preference.SortOrder)
-            .Select(item => item.Definition);
+            .Select(item => item.Definition)
+            .ToArray();
 
         FeaturedCalculators.Clear();
-        foreach (var calculator in visibleCalculators)
+        foreach (var calculator in SuggestedCalculatorIds
+                     .Select(id => visibleCalculators.FirstOrDefault(definition => definition.Id == id))
+                     .OfType<CalculatorDefinition>()
+                     .Concat(visibleCalculators)
+                     .DistinctBy(definition => definition.Id)
+                     .Take(3))
         {
             FeaturedCalculators.Add(calculator);
         }

--- a/app/MyFireNumber/ViewModels/PlansViewModel.cs
+++ b/app/MyFireNumber/ViewModels/PlansViewModel.cs
@@ -7,8 +7,22 @@ using MyFireNumber.Storage;
 
 namespace MyFireNumber.ViewModels;
 
-public sealed record PlanListItem(string Id, string CalculatorId, string Name, string CalculatorTitle, string UpdatedDescription);
-public sealed record CalculatorFilter(string? CalculatorId, string Name);
+public sealed record PlanListItem(
+    string Id,
+    string CalculatorId,
+    string Name,
+    string CalculatorTitle,
+    DateTime UpdatedAtUtc,
+    string UpdatedDescription);
+
+public enum PlanSortOrder
+{
+    RecentlyUpdated,
+    Name,
+    Calculator
+}
+
+public sealed record PlanSortOption(PlanSortOrder Order, string Name);
 
 public partial class PlansViewModel : ObservableObject
 {
@@ -40,17 +54,14 @@ public partial class PlansViewModel : ObservableObject
         this.errorPresentationService = errorPresentationService;
         this.planNamePromptService = planNamePromptService;
         this.recentActivityRepository = recentActivityRepository;
-        CalculatorFilters.Add(new CalculatorFilter(null, "All calculators"));
-        foreach (var definition in catalog.All)
-        {
-            CalculatorFilters.Add(new CalculatorFilter(definition.Id, definition.Title));
-        }
-
-        SelectedCalculatorFilter = CalculatorFilters[0];
+        SortOptions.Add(new PlanSortOption(PlanSortOrder.RecentlyUpdated, "Recently updated"));
+        SortOptions.Add(new PlanSortOption(PlanSortOrder.Name, "Plan name"));
+        SortOptions.Add(new PlanSortOption(PlanSortOrder.Calculator, "Calculator"));
+        SelectedSortOption = SortOptions[0];
     }
 
     public ObservableCollection<PlanListItem> Plans { get; } = [];
-    public ObservableCollection<CalculatorFilter> CalculatorFilters { get; } = [];
+    public ObservableCollection<PlanSortOption> SortOptions { get; } = [];
 
     [ObservableProperty]
     private bool isLoading;
@@ -62,7 +73,7 @@ public partial class PlansViewModel : ObservableObject
     private string searchText = string.Empty;
 
     [ObservableProperty]
-    private CalculatorFilter? selectedCalculatorFilter;
+    private PlanSortOption? selectedSortOption;
 
     public bool HasPlans => Plans.Count > 0;
 
@@ -84,6 +95,7 @@ public partial class PlansViewModel : ObservableObject
                     record.CalculatorId,
                     record.Name,
                     title,
+                    record.UpdatedAtUtc,
                     $"Updated {record.UpdatedAtUtc.ToLocalTime():g}"));
             }
 
@@ -102,7 +114,7 @@ public partial class PlansViewModel : ObservableObject
 
     partial void OnSearchTextChanged(string value) => ApplyFilters();
 
-    partial void OnSelectedCalculatorFilterChanged(CalculatorFilter? value) => ApplyFilters();
+    partial void OnSelectedSortOptionChanged(PlanSortOption? value) => ApplyFilters();
 
     [RelayCommand]
     private async Task OpenPlanAsync(PlanListItem plan)
@@ -222,11 +234,19 @@ public partial class PlansViewModel : ObservableObject
 
     private void ApplyFilters()
     {
-        var selectedCalculatorId = SelectedCalculatorFilter?.CalculatorId;
         var search = SearchText.Trim();
         var filteredPlans = allPlans.Where(plan =>
-            (selectedCalculatorId is null || plan.CalculatorId == selectedCalculatorId)
-            && (search.Length == 0 || plan.Name.Contains(search, StringComparison.CurrentCultureIgnoreCase)));
+            search.Length == 0 || plan.Name.Contains(search, StringComparison.CurrentCultureIgnoreCase));
+        filteredPlans = SelectedSortOption?.Order switch
+        {
+            PlanSortOrder.Name => filteredPlans
+                .OrderBy(plan => plan.Name, StringComparer.CurrentCultureIgnoreCase)
+                .ThenByDescending(plan => plan.UpdatedAtUtc),
+            PlanSortOrder.Calculator => filteredPlans
+                .OrderBy(plan => plan.CalculatorTitle, StringComparer.CurrentCultureIgnoreCase)
+                .ThenBy(plan => plan.Name, StringComparer.CurrentCultureIgnoreCase),
+            _ => filteredPlans.OrderByDescending(plan => plan.UpdatedAtUtc)
+        };
 
         Plans.Clear();
         foreach (var plan in filteredPlans)

--- a/app/MyFireNumber/ViewModels/QuizViewModel.cs
+++ b/app/MyFireNumber/ViewModels/QuizViewModel.cs
@@ -25,9 +25,11 @@ public partial class QuizViewModel : ObservableObject
     private const int QuestionCount = 8;
     private readonly ICalculatorCatalog catalog;
     private readonly IConfirmationService confirmationService;
+    private readonly ICalculatorDefaultsService calculatorDefaultsService;
     private readonly IDraftRepository draftRepository;
     private readonly INavigationService navigationService;
     private readonly IOnboardingService onboardingService;
+    private readonly IRecentActivityRepository recentActivityRepository;
     private FireQuizRecommendation? recommendation;
     private int? currentAge;
     private int? retirementAge;
@@ -41,15 +43,23 @@ public partial class QuizViewModel : ObservableObject
     public QuizViewModel(
         ICalculatorCatalog catalog,
         IConfirmationService confirmationService,
+        ICalculatorDefaultsService calculatorDefaultsService,
         IDraftRepository draftRepository,
         INavigationService navigationService,
-        IOnboardingService onboardingService)
+        IOnboardingService onboardingService,
+        IRecentActivityRepository recentActivityRepository)
     {
         this.catalog = catalog;
         this.confirmationService = confirmationService;
+        this.calculatorDefaultsService = calculatorDefaultsService;
         this.draftRepository = draftRepository;
         this.navigationService = navigationService;
         this.onboardingService = onboardingService;
+        this.recentActivityRepository = recentActivityRepository;
+
+        var defaults = calculatorDefaultsService.Current;
+        currentAge = defaults.CurrentAge;
+        retirementAge = defaults.RetirementAge;
         ShowQuestion();
     }
 
@@ -203,6 +213,10 @@ public partial class QuizViewModel : ObservableObject
         var draft = CreateRecommendedDraft(recommendation.CalculatorId);
         await draftRepository.SaveAsync(draft);
         onboardingService.Complete();
+        await recentActivityRepository.TrackAsync(new RecentActivityRecord(
+            RecentActivityKind.Calculator,
+            recommendation.CalculatorId,
+            DateTime.UtcNow));
         await navigationService.GoToAsync(
             $"../calculator?calculatorId={Uri.EscapeDataString(recommendation.CalculatorId)}");
     }

--- a/app/MyFireNumber/Views/CalculatorDetailPage.xaml
+++ b/app/MyFireNumber/Views/CalculatorDetailPage.xaml
@@ -11,26 +11,14 @@
              Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
 
     <ContentPage.ToolbarItems>
-        <ToolbarItem Text="{Binding SavePlanActionText}"
+        <ToolbarItem Text="Save"
                     Order="Primary"
                     Priority="0"
-                    Command="{Binding SavePlanCommand}"
+                   Command="{Binding SavePlanAndCloseCommand}"
                     SemanticProperties.Description="{Binding SavePlanActionDescription}">
             <ToolbarItem.IconImageSource>
                <FontImageSource FontFamily="FontAwesomeSolid"
                                 Glyph="&#xf0c7;"
-                                Color="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
-                                Size="18" />
-            </ToolbarItem.IconImageSource>
-        </ToolbarItem>
-        <ToolbarItem Text="Export"
-                    Order="Primary"
-                    Priority="2"
-                    Command="{Binding ExportCommand}"
-                    SemanticProperties.Description="Export this calculator to Excel.">
-            <ToolbarItem.IconImageSource>
-               <FontImageSource FontFamily="FontAwesomeSolid"
-                                Glyph="&#xf56e;"
                                 Color="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
                                 Size="18" />
             </ToolbarItem.IconImageSource>

--- a/app/MyFireNumber/Views/HomePage.xaml
+++ b/app/MyFireNumber/Views/HomePage.xaml
@@ -160,7 +160,7 @@
                                 TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
                                    SemanticProperties.Description="Calculator" />
                             <Label Grid.Column="1"
-                                Text="Your FIRE starting point"
+                                Text="Suggested calculators"
                                 TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
                                 FontAttributes="Bold"
                                 FontSize="20" />
@@ -203,6 +203,10 @@
                                        SemanticProperties.Description="Open" />
                             </Grid>
                         </Border>
+                        <Label IsVisible="{Binding ShowFeaturedCalculators}"
+                               Text="Start with one of these to build your first estimate."
+                               TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
+                               LineHeight="1.3" />
                         <VerticalStackLayout IsVisible="{Binding ShowFeaturedCalculators}"
                                              BindableLayout.ItemsSource="{Binding FeaturedCalculators}"
                                              Spacing="10">

--- a/app/MyFireNumber/Views/PlansPage.xaml
+++ b/app/MyFireNumber/Views/PlansPage.xaml
@@ -34,15 +34,8 @@
                             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
                             Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                             StrokeShape="RoundRectangle 12">
-                        <Grid RowDefinitions="Auto,1,Auto" ColumnDefinitions="Auto,*" ColumnSpacing="8">
-                            <Label Text="&#xf002;"
-                                   FontFamily="FontAwesomeSolid"
-                                   FontSize="15"
-                                   VerticalTextAlignment="Center"
-                                   TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
-                                   SemanticProperties.Description="Search" />
+                        <Grid RowDefinitions="Auto,1,Auto">
                             <SearchBar AutomationId="PlanSearch"
-                                       Grid.Column="1"
                                        Placeholder="Search saved plans"
                                        Text="{Binding SearchText, Mode=TwoWay}"
                                        Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
@@ -50,28 +43,19 @@
                                        PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
                                        SemanticProperties.Description="Search saved plans by name." />
                             <BoxView Grid.Row="1"
-                                     Grid.ColumnSpan="2"
-                                     Margin="0,2"
-                                     HeightRequest="1"
-                                     Background="{AppThemeBinding Light=#E1E7E2, Dark=#365244}" />
-                            <Label Grid.Row="2"
-                                   Text="&#xf0b0;"
-                                   FontFamily="FontAwesomeSolid"
-                                   FontSize="14"
-                                   VerticalTextAlignment="Center"
-                                   TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
-                                   SemanticProperties.Description="Filter" />
-                            <Picker AutomationId="PlanCalculatorFilter"
+                                    Margin="0,2"
+                                    HeightRequest="1"
+                                    Background="{AppThemeBinding Light=#E1E7E2, Dark=#365244}" />
+                            <Picker AutomationId="PlanSort"
                                     Grid.Row="2"
-                                    Grid.Column="1"
-                                    Title="All calculators"
-                                    ItemsSource="{Binding CalculatorFilters}"
+                                    Title="Sort by"
+                                    ItemsSource="{Binding SortOptions}"
                                     ItemDisplayBinding="{Binding Name}"
-                                    SelectedItem="{Binding SelectedCalculatorFilter, Mode=TwoWay}"
+                                    SelectedItem="{Binding SelectedSortOption, Mode=TwoWay}"
                                     Background="Transparent"
                                     TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
                                     TitleColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
-                                    SemanticProperties.Description="Filter saved plans by calculator." />
+                                    SemanticProperties.Description="Sort saved plans." />
                         </Grid>
                     </Border>
                 </VerticalStackLayout>
@@ -81,7 +65,7 @@
                    <SwipeView Margin="0,0,0,10">
                        <SwipeView.RightItems>
                            <SwipeItems Mode="Reveal">
-                               <SwipeItem Text="Rename"
+                               <SwipeItem Text=""
                                           BackgroundColor="#326B57"
                                           Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:PlansViewModel}}, Path=RenamePlanCommand}"
                                           CommandParameter="{Binding .}"
@@ -89,10 +73,11 @@
                                    <SwipeItem.IconImageSource>
                                        <FontImageSource Glyph="&#xf044;"
                                                         FontFamily="FontAwesomeSolid"
-                                                        Color="White" />
+                                                        Color="#FFFFFF"
+                                                        Size="13" />
                                    </SwipeItem.IconImageSource>
                                </SwipeItem>
-                               <SwipeItem Text="Duplicate"
+                               <SwipeItem Text=""
                                           BackgroundColor="#426B9D"
                                           Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:PlansViewModel}}, Path=DuplicatePlanCommand}"
                                           CommandParameter="{Binding .}"
@@ -100,10 +85,11 @@
                                    <SwipeItem.IconImageSource>
                                        <FontImageSource Glyph="&#xf0c5;"
                                                         FontFamily="FontAwesomeSolid"
-                                                        Color="White" />
+                                                        Color="#FFFFFF"
+                                                        Size="13" />
                                    </SwipeItem.IconImageSource>
                                </SwipeItem>
-                               <SwipeItem Text="Delete"
+                               <SwipeItem Text=""
                                           BackgroundColor="#A33A31"
                                           Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:PlansViewModel}}, Path=DeletePlanCommand}"
                                           CommandParameter="{Binding .}"
@@ -111,7 +97,8 @@
                                    <SwipeItem.IconImageSource>
                                        <FontImageSource Glyph="&#xf2ed;"
                                                         FontFamily="FontAwesomeSolid"
-                                                        Color="White" />
+                                                        Color="#FFFFFF"
+                                                        Size="13" />
                                    </SwipeItem.IconImageSource>
                                </SwipeItem>
                            </SwipeItems>


### PR DESCRIPTION
New users were repeating information already supplied during setup, and key follow-up paths left the home and saved-plan experiences feeling empty or inconsistent.

- Pre-fill the quiz with onboarding age defaults and record the quiz-selected calculator as recent activity.
- Show three focused calculator suggestions when there is no recent activity.
- Replace saved-plan calculator filtering with deterministic sorting, remove the duplicate search icon, and streamline swipe actions.
- Make the calculator toolbar save then return to the prior screen, while retaining the in-page export action and removing the duplicate toolbar export.