### PR TITLE
Prevent plan save lifecycle crashes

### DIFF
--- a/app/MyFireNumber/ViewModels/CalculatorDetailViewModel.cs
+++ b/app/MyFireNumber/ViewModels/CalculatorDetailViewModel.cs
@@ -2549,7 +2549,14 @@ public partial class CalculatorDetailViewModel : ObservableObject
 
         if (draft is not null)
         {
-            await SaveDraftRecordAsync(draft, CancellationToken.None);
+            try
+            {
+                await SaveDraftRecordAsync(draft, CancellationToken.None);
+            }
+            catch (Exception)
+            {
+                ValidationMessage = "Your changes are shown here, but could not be saved locally yet.";
+            }
         }
     }
 


### PR DESCRIPTION
Saving the first plan during onboarding can immediately navigate away from the calculator. A pending draft write could then throw from the page lifecycle callback and terminate the app.

Contain failures while flushing the pending draft and surface the existing local-save status message instead of propagating the exception.