### PR TITLE
Improve FIRE quiz recommendations

### DIFF
--- a/app/MyFireNumber.Core/Calculations/FireQuizRecommender.cs
+++ b/app/MyFireNumber.Core/Calculations/FireQuizRecommender.cs
@@ -5,7 +5,8 @@ public enum FireQuizLifestyle
     Minimal,
     Moderate,
     Comfortable,
-    Luxury
+    Luxury,
+    NotSure
 }
 
 public enum FireQuizWorkPreference
@@ -13,7 +14,17 @@ public enum FireQuizWorkPreference
     QuitCompletely,
     PartTime,
     Coast,
-    Flexible
+    Flexible,
+    NotSure
+}
+
+public enum FireQuizTimeline
+{
+    WithinFiveYears,
+    FiveToTenYears,
+    TenToTwentyYears,
+    TwentyPlusYears,
+    NotSure
 }
 
 public enum FireQuizPrimaryGoal
@@ -21,125 +32,272 @@ public enum FireQuizPrimaryGoal
     RetireEarly,
     FinancialSecurity,
     MaintainLifestyle,
-    Flexibility
+    Flexibility,
+    NotSure
+}
+
+public enum FireQuizConfidence
+{
+    Low,
+    Medium,
+    High
 }
 
 public sealed record FireQuizAnswers(
-    int CurrentAge,
-    int RetirementAge,
-    double CurrentSavings,
-    double AnnualIncome,
-    double AnnualExpenses,
     FireQuizLifestyle Lifestyle,
     FireQuizWorkPreference WorkPreference,
-    FireQuizPrimaryGoal PrimaryGoal);
+    FireQuizTimeline Timeline,
+    FireQuizPrimaryGoal PrimaryGoal,
+    int? CurrentAge = null,
+    int? RetirementAge = null,
+    double? CurrentSavings = null,
+    double? AnnualIncome = null,
+    double? AnnualExpenses = null);
 
-public sealed record FireQuizRecommendation(
+public sealed record FireQuizMatch(
     string CalculatorId,
     string Title,
     string Reason,
     string Description,
-    IReadOnlyList<string> Benefits);
+    IReadOnlyList<string> Benefits,
+    IReadOnlyList<string> ReasonIds,
+    int Score);
+
+public sealed record FireQuizRecommendation(
+    FireQuizMatch Primary,
+    IReadOnlyList<FireQuizMatch> Alternatives,
+    FireQuizConfidence Confidence);
 
 public static class FireQuizRecommender
 {
+    private static readonly string[] TieBreakOrder =
+    [
+        "standard-fire",
+        "coast-fire",
+        "barista-fire",
+        "reverse-fire",
+        "lean-fire",
+        "fat-fire"
+    ];
+
+    private static readonly IReadOnlyDictionary<string, PathDefinition> Definitions =
+        new Dictionary<string, PathDefinition>
+        {
+            ["standard-fire"] = new(
+                "Standard FIRE",
+                "Build a complete retirement portfolio using a balanced spending and withdrawal plan.",
+                ["Plan for full financial independence", "Balance lifestyle and timing", "Adjust assumptions as life changes"]),
+            ["lean-fire"] = new(
+                "Lean FIRE",
+                "Reach financial independence with intentional spending and a smaller portfolio target.",
+                ["Lower the portfolio target", "Prioritize an earlier timeline", "Keep spending intentional"]),
+            ["fat-fire"] = new(
+                "Fat FIRE",
+                "Build a larger portfolio target to support more spending and additional financial margin.",
+                ["Maintain a higher-spending lifestyle", "Create a larger market buffer", "Preserve room for travel and family goals"]),
+            ["barista-fire"] = new(
+                "Barista FIRE",
+                "Blend portfolio income with part-time work to leave full-time work sooner.",
+                ["Leave full-time work earlier", "Cover some expenses with earned income", "Keep flexibility and social connection"]),
+            ["coast-fire"] = new(
+                "Coast FIRE",
+                "Let invested savings grow toward retirement while current work covers today's expenses.",
+                ["Front-load retirement savings", "Give compound growth more time", "Create room for lower-stress work"]),
+            ["reverse-fire"] = new(
+                "Reverse FIRE",
+                "Work backward from a target timeline to find the savings required to reach it.",
+                ["Set a clear savings target", "Compare timeline and contribution tradeoffs", "Plan around a firm deadline"])
+        };
+
+    private static readonly IReadOnlyDictionary<string, string> ReasonText =
+        new Dictionary<string, string>
+        {
+            ["balanced-lifestyle"] = "your balanced lifestyle goal",
+            ["comfortable-lifestyle"] = "your preference for comfort without the highest spending target",
+            ["full-retirement"] = "your goal of fully leaving paid work",
+            ["security-first"] = "your focus on long-term financial security",
+            ["balanced-timeline"] = "your flexible mid-to-long-term timeline",
+            ["minimal-lifestyle"] = "your lower-spending lifestyle",
+            ["early-priority"] = "your priority to reach financial independence sooner",
+            ["lower-expenses"] = "the lower annual expenses you shared",
+            ["luxury-lifestyle"] = "your higher-spending lifestyle goal",
+            ["maintain-lifestyle"] = "your priority to preserve your lifestyle",
+            ["higher-expenses"] = "the higher annual expenses you shared",
+            ["part-time-work"] = "your interest in part-time work",
+            ["work-flexibility"] = "your desire to keep work options open",
+            ["near-term-transition"] = "your near-term transition goal",
+            ["coast-work"] = "your preference to let investments grow while work covers current expenses",
+            ["long-horizon"] = "your longer time horizon",
+            ["deadline-focus"] = "your firm, near-term timeline",
+            ["retire-early"] = "your goal to retire as early as practical",
+            ["balanced-start"] = "a balanced starting point while you refine your preferences"
+        };
+
     public static FireQuizRecommendation Recommend(FireQuizAnswers answers)
     {
-        var yearsToFire = answers.RetirementAge - answers.CurrentAge;
+        var candidates = Definitions.ToDictionary(
+            pair => pair.Key,
+            pair => new Candidate(pair.Key, pair.Value));
 
-        if (answers.Lifestyle == FireQuizLifestyle.Minimal
-            || (answers.AnnualExpenses < 40_000 && answers.PrimaryGoal == FireQuizPrimaryGoal.RetireEarly))
+        Add(candidates, "standard-fire", 1, "balanced-start");
+
+        switch (answers.Lifestyle)
         {
-            return Create(
-                "lean-fire",
-                "Lean FIRE",
-                "Your minimalist lifestyle and lower expenses make Lean FIRE achievable.",
-                "Reach financial independence faster through intentional spending and a smaller portfolio target.",
-                "Retire earlier than traditional FIRE",
-                "Need less total savings",
-                "Build intentional spending habits");
+            case FireQuizLifestyle.Minimal:
+                Add(candidates, "lean-fire", 6, "minimal-lifestyle");
+                break;
+            case FireQuizLifestyle.Moderate:
+                Add(candidates, "standard-fire", 4, "balanced-lifestyle");
+                break;
+            case FireQuizLifestyle.Comfortable:
+                Add(candidates, "standard-fire", 3, "comfortable-lifestyle");
+                Add(candidates, "fat-fire", 1, "comfortable-lifestyle");
+                break;
+            case FireQuizLifestyle.Luxury:
+                Add(candidates, "fat-fire", 6, "luxury-lifestyle");
+                break;
         }
 
-        if (answers.Lifestyle == FireQuizLifestyle.Luxury
-            || (answers.AnnualExpenses >= 100_000 && answers.PrimaryGoal == FireQuizPrimaryGoal.MaintainLifestyle))
+        switch (answers.WorkPreference)
         {
-            return Create(
-                "fat-fire",
-                "Fat FIRE",
-                "Your desired lifestyle without compromise aligns with Fat FIRE.",
-                "Build a larger portfolio target for travel, flexibility, and additional margin.",
-                "Maintain your planned lifestyle",
-                "Create a larger market buffer",
-                "Preserve room for travel and family goals");
+            case FireQuizWorkPreference.QuitCompletely:
+                Add(candidates, "standard-fire", 2, "full-retirement");
+                Add(candidates, "reverse-fire", 1, "full-retirement");
+                break;
+            case FireQuizWorkPreference.PartTime:
+                Add(candidates, "barista-fire", 7, "part-time-work");
+                break;
+            case FireQuizWorkPreference.Coast:
+                Add(candidates, "coast-fire", 7, "coast-work");
+                break;
+            case FireQuizWorkPreference.Flexible:
+                Add(candidates, "barista-fire", 2, "work-flexibility");
+                Add(candidates, "coast-fire", 2, "work-flexibility");
+                Add(candidates, "standard-fire", 1, "work-flexibility");
+                break;
         }
 
-        if (answers.WorkPreference == FireQuizWorkPreference.PartTime
-            || (yearsToFire < 10 && answers.PrimaryGoal == FireQuizPrimaryGoal.Flexibility))
+        switch (answers.Timeline)
         {
-            return Create(
-                "barista-fire",
-                "Barista FIRE",
-                "Your interest in part-time work makes Barista FIRE a useful stepping stone.",
-                "Blend portfolio withdrawals with part-time income to leave full-time work sooner.",
-                "Leave full-time work earlier",
-                "Cover part of your expenses with earned income",
-                "Keep flexibility and social connection");
+            case FireQuizTimeline.WithinFiveYears:
+                Add(candidates, "reverse-fire", 5, "deadline-focus");
+                Add(candidates, "barista-fire", 2, "near-term-transition");
+                Add(candidates, "lean-fire", 1, "near-term-transition");
+                break;
+            case FireQuizTimeline.FiveToTenYears:
+                Add(candidates, "reverse-fire", 3, "deadline-focus");
+                Add(candidates, "barista-fire", 1, "near-term-transition");
+                Add(candidates, "lean-fire", 1, "near-term-transition");
+                break;
+            case FireQuizTimeline.TenToTwentyYears:
+                Add(candidates, "standard-fire", 2, "balanced-timeline");
+                Add(candidates, "coast-fire", 1, "long-horizon");
+                break;
+            case FireQuizTimeline.TwentyPlusYears:
+                Add(candidates, "coast-fire", 3, "long-horizon");
+                Add(candidates, "standard-fire", 1, "balanced-timeline");
+                break;
         }
 
-        if (answers.WorkPreference == FireQuizWorkPreference.Coast
-            || (answers.CurrentAge < 35 && yearsToFire > 20))
+        switch (answers.PrimaryGoal)
         {
-            return Create(
-                "coast-fire",
-                "Coast FIRE",
-                "Your age and timeline make compound growth a strategic part of the plan.",
-                "Invest aggressively now, then let existing savings grow toward retirement while work covers current expenses.",
-                "Front-load retirement savings",
-                "Let compound growth do more of the work",
-                "Create room for lower-stress work");
+            case FireQuizPrimaryGoal.RetireEarly:
+                Add(candidates, "reverse-fire", 4, "retire-early");
+                Add(candidates, "lean-fire", 2, "early-priority");
+                break;
+            case FireQuizPrimaryGoal.FinancialSecurity:
+                Add(candidates, "standard-fire", 4, "security-first");
+                break;
+            case FireQuizPrimaryGoal.MaintainLifestyle:
+                Add(candidates, "fat-fire", 2, "maintain-lifestyle");
+                Add(candidates, "standard-fire", 2, "maintain-lifestyle");
+                break;
+            case FireQuizPrimaryGoal.Flexibility:
+                Add(candidates, "coast-fire", 2, "work-flexibility");
+                Add(candidates, "barista-fire", 2, "work-flexibility");
+                break;
         }
 
-        if (answers.PrimaryGoal == FireQuizPrimaryGoal.RetireEarly && yearsToFire < 15)
+        if (answers.AnnualExpenses is < 40_000)
         {
-            return Create(
-                "reverse-fire",
-                "Reverse FIRE",
-                "Your specific retirement date calls for a targeted savings plan.",
-                "Work backward from your target age to calculate the contribution required to get there.",
-                "Get a clear savings target",
-                "Compare timeline and contribution tradeoffs",
-                "Track a deadline-driven goal");
+            Add(candidates, "lean-fire", 2, "lower-expenses");
+        }
+        else if (answers.AnnualExpenses is >= 100_000)
+        {
+            Add(candidates, "fat-fire", 3, "higher-expenses");
         }
 
-        if (answers.PrimaryGoal == FireQuizPrimaryGoal.FinancialSecurity)
-        {
-            return Create(
-                "savings-rate",
-                "Savings and Investment Rate",
-                "Understanding your savings rate is a strong foundation for financial security.",
-                "See how income, contributions, and time combine to grow your invested assets.",
-                "Measure your current savings rate",
-                "See the impact of saving more",
-                "Build a flexible foundation for any FIRE path");
-        }
+        var ranked = candidates.Values
+            .OrderByDescending(candidate => candidate.Score)
+            .ThenBy(candidate => Array.IndexOf(TieBreakOrder, candidate.CalculatorId))
+            .Select(ToMatch)
+            .ToArray();
 
-        return Create(
-            "standard-fire",
-            "Standard FIRE",
-            "The classic FIRE approach fits your balanced goals and timeline.",
-            "Use the traditional portfolio target and withdrawal-rate framework as a practical starting point.",
-            "Use a time-tested planning framework",
-            "Balance lifestyle and retirement timing",
-            "Adjust assumptions as your plan changes");
+        var knownCoreAnswers = new[]
+        {
+            answers.Lifestyle != FireQuizLifestyle.NotSure,
+            answers.WorkPreference != FireQuizWorkPreference.NotSure,
+            answers.Timeline != FireQuizTimeline.NotSure,
+            answers.PrimaryGoal != FireQuizPrimaryGoal.NotSure
+        }.Count(value => value);
+        var margin = ranked[0].Score - ranked[1].Score;
+        var confidence = knownCoreAnswers >= 4 && margin >= 3
+            ? FireQuizConfidence.High
+            : knownCoreAnswers >= 2 && margin >= 2
+                ? FireQuizConfidence.Medium
+                : FireQuizConfidence.Low;
+
+        return new FireQuizRecommendation(ranked[0], ranked.Skip(1).Take(2).ToArray(), confidence);
     }
 
-    private static FireQuizRecommendation Create(
+    private static void Add(
+        IDictionary<string, Candidate> candidates,
         string calculatorId,
-        string title,
-        string reason,
-        string description,
-        params string[] benefits)
+        int score,
+        string reasonId)
     {
-        return new FireQuizRecommendation(calculatorId, title, reason, description, benefits);
+        var candidate = candidates[calculatorId];
+        candidate.Score += score;
+        if (!candidate.ReasonIds.Contains(reasonId))
+        {
+            candidate.ReasonIds.Add(reasonId);
+        }
+    }
+
+    private static FireQuizMatch ToMatch(Candidate candidate)
+    {
+        var meaningfulReasons = candidate.ReasonIds
+            .Where(reasonId => reasonId != "balanced-start" || candidate.ReasonIds.Count == 1)
+            .Take(2)
+            .Select(reasonId => ReasonText[reasonId])
+            .ToArray();
+        var reason = meaningfulReasons.Length switch
+        {
+            0 => $"This is a useful path to compare with your leading match.",
+            1 => $"This path aligns with {meaningfulReasons[0]}.",
+            _ => $"This path aligns with {meaningfulReasons[0]} and {meaningfulReasons[1]}."
+        };
+
+        return new FireQuizMatch(
+            candidate.CalculatorId,
+            candidate.Definition.Title,
+            reason,
+            candidate.Definition.Description,
+            candidate.Definition.Benefits,
+            candidate.ReasonIds.ToArray(),
+            candidate.Score);
+    }
+
+    private sealed record PathDefinition(
+        string Title,
+        string Description,
+        IReadOnlyList<string> Benefits);
+
+    private sealed class Candidate(string calculatorId, PathDefinition definition)
+    {
+        public string CalculatorId { get; } = calculatorId;
+        public PathDefinition Definition { get; } = definition;
+        public int Score { get; set; }
+        public List<string> ReasonIds { get; } = [];
     }
 }

--- a/app/MyFireNumber.Tests/Calculations/FireQuizRecommenderTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/FireQuizRecommenderTests.cs
@@ -9,38 +9,44 @@ public sealed class FireQuizRecommenderTests
         { Answers(lifestyle: FireQuizLifestyle.Minimal), "lean-fire" },
         { Answers(lifestyle: FireQuizLifestyle.Luxury), "fat-fire" },
         { Answers(work: FireQuizWorkPreference.PartTime), "barista-fire" },
-        { Answers(currentAge: 25, retirementAge: 60, work: FireQuizWorkPreference.Flexible), "coast-fire" },
-        { Answers(currentAge: 45, retirementAge: 55, goal: FireQuizPrimaryGoal.RetireEarly), "reverse-fire" },
-        { Answers(goal: FireQuizPrimaryGoal.FinancialSecurity), "savings-rate" },
-        { Answers(), "standard-fire" }
+        { Answers(work: FireQuizWorkPreference.Coast, timeline: FireQuizTimeline.TwentyPlusYears), "coast-fire" },
+        { Answers(timeline: FireQuizTimeline.WithinFiveYears, goal: FireQuizPrimaryGoal.RetireEarly), "reverse-fire" },
+        { Answers(goal: FireQuizPrimaryGoal.FinancialSecurity), "standard-fire" },
+        {
+            Answers(
+                lifestyle: FireQuizLifestyle.NotSure,
+                work: FireQuizWorkPreference.NotSure,
+                timeline: FireQuizTimeline.NotSure,
+                goal: FireQuizPrimaryGoal.NotSure),
+            "standard-fire"
+        }
     };
 
     [Theory]
     [MemberData(nameof(RecommendationCases))]
-    public void Recommend_MatchesWebRulePriority(FireQuizAnswers answers, string expectedCalculatorId)
+    public void Recommend_MatchesRankedPathContract(FireQuizAnswers answers, string expectedCalculatorId)
     {
         var recommendation = FireQuizRecommender.Recommend(answers);
 
-        Assert.Equal(expectedCalculatorId, recommendation.CalculatorId);
-        Assert.NotEmpty(recommendation.Benefits);
+        Assert.Equal(expectedCalculatorId, recommendation.Primary.CalculatorId);
+        Assert.NotEmpty(recommendation.Primary.Benefits);
+        Assert.Equal(2, recommendation.Alternatives.Count);
     }
 
     private static FireQuizAnswers Answers(
-        int currentAge = 40,
-        int retirementAge = 60,
         double expenses = 60_000,
         FireQuizLifestyle lifestyle = FireQuizLifestyle.Moderate,
         FireQuizWorkPreference work = FireQuizWorkPreference.QuitCompletely,
+        FireQuizTimeline timeline = FireQuizTimeline.TenToTwentyYears,
         FireQuizPrimaryGoal goal = FireQuizPrimaryGoal.Flexibility)
     {
         return new FireQuizAnswers(
-            currentAge,
-            retirementAge,
-            CurrentSavings: 200_000,
-            AnnualIncome: 100_000,
-            expenses,
             lifestyle,
             work,
-            goal);
+            timeline,
+            goal,
+            CurrentSavings: 200_000,
+            AnnualIncome: 100_000,
+            AnnualExpenses: expenses);
     }
 }

--- a/app/MyFireNumber.Tests/FireQuizRecommenderTests.cs
+++ b/app/MyFireNumber.Tests/FireQuizRecommenderTests.cs
@@ -1,0 +1,102 @@
+using MyFireNumber.Core.Calculations;
+
+namespace MyFireNumber.Tests;
+
+public class FireQuizRecommenderTests
+{
+    public static TheoryData<string, FireQuizAnswers> PathProfiles => new()
+    {
+        {
+            "standard-fire",
+            new(
+                FireQuizLifestyle.Moderate,
+                FireQuizWorkPreference.QuitCompletely,
+                FireQuizTimeline.TenToTwentyYears,
+                FireQuizPrimaryGoal.FinancialSecurity)
+        },
+        {
+            "lean-fire",
+            new(
+                FireQuizLifestyle.Minimal,
+                FireQuizWorkPreference.QuitCompletely,
+                FireQuizTimeline.FiveToTenYears,
+                FireQuizPrimaryGoal.RetireEarly,
+                AnnualExpenses: 35_000)
+        },
+        {
+            "fat-fire",
+            new(
+                FireQuizLifestyle.Luxury,
+                FireQuizWorkPreference.QuitCompletely,
+                FireQuizTimeline.TenToTwentyYears,
+                FireQuizPrimaryGoal.MaintainLifestyle,
+                AnnualExpenses: 120_000)
+        },
+        {
+            "barista-fire",
+            new(
+                FireQuizLifestyle.Moderate,
+                FireQuizWorkPreference.PartTime,
+                FireQuizTimeline.WithinFiveYears,
+                FireQuizPrimaryGoal.Flexibility)
+        },
+        {
+            "coast-fire",
+            new(
+                FireQuizLifestyle.Moderate,
+                FireQuizWorkPreference.Coast,
+                FireQuizTimeline.TwentyPlusYears,
+                FireQuizPrimaryGoal.Flexibility)
+        },
+        {
+            "reverse-fire",
+            new(
+                FireQuizLifestyle.Comfortable,
+                FireQuizWorkPreference.QuitCompletely,
+                FireQuizTimeline.WithinFiveYears,
+                FireQuizPrimaryGoal.RetireEarly)
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(PathProfiles))]
+    public void Recommend_AllowsEveryFirePathToRankFirst(string expectedCalculatorId, FireQuizAnswers answers)
+    {
+        var recommendation = FireQuizRecommender.Recommend(answers);
+
+        Assert.Equal(expectedCalculatorId, recommendation.Primary.CalculatorId);
+        Assert.Equal(2, recommendation.Alternatives.Count);
+    }
+
+    [Fact]
+    public void Recommend_AllUnknownAnswersReturnsBalancedLowConfidenceStart()
+    {
+        var answers = new FireQuizAnswers(
+            FireQuizLifestyle.NotSure,
+            FireQuizWorkPreference.NotSure,
+            FireQuizTimeline.NotSure,
+            FireQuizPrimaryGoal.NotSure);
+
+        var recommendation = FireQuizRecommender.Recommend(answers);
+
+        Assert.Equal("standard-fire", recommendation.Primary.CalculatorId);
+        Assert.Equal(FireQuizConfidence.Low, recommendation.Confidence);
+        Assert.Contains("balanced-start", recommendation.Primary.ReasonIds);
+    }
+
+    [Fact]
+    public void Recommend_UsesStableTieBreaking()
+    {
+        var answers = new FireQuizAnswers(
+            FireQuizLifestyle.NotSure,
+            FireQuizWorkPreference.Flexible,
+            FireQuizTimeline.NotSure,
+            FireQuizPrimaryGoal.NotSure);
+
+        var recommendation = FireQuizRecommender.Recommend(answers);
+
+        Assert.Equal("standard-fire", recommendation.Primary.CalculatorId);
+        Assert.Equal("coast-fire", recommendation.Alternatives[0].CalculatorId);
+        Assert.Equal("barista-fire", recommendation.Alternatives[1].CalculatorId);
+    }
+}

--- a/app/MyFireNumber/ViewModels/QuizViewModel.cs
+++ b/app/MyFireNumber/ViewModels/QuizViewModel.cs
@@ -1,5 +1,4 @@
 using System.Collections.ObjectModel;
-using System.Globalization;
 using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -15,29 +14,37 @@ public partial class QuizChoice(string value, string label, string description) 
     public string Value { get; } = value;
     public string Label { get; } = label;
     public string Description { get; } = description;
+    public string DisplayText => $"{Label}{Environment.NewLine}{Description}";
+    public string AutomationId => $"QuizChoice{Value}";
 
     [ObservableProperty]
     private bool isSelected;
 }
 
+public sealed record QuizRecommendationOption(
+    string CalculatorId,
+    string Title,
+    string Reason,
+    string Description,
+    string Benefits,
+    string IconGlyph)
+{
+    public string AutomationId => $"QuizRecommendation{CalculatorId}";
+}
+
 public partial class QuizViewModel : ObservableObject
 {
-    private const int QuestionCount = 8;
+    private const int QuestionCount = 4;
     private readonly ICalculatorCatalog catalog;
-    private readonly IConfirmationService confirmationService;
     private readonly ICalculatorDefaultsService calculatorDefaultsService;
+    private readonly IConfirmationService confirmationService;
     private readonly IDraftRepository draftRepository;
     private readonly INavigationService navigationService;
     private readonly IOnboardingService onboardingService;
     private readonly IRecentActivityRepository recentActivityRepository;
-    private FireQuizRecommendation? recommendation;
-    private int? currentAge;
-    private int? retirementAge;
-    private double? currentSavings;
-    private double? annualIncome;
-    private double? annualExpenses;
     private FireQuizLifestyle? lifestyle;
     private FireQuizWorkPreference? workPreference;
+    private FireQuizTimeline? timeline;
     private FireQuizPrimaryGoal? primaryGoal;
 
     public QuizViewModel(
@@ -50,23 +57,25 @@ public partial class QuizViewModel : ObservableObject
         IRecentActivityRepository recentActivityRepository)
     {
         this.catalog = catalog;
-        this.confirmationService = confirmationService;
         this.calculatorDefaultsService = calculatorDefaultsService;
+        this.confirmationService = confirmationService;
         this.draftRepository = draftRepository;
         this.navigationService = navigationService;
         this.onboardingService = onboardingService;
         this.recentActivityRepository = recentActivityRepository;
 
-        var defaults = calculatorDefaultsService.Current;
-        currentAge = defaults.CurrentAge;
-        retirementAge = defaults.RetirementAge;
         ShowQuestion();
     }
 
     public ObservableCollection<QuizChoice> Choices { get; } = [];
+    public ObservableCollection<QuizRecommendationOption> AlternativeRecommendations { get; } = [];
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(QuestionProgress), nameof(QuestionProgressText), nameof(CanGoBack))]
+    [NotifyPropertyChangedFor(
+        nameof(QuestionProgress),
+        nameof(QuestionProgressText),
+        nameof(CanGoBack),
+        nameof(CanSkipQuestion))]
     private int questionIndex;
 
     [ObservableProperty]
@@ -75,13 +84,7 @@ public partial class QuizViewModel : ObservableObject
     [ObservableProperty]
     private string questionSubtitle = string.Empty;
 
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(CanContinue))]
-    private string answerText = string.Empty;
-
-    [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(IsNumericQuestion))]
-    private bool isChoiceQuestion;
+    public bool IsChoiceQuestion => true;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsQuestionVisible))]
@@ -92,34 +95,20 @@ public partial class QuizViewModel : ObservableObject
     private string validationMessage = string.Empty;
 
     [ObservableProperty]
-    private string recommendationTitle = string.Empty;
+    private QuizRecommendationOption? primaryRecommendation;
 
     [ObservableProperty]
-    private string recommendationReason = string.Empty;
-
-    [ObservableProperty]
-    private string recommendationDescription = string.Empty;
-
-    [ObservableProperty]
-    private string recommendationBenefits = string.Empty;
-
-    [ObservableProperty]
-    private string recommendationIconGlyph = "\uf201";
+    private string recommendationConfidenceText = string.Empty;
 
     public double QuestionProgress => (QuestionIndex + 1d) / QuestionCount;
     public string QuestionProgressText => $"Question {QuestionIndex + 1} of {QuestionCount}";
+
     public bool CanGoBack => QuestionIndex > 0;
     public bool IsQuestionVisible => !IsRecommendationVisible;
-    public bool IsNumericQuestion => !IsChoiceQuestion;
+    public bool IsNumericQuestion => false;
+    public bool CanSkipQuestion => false;
     public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
-    public bool CanContinue => IsChoiceQuestion
-        ? Choices.Any(choice => choice.IsSelected)
-        : !string.IsNullOrWhiteSpace(AnswerText);
-
-    partial void OnAnswerTextChanged(string value)
-    {
-        ValidationMessage = string.Empty;
-    }
+    public bool CanContinue => Choices.Any(choice => choice.IsSelected);
 
     [RelayCommand]
     private async Task SkipAsync()
@@ -148,7 +137,6 @@ public partial class QuizViewModel : ObservableObject
             return;
         }
 
-        _ = SaveCurrentAnswer();
         QuestionIndex--;
         ShowQuestion();
     }
@@ -174,34 +162,26 @@ public partial class QuizViewModel : ObservableObject
     [RelayCommand]
     private void StartOver()
     {
-        currentAge = null;
-        retirementAge = null;
-        currentSavings = null;
-        annualIncome = null;
-        annualExpenses = null;
         lifestyle = null;
         workPreference = null;
+        timeline = null;
         primaryGoal = null;
-        recommendation = null;
+        PrimaryRecommendation = null;
+        AlternativeRecommendations.Clear();
         IsRecommendationVisible = false;
         QuestionIndex = 0;
         ShowQuestion();
     }
 
     [RelayCommand]
-    private async Task UseRecommendationAsync()
+    private async Task UseRecommendationAsync(QuizRecommendationOption option)
     {
-        if (recommendation is null)
-        {
-            return;
-        }
-
-        var existingDraft = await draftRepository.GetAsync(recommendation.CalculatorId);
+        var existingDraft = await draftRepository.GetAsync(option.CalculatorId);
         if (existingDraft is not null)
         {
             var replace = await confirmationService.ConfirmAsync(
                 "Replace existing draft?",
-                $"Your current {recommendation.Title} draft will be replaced with these quiz answers.",
+                $"Your current {option.Title} draft will be replaced with the quiz details you supplied.",
                 "Replace",
                 "Cancel");
             if (!replace)
@@ -210,90 +190,46 @@ public partial class QuizViewModel : ObservableObject
             }
         }
 
-        var draft = CreateRecommendedDraft(recommendation.CalculatorId);
+        var draft = CreateRecommendedDraft(option.CalculatorId);
         await draftRepository.SaveAsync(draft);
+        onboardingService.SetRecommendation(option.CalculatorId);
         onboardingService.Complete();
         await recentActivityRepository.TrackAsync(new RecentActivityRecord(
             RecentActivityKind.Calculator,
-            recommendation.CalculatorId,
+            option.CalculatorId,
             DateTime.UtcNow));
         await navigationService.GoToAsync(
-            $"../calculator?calculatorId={Uri.EscapeDataString(recommendation.CalculatorId)}&returnHomeAfterSave=true");
+            $"../calculator?calculatorId={Uri.EscapeDataString(option.CalculatorId)}&returnHomeAfterSave=true");
     }
 
     private bool SaveCurrentAnswer()
     {
         ValidationMessage = string.Empty;
-        if (IsChoiceQuestion)
+        var selected = Choices.FirstOrDefault(choice => choice.IsSelected);
+        if (selected is null)
         {
-            var selected = Choices.FirstOrDefault(choice => choice.IsSelected);
-            if (selected is null)
-            {
-                ValidationMessage = "Choose an option to continue.";
-                return false;
-            }
-
-            SaveChoiceAnswer();
-            return true;
-        }
-
-        if (!double.TryParse(
-                AnswerText,
-                NumberStyles.Number | NumberStyles.AllowCurrencySymbol,
-                CultureInfo.CurrentCulture,
-                out var value))
-        {
-            ValidationMessage = "Enter a valid number to continue.";
+            ValidationMessage = "Choose an option to continue.";
             return false;
         }
 
-        switch (QuestionIndex)
-        {
-            case 0 when value is >= 18 and <= 80:
-                currentAge = (int)value;
-                break;
-            case 1 when currentAge.HasValue && value > currentAge.Value && value <= 80:
-                retirementAge = (int)value;
-                break;
-            case 2 when value >= 0:
-                currentSavings = value;
-                break;
-            case 3 when value >= 0:
-                annualIncome = value;
-                break;
-            case 4 when value >= 0:
-                annualExpenses = value;
-                break;
-            default:
-                ValidationMessage = QuestionIndex switch
-                {
-                    0 => "Enter an age from 18 to 80.",
-                    1 => $"Enter a target age after {currentAge ?? 18} and no later than 80.",
-                    _ => "Enter an amount of zero or more."
-                };
-                return false;
-        }
-
+        SaveChoiceAnswer(selected.Value);
         return true;
     }
 
-    private void SaveChoiceAnswer()
+    private void SaveChoiceAnswer(string value)
     {
-        var value = Choices.FirstOrDefault(choice => choice.IsSelected)?.Value;
-        if (value is null)
-        {
-            return;
-        }
-
         switch (QuestionIndex)
         {
-            case 5:
+            case 0:
                 lifestyle = Enum.Parse<FireQuizLifestyle>(value);
                 break;
-            case 6:
+            case 1:
                 workPreference = Enum.Parse<FireQuizWorkPreference>(value);
                 break;
-            case 7:
+            case 2:
+                timeline = Enum.Parse<FireQuizTimeline>(value);
+                break;
+            case 3:
                 primaryGoal = Enum.Parse<FireQuizPrimaryGoal>(value);
                 break;
         }
@@ -304,24 +240,20 @@ public partial class QuizViewModel : ObservableObject
         IsRecommendationVisible = false;
         ValidationMessage = string.Empty;
         Choices.Clear();
-        IsChoiceQuestion = QuestionIndex >= 5;
 
-        (QuestionTitle, QuestionSubtitle, AnswerText) = QuestionIndex switch
+        (QuestionTitle, QuestionSubtitle) = QuestionIndex switch
         {
-            0 => ("How old are you?", "This helps establish your planning timeline.", FormatAnswer(currentAge)),
-            1 => ("When do you want to reach financial independence?", "Choose a target age after your current age.", FormatAnswer(retirementAge)),
-            2 => ("How much do you currently have saved or invested?", "Include retirement accounts and other invested assets.", FormatAnswer(currentSavings)),
-            3 => ("What is your annual household income?", "Use your current annual income before taxes.", FormatAnswer(annualIncome)),
-            4 => ("What are your annual expenses?", "Use current spending or your expected retirement spending.", FormatAnswer(annualExpenses)),
-            5 => ("What lifestyle do you want in retirement?", "Choose the spending style that best matches your goal.", string.Empty),
-            6 => ("What is your ideal work situation after reaching FI?", "Choose how you want work to fit into your life.", string.Empty),
-            _ => ("What is most important to you?", "Choose your primary motivation for financial independence.", string.Empty)
+            0 => ("What kind of retirement lifestyle are you planning for?", "Choose the closest fit. You can refine the numbers later."),
+            1 => ("How would you like work to fit into your future?", "Financial independence can mean stopping, scaling back, or simply gaining options."),
+            2 => ("How soon would you like to reach financial independence?", "A range is enough. This shapes which strategy is most useful to explore first."),
+            _ => ("What matters most in your FIRE plan?", "Pick the priority you would protect when tradeoffs appear.")
         };
 
         AddChoicesForCurrentQuestion();
         OnPropertyChanged(nameof(QuestionProgress));
         OnPropertyChanged(nameof(QuestionProgressText));
         OnPropertyChanged(nameof(CanGoBack));
+        OnPropertyChanged(nameof(CanSkipQuestion));
         OnPropertyChanged(nameof(CanContinue));
     }
 
@@ -329,37 +261,50 @@ public partial class QuizViewModel : ObservableObject
     {
         IEnumerable<QuizChoice> choices = QuestionIndex switch
         {
-            5 =>
+            0 =>
             [
-                new(nameof(FireQuizLifestyle.Minimal), "Minimal / Frugal", "Living simply on about $30,000-$40,000 per year."),
-                new(nameof(FireQuizLifestyle.Moderate), "Moderate", "Comfortable basics on about $40,000-$70,000 per year."),
-                new(nameof(FireQuizLifestyle.Comfortable), "Comfortable", "Few major sacrifices on about $70,000-$100,000 per year."),
-                new(nameof(FireQuizLifestyle.Luxury), "Luxury / Fat", "A high-end lifestyle of $100,000 or more per year.")
+                new(nameof(FireQuizLifestyle.Minimal), "Minimal / frugal", "Keep spending intentionally low."),
+                new(nameof(FireQuizLifestyle.Moderate), "Moderate", "Cover comfortable basics with a balanced budget."),
+                new(nameof(FireQuizLifestyle.Comfortable), "Comfortable", "Maintain flexibility with few major sacrifices."),
+                new(nameof(FireQuizLifestyle.Luxury), "Higher spending", "Plan for more travel, experiences, or financial margin."),
+                new(nameof(FireQuizLifestyle.NotSure), "Not sure yet", "Keep the recommendation broad for now.")
             ],
-            6 =>
+            1 =>
             [
-                new(nameof(FireQuizWorkPreference.QuitCompletely), "Quit completely", "Leave paid work behind."),
-                new(nameof(FireQuizWorkPreference.PartTime), "Part-time work", "Work for benefits, purpose, or extra income."),
-                new(nameof(FireQuizWorkPreference.Coast), "Coast mode", "Choose lower-stress work that covers current expenses."),
-                new(nameof(FireQuizWorkPreference.Flexible), "Stay flexible", "Keep multiple work and lifestyle options open.")
+                new(nameof(FireQuizWorkPreference.QuitCompletely), "Leave paid work", "Build toward fully funding your lifestyle from investments."),
+                new(nameof(FireQuizWorkPreference.PartTime), "Work part-time", "Use some earned income for expenses, benefits, or purpose."),
+                new(nameof(FireQuizWorkPreference.Coast), "Shift into coast mode", "Let investments grow while lower-stress work covers today."),
+                new(nameof(FireQuizWorkPreference.Flexible), "Keep my options open", "Create room to change how and when you work."),
+                new(nameof(FireQuizWorkPreference.NotSure), "Not sure yet", "Explore paths with different relationships to work.")
             ],
-            7 =>
+            2 =>
             [
-                new(nameof(FireQuizPrimaryGoal.RetireEarly), "Retire as soon as possible", "Prioritize leaving full-time work early."),
-                new(nameof(FireQuizPrimaryGoal.FinancialSecurity), "Financial security", "Build peace of mind and resilience."),
-                new(nameof(FireQuizPrimaryGoal.MaintainLifestyle), "Maintain my lifestyle", "Retire without a large spending change."),
-                new(nameof(FireQuizPrimaryGoal.Flexibility), "Flexibility", "Create more options and work-life balance.")
+                new(nameof(FireQuizTimeline.WithinFiveYears), "Within 5 years", "I have a near-term target."),
+                new(nameof(FireQuizTimeline.FiveToTenYears), "In 5–10 years", "I want a focused medium-term plan."),
+                new(nameof(FireQuizTimeline.TenToTwentyYears), "In 10–20 years", "I have time to balance growth and flexibility."),
+                new(nameof(FireQuizTimeline.TwentyPlusYears), "More than 20 years", "I can give compound growth a long runway."),
+                new(nameof(FireQuizTimeline.NotSure), "Not sure yet", "I am still exploring what is realistic.")
+            ],
+            3 =>
+            [
+                new(nameof(FireQuizPrimaryGoal.RetireEarly), "Reach FI as soon as practical", "Prioritize the timeline."),
+                new(nameof(FireQuizPrimaryGoal.FinancialSecurity), "Build financial security", "Prioritize resilience and a balanced foundation."),
+                new(nameof(FireQuizPrimaryGoal.MaintainLifestyle), "Maintain my lifestyle", "Prioritize spending capacity and margin."),
+                new(nameof(FireQuizPrimaryGoal.Flexibility), "Create more flexibility", "Prioritize options and work-life balance."),
+                new(nameof(FireQuizPrimaryGoal.NotSure), "Not sure yet", "Compare several reasonable starting points.")
             ],
             _ => []
         };
 
         var selectedValue = QuestionIndex switch
         {
-            5 => lifestyle?.ToString(),
-            6 => workPreference?.ToString(),
-            7 => primaryGoal?.ToString(),
+            0 => lifestyle?.ToString(),
+            1 => workPreference?.ToString(),
+            2 => timeline?.ToString(),
+            3 => primaryGoal?.ToString(),
             _ => null
         };
+
         foreach (var choice in choices)
         {
             choice.IsSelected = choice.Value == selectedValue;
@@ -369,42 +314,54 @@ public partial class QuizViewModel : ObservableObject
 
     private void ShowRecommendation()
     {
+        var defaults = calculatorDefaultsService.Current;
         var answers = new FireQuizAnswers(
-            currentAge!.Value,
-            retirementAge!.Value,
-            currentSavings!.Value,
-            annualIncome!.Value,
-            annualExpenses!.Value,
-            lifestyle!.Value,
-            workPreference!.Value,
-            primaryGoal!.Value);
-        recommendation = FireQuizRecommender.Recommend(answers);
-        RecommendationTitle = recommendation.Title;
-        RecommendationReason = recommendation.Reason;
-        RecommendationDescription = recommendation.Description;
-        RecommendationBenefits = string.Join(Environment.NewLine, recommendation.Benefits.Select(benefit => $"- {benefit}"));
-        RecommendationIconGlyph = catalog.GetRequired(recommendation.CalculatorId).IconGlyph;
-        onboardingService.SetRecommendation(recommendation.CalculatorId);
+            lifestyle ?? FireQuizLifestyle.NotSure,
+            workPreference ?? FireQuizWorkPreference.NotSure,
+            timeline ?? FireQuizTimeline.NotSure,
+            primaryGoal ?? FireQuizPrimaryGoal.NotSure,
+            defaults.CurrentAge,
+            defaults.RetirementAge);
+        var recommendation = FireQuizRecommender.Recommend(answers);
+
+        PrimaryRecommendation = CreateOption(recommendation.Primary);
+        AlternativeRecommendations.Clear();
+        foreach (var alternative in recommendation.Alternatives)
+        {
+            AlternativeRecommendations.Add(CreateOption(alternative));
+        }
+
+        RecommendationConfidenceText = recommendation.Confidence switch
+        {
+            FireQuizConfidence.High => "Your answers point clearly to this starting path.",
+            FireQuizConfidence.Medium => "This is a useful starting path, with nearby alternatives worth comparing.",
+            _ => "Your answers are broad, so compare the alternatives before choosing."
+        };
+        onboardingService.SetRecommendation(recommendation.Primary.CalculatorId);
         IsRecommendationVisible = true;
+    }
+
+    private QuizRecommendationOption CreateOption(FireQuizMatch match)
+    {
+        return new QuizRecommendationOption(
+            match.CalculatorId,
+            match.Title,
+            match.Reason,
+            match.Description,
+            string.Join(Environment.NewLine, match.Benefits.Select(benefit => $"• {benefit}")),
+            catalog.GetRequired(match.CalculatorId).IconGlyph);
     }
 
     private DraftRecord CreateRecommendedDraft(string calculatorId)
     {
-        var age = currentAge!.Value;
-        var targetAge = retirementAge!.Value;
-        var savings = currentSavings!.Value;
-        var income = annualIncome!.Value;
-        var expenses = annualExpenses!.Value;
-        var contribution = Math.Max(0, income - expenses);
         object payload = calculatorId switch
         {
-            "lean-fire" => LeanFireDraft.Default with { CurrentAge = age, RetirementAge = targetAge, CurrentSavings = savings, AnnualContribution = contribution, AnnualIncome = income, AnnualExpenses = expenses },
-            "fat-fire" => FatFireDraft.Default with { CurrentAge = age, RetirementAge = targetAge, CurrentSavings = savings, AnnualContribution = contribution, AnnualIncome = income, AnnualExpenses = expenses },
-            "barista-fire" => BaristaFireDraft.Default with { CurrentAge = age, CurrentSavings = savings, AnnualContribution = contribution, AnnualExpenses = expenses },
-            "coast-fire" => CoastFireDraft.Default with { CurrentAge = age, RetirementAge = targetAge, CurrentSavings = savings, AnnualContribution = contribution, AnnualExpenses = expenses },
-            "reverse-fire" => ReverseFireDraft.Default with { CurrentAge = age, TargetRetirementAge = targetAge, CurrentSavings = savings, AnnualExpenses = expenses },
-            "savings-rate" => SavingsInvestmentDraft.Default with { StartingAmount = savings, ContributionAmount = contribution / 12, YearsInvesting = targetAge - age, AnnualIncome = income, CurrentAge = age },
-            _ => StandardFireDraft.Default with { CurrentAge = age, RetirementAge = targetAge, CurrentSavings = savings, AnnualContribution = contribution, AnnualIncome = income, AnnualExpenses = expenses }
+            "lean-fire" => calculatorDefaultsService.LeanFire,
+            "fat-fire" => calculatorDefaultsService.FatFire,
+            "barista-fire" => calculatorDefaultsService.BaristaFire,
+            "coast-fire" => calculatorDefaultsService.CoastFire,
+            "reverse-fire" => calculatorDefaultsService.ReverseFire,
+            _ => calculatorDefaultsService.StandardFire
         };
 
         return new DraftRecord(
@@ -412,10 +369,5 @@ public partial class QuizViewModel : ObservableObject
             1,
             JsonSerializer.Serialize(payload, payload.GetType()),
             DateTime.UtcNow);
-    }
-
-    private static string FormatAnswer(double? value)
-    {
-        return value?.ToString("0.##", CultureInfo.CurrentCulture) ?? string.Empty;
     }
 }

--- a/app/MyFireNumber/Views/OnboardingChoicePage.xaml
+++ b/app/MyFireNumber/Views/OnboardingChoicePage.xaml
@@ -32,7 +32,7 @@
                                FontSize="20"
                                FontAttributes="Bold"
                                TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />
-                        <Label Text="Answer a few questions for a personalized calculator recommendation."
+                        <Label Text="Answer a few questions to find a starting path and compare alternatives."
                                LineHeight="1.3"
                                TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
                         <Button AutomationId="OnboardingTakeQuizButton"
@@ -40,7 +40,7 @@
                                 Command="{Binding TakeQuizCommand}"
                                 Background="#2F6B57"
                                 TextColor="#FFFFFF"
-                                SemanticProperties.Description="Take the FIRE Quiz for a personalized calculator recommendation." />
+                                SemanticProperties.Description="Take the FIRE Quiz to find a starting path and compare alternatives." />
                     </VerticalStackLayout>
                 </Border>
 

--- a/app/MyFireNumber/Views/QuizPage.xaml
+++ b/app/MyFireNumber/Views/QuizPage.xaml
@@ -32,7 +32,7 @@
                                FontSize="26"
                                LineHeight="1.1"
                                SemanticProperties.HeadingLevel="Level1" />
-                        <Label Text="Your answers stay on this device."
+                        <Label Text="About two minutes. Your answers stay on this device."
                                TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
                                FontSize="13" />
                     </VerticalStackLayout>
@@ -65,58 +65,59 @@
                                        LineHeight="1.3" />
                             </VerticalStackLayout>
 
-                            <Entry AutomationId="QuizNumericAnswer"
-                                   IsVisible="{Binding IsNumericQuestion}"
-                                   Text="{Binding AnswerText}"
-                                   Keyboard="Numeric"
-                                   Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
-                                   TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
-                                   Placeholder="Enter your answer"
-                                   PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
-                                   SemanticProperties.Description="{Binding QuestionTitle}" />
-
-                            <VerticalStackLayout IsVisible="{Binding IsChoiceQuestion}"
-                                                 BindableLayout.ItemsSource="{Binding Choices}"
+                            <VerticalStackLayout BindableLayout.ItemsSource="{Binding Choices}"
                                                  Spacing="8">
                                 <BindableLayout.ItemTemplate>
                                     <DataTemplate x:DataType="viewModels:QuizChoice">
-                                        <Border Padding="14"
-                                                MinimumHeightRequest="60"
-                                                Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
-                                                Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
-                                                StrokeShape="RoundRectangle 10"
-                                                SemanticProperties.Description="{Binding Description}">
-                                            <Border.GestureRecognizers>
-                                                <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizViewModel}}, Path=SelectChoiceCommand}"
-                                                                      CommandParameter="{Binding .}" />
-                                            </Border.GestureRecognizers>
-                                            <Border.Triggers>
-                                                <DataTrigger TargetType="Border" Binding="{Binding IsSelected}" Value="True">
-                                                    <Setter Property="Background" Value="#2F6B57" />
-                                                    <Setter Property="Stroke" Value="#9ACCB3" />
-                                                </DataTrigger>
-                                            </Border.Triggers>
-                                            <VerticalStackLayout Spacing="3">
-                                                <Label Text="{Binding Label}"
-                                                       FontAttributes="Bold"
-                                                       TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}">
-                                                    <Label.Triggers>
-                                                        <DataTrigger TargetType="Label" Binding="{Binding IsSelected}" Value="True">
-                                                            <Setter Property="TextColor" Value="#FFFFFF" />
-                                                        </DataTrigger>
-                                                    </Label.Triggers>
-                                                </Label>
-                                                <Label Text="{Binding Description}"
-                                                       FontSize="12"
-                                                       TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}">
-                                                    <Label.Triggers>
-                                                        <DataTrigger TargetType="Label" Binding="{Binding IsSelected}" Value="True">
-                                                            <Setter Property="TextColor" Value="#E4F0E9" />
-                                                        </DataTrigger>
-                                                    </Label.Triggers>
-                                                </Label>
-                                            </VerticalStackLayout>
-                                        </Border>
+                                        <Grid MinimumHeightRequest="72">
+                                            <Border Padding="14,10"
+                                                    Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                                                    Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
+                                                    StrokeShape="RoundRectangle 10"
+                                                    InputTransparent="True">
+                                                <Border.Triggers>
+                                                    <DataTrigger TargetType="Border" Binding="{Binding IsSelected}" Value="True">
+                                                        <Setter Property="Background" Value="#2F6B57" />
+                                                        <Setter Property="Stroke" Value="#9ACCB3" />
+                                                    </DataTrigger>
+                                                </Border.Triggers>
+                                                <VerticalStackLayout Spacing="3"
+                                                                     HorizontalOptions="Fill"
+                                                                     VerticalOptions="Center"
+                                                                     InputTransparent="True">
+                                                    <Label Text="{Binding Label}"
+                                                           HorizontalTextAlignment="Start"
+                                                           FontAttributes="Bold"
+                                                           FontSize="14"
+                                                           TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}">
+                                                        <Label.Triggers>
+                                                            <DataTrigger TargetType="Label" Binding="{Binding IsSelected}" Value="True">
+                                                                <Setter Property="TextColor" Value="#FFFFFF" />
+                                                            </DataTrigger>
+                                                        </Label.Triggers>
+                                                    </Label>
+                                                    <Label Text="{Binding Description}"
+                                                           HorizontalTextAlignment="Start"
+                                                           FontSize="12"
+                                                           LineBreakMode="WordWrap"
+                                                           TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}">
+                                                        <Label.Triggers>
+                                                            <DataTrigger TargetType="Label" Binding="{Binding IsSelected}" Value="True">
+                                                                <Setter Property="TextColor" Value="#E4F0E9" />
+                                                            </DataTrigger>
+                                                        </Label.Triggers>
+                                                    </Label>
+                                                </VerticalStackLayout>
+                                            </Border>
+                                            <Button AutomationId="{Binding AutomationId}"
+                                                    Text=""
+                                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizViewModel}}, Path=SelectChoiceCommand}"
+                                                    CommandParameter="{Binding .}"
+                                                    Background="Transparent"
+                                                    BorderWidth="0"
+                                                    Padding="0"
+                                                    SemanticProperties.Description="{Binding DisplayText}" />
+                                        </Grid>
                                     </DataTemplate>
                                 </BindableLayout.ItemTemplate>
                             </VerticalStackLayout>
@@ -144,52 +145,105 @@
                     </Grid>
                 </VerticalStackLayout>
 
-                <VerticalStackLayout IsVisible="{Binding IsRecommendationVisible}" Spacing="18">
+                <VerticalStackLayout IsVisible="{Binding IsRecommendationVisible}" Spacing="20">
+                    <VerticalStackLayout Spacing="5">
+                        <Label Text="Your best FIRE starting point"
+                               FontAttributes="Bold"
+                               FontSize="26"
+                               TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
+                               SemanticProperties.HeadingLevel="Level2" />
+                        <Label Text="This is an educational match based on your priorities, not a prediction or financial advice."
+                               TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
+                               LineHeight="1.3" />
+                    </VerticalStackLayout>
+
                     <Border Padding="20"
                             Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                             Stroke="{AppThemeBinding Light=#A8D4B2, Dark=#43805B}"
                             StrokeThickness="2"
                             StrokeShape="RoundRectangle 12">
                         <VerticalStackLayout Spacing="12">
-                            <Label Text="Your recommended path"
-                                   FontAttributes="Bold"
-                                   FontSize="14"
-                                   TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}" />
-                            <Label Text="{Binding RecommendationIconGlyph}"
+                            <Label Text="{Binding PrimaryRecommendation.IconGlyph}"
                                    FontFamily="FontAwesomeSolid"
                                    FontSize="32"
                                    TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
                                    HorizontalTextAlignment="Center"
                                    SemanticProperties.Description="Recommended calculator" />
                             <Label AutomationId="QuizRecommendationTitle"
-                                   Text="{Binding RecommendationTitle}"
+                                   Text="{Binding PrimaryRecommendation.Title}"
                                    FontAttributes="Bold"
                                    FontSize="28"
                                    HorizontalTextAlignment="Center"
-                                   TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
-                                   SemanticProperties.HeadingLevel="Level2" />
-                            <Label Text="{Binding RecommendationReason}"
+                                   TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />
+                            <Label Text="{Binding PrimaryRecommendation.Reason}"
                                    FontAttributes="Bold"
                                    HorizontalTextAlignment="Center"
                                    TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
                                    LineHeight="1.3" />
-                            <Label Text="{Binding RecommendationDescription}"
+                            <Label Text="{Binding PrimaryRecommendation.Description}"
                                    TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
                                    LineHeight="1.3" />
-                            <Label Text="{Binding RecommendationBenefits}"
+                            <Label Text="{Binding PrimaryRecommendation.Benefits}"
                                    TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
                                    LineHeight="1.4" />
-                            <Button Text="{Binding RecommendationTitle, StringFormat='Open {0}'}"
+                            <Label Text="{Binding RecommendationConfidenceText}"
+                                   FontSize="13"
+                                   TextColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" />
+                            <Button AutomationId="QuizOpenPrimaryButton"
+                                    Text="{Binding PrimaryRecommendation.Title, StringFormat='Start with {0}'}"
                                     Command="{Binding UseRecommendationCommand}"
+                                    CommandParameter="{Binding PrimaryRecommendation}"
                                     Background="#2F6B57"
                                     TextColor="#FFFFFF" />
-                            <Button Text="Start over"
-                                    Command="{Binding StartOverCommand}"
-                                    Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}"
-                                    TextColor="{AppThemeBinding Light=#245744, Dark=#C8E7D5}" />
                         </VerticalStackLayout>
                     </Border>
+
+                    <VerticalStackLayout Spacing="10">
+                        <Label Text="Two paths worth comparing"
+                               FontAttributes="Bold"
+                               FontSize="20"
+                               TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />
+                        <Label Text="FIRE paths overlap. These alternatives emphasize different tradeoffs in your answers."
+                               TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
+                               LineHeight="1.3" />
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding AlternativeRecommendations}"
+                                             Spacing="10">
+                            <BindableLayout.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:QuizRecommendationOption">
+                                    <Border Padding="16"
+                                            Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
+                                            Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
+                                            StrokeShape="RoundRectangle 10">
+                                        <VerticalStackLayout Spacing="8">
+                                            <Label Text="{Binding Title}"
+                                                   FontAttributes="Bold"
+                                                   FontSize="18"
+                                                   TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />
+                                            <Label Text="{Binding Reason}"
+                                                   FontSize="13"
+                                                   TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
+                                                   LineHeight="1.3" />
+                                            <Button AutomationId="{Binding AutomationId}"
+                                                    Text="{Binding Title, StringFormat='Explore {0}'}"
+                                                    Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:QuizViewModel}}, Path=UseRecommendationCommand}"
+                                                    CommandParameter="{Binding .}"
+                                                    Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}"
+                                                    TextColor="{AppThemeBinding Light=#245744, Dark=#C8E7D5}" />
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </BindableLayout.ItemTemplate>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+
+                    <Button Text="Retake the quiz"
+                            Command="{Binding StartOverCommand}"
+                            Background="Transparent"
+                            BorderColor="{AppThemeBinding Light=#A8B8AF, Dark=#587668}"
+                            BorderWidth="1"
+                            TextColor="{AppThemeBinding Light=#425D54, Dark=#D6E5DC}" />
                 </VerticalStackLayout>
+
                 <controls:EducationalDisclaimerView />
             </VerticalStackLayout>
         </ScrollView>

--- a/web/src/config/seo.ts
+++ b/web/src/config/seo.ts
@@ -90,8 +90,8 @@ export const calculatorSEO: Record<string, PageSEO> = {
     canonicalPath: '/apps',
   },
   quiz: {
-    title: 'FIRE Calculator Quiz - Find Your Perfect FIRE Path',
-    description: 'Take our free FIRE quiz to discover which calculator and strategy fits your situation. Answer a few questions and get personalized calculator recommendations with pre-filled values.',
+    title: 'FIRE Calculator Quiz - Find Your FIRE Starting Point',
+    description: 'Compare FIRE paths based on your timeline, lifestyle, and work preferences. Get a starting recommendation, two alternatives, and optional calculator prefilling.',
     keywords: 'FIRE quiz, which FIRE calculator, FIRE personality quiz, financial independence quiz, early retirement quiz',
     canonicalPath: '/quiz',
   },

--- a/web/src/pages/FIREQuiz.tsx
+++ b/web/src/pages/FIREQuiz.tsx
@@ -1,493 +1,453 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Card, CardHeader, CardContent } from '../components/ui'
 import SEO from '../components/SEO'
+import { Card, CardContent } from '../components/ui'
+import { getCalculatorByPath } from '../config/calculators'
 import { calculatorSEO } from '../config/seo'
+import {
+  recommendFirePaths,
+  type FireQuizMatch,
+  type FireQuizRecommendation,
+  type QuizAnswers,
+} from '../utils/quizRecommendations'
 
-interface QuizAnswers {
-  currentAge?: number
-  retirementAge?: number
-  currentSavings?: number
-  annualIncome?: number
-  annualExpenses?: number
-  lifestyle?: 'minimal' | 'moderate' | 'comfortable' | 'luxury'
-  workPreference?: 'quit-completely' | 'part-time' | 'flexible' | 'coast'
-  riskTolerance?: 'conservative' | 'moderate' | 'aggressive'
-  primaryGoal?: 'retire-early' | 'financial-security' | 'maintain-lifestyle' | 'flexibility'
-}
+type ChoiceId = 'lifestyle' | 'workPreference' | 'timeline' | 'primaryGoal' | 'personalize'
+type NumericId = 'currentAge' | 'retirementAge' | 'currentSavings' | 'annualIncome' | 'annualExpenses'
 
-interface Recommendation {
-  path: string
+interface ChoiceQuestion {
+  id: ChoiceId
+  type: 'choice'
   title: string
-  icon: string
-  reason: string
-  description: string
-  benefits: string[]
+  subtitle: string
+  choices: { value: string; label: string; description: string }[]
 }
+
+interface NumericQuestion {
+  id: NumericId
+  type: 'number' | 'currency'
+  title: string
+  subtitle: string
+  placeholder: string
+  min: number
+  max?: number
+}
+
+type Question = ChoiceQuestion | NumericQuestion
+
+const questions: Question[] = [
+  {
+    id: 'lifestyle',
+    type: 'choice',
+    title: 'What kind of retirement lifestyle are you planning for?',
+    subtitle: 'Choose the closest fit. You can refine the numbers later.',
+    choices: [
+      { value: 'minimal', label: 'Minimal / frugal', description: 'Keep spending intentionally low.' },
+      { value: 'moderate', label: 'Moderate', description: 'Cover comfortable basics with a balanced budget.' },
+      { value: 'comfortable', label: 'Comfortable', description: 'Maintain flexibility with few major sacrifices.' },
+      { value: 'luxury', label: 'Higher spending', description: 'Plan for more travel, experiences, or financial margin.' },
+      { value: 'not-sure', label: 'Not sure yet', description: 'Keep the recommendation broad for now.' },
+    ],
+  },
+  {
+    id: 'workPreference',
+    type: 'choice',
+    title: 'How would you like work to fit into your future?',
+    subtitle: 'Financial independence can mean stopping, scaling back, or simply gaining options.',
+    choices: [
+      { value: 'quit-completely', label: 'Leave paid work', description: 'Build toward fully funding your lifestyle from investments.' },
+      { value: 'part-time', label: 'Work part-time', description: 'Use some earned income for expenses, benefits, or purpose.' },
+      { value: 'coast', label: 'Shift into coast mode', description: 'Let investments grow while lower-stress work covers today.' },
+      { value: 'flexible', label: 'Keep my options open', description: 'Create room to change how and when you work.' },
+      { value: 'not-sure', label: 'Not sure yet', description: 'Explore paths with different relationships to work.' },
+    ],
+  },
+  {
+    id: 'timeline',
+    type: 'choice',
+    title: 'How soon would you like to reach financial independence?',
+    subtitle: 'A range is enough. This shapes which strategy is most useful to explore first.',
+    choices: [
+      { value: 'within-5', label: 'Within 5 years', description: 'I have a near-term target.' },
+      { value: '5-10', label: 'In 5–10 years', description: 'I want a focused medium-term plan.' },
+      { value: '10-20', label: 'In 10–20 years', description: 'I have time to balance growth and flexibility.' },
+      { value: '20-plus', label: 'More than 20 years', description: 'I can give compound growth a long runway.' },
+      { value: 'not-sure', label: 'Not sure yet', description: 'I am still exploring what is realistic.' },
+    ],
+  },
+  {
+    id: 'primaryGoal',
+    type: 'choice',
+    title: 'What matters most in your FIRE plan?',
+    subtitle: 'Pick the priority you would protect when tradeoffs appear.',
+    choices: [
+      { value: 'retire-early', label: 'Reach FI as soon as practical', description: 'Prioritize the timeline.' },
+      { value: 'financial-security', label: 'Build financial security', description: 'Prioritize resilience and a balanced foundation.' },
+      { value: 'maintain-lifestyle', label: 'Maintain my lifestyle', description: 'Prioritize spending capacity and margin.' },
+      { value: 'flexibility', label: 'Create more flexibility', description: 'Prioritize options and work-life balance.' },
+      { value: 'not-sure', label: 'Not sure yet', description: 'Compare several reasonable starting points.' },
+    ],
+  },
+  {
+    id: 'personalize',
+    type: 'choice',
+    title: 'Would you like to personalize the calculator you open?',
+    subtitle: 'These optional details stay in your browser and do not change the core path recommendation.',
+    choices: [
+      { value: 'yes', label: 'Add my starting numbers', description: 'Answer five optional questions to prefill the calculator.' },
+      { value: 'no', label: 'Show my matches now', description: 'Use calculator defaults and adjust them later.' },
+    ],
+  },
+  {
+    id: 'currentAge',
+    type: 'number',
+    title: 'What is your current age?',
+    subtitle: 'Optional · Used only to prefill the calculator.',
+    placeholder: '30',
+    min: 18,
+    max: 80,
+  },
+  {
+    id: 'retirementAge',
+    type: 'number',
+    title: 'What age would you like to reach FI?',
+    subtitle: 'Optional · A specific age helps personalize timeline calculations.',
+    placeholder: '50',
+    min: 19,
+    max: 100,
+  },
+  {
+    id: 'currentSavings',
+    type: 'currency',
+    title: 'How much do you currently have invested?',
+    subtitle: 'Optional · Include retirement accounts and other invested assets.',
+    placeholder: '100,000',
+    min: 0,
+  },
+  {
+    id: 'annualIncome',
+    type: 'currency',
+    title: 'What is your annual household income?',
+    subtitle: 'Optional · Use income before taxes.',
+    placeholder: '80,000',
+    min: 0,
+  },
+  {
+    id: 'annualExpenses',
+    type: 'currency',
+    title: 'What are your expected annual retirement expenses?',
+    subtitle: 'Optional · This can fine-tune Lean and Fat FIRE matches.',
+    placeholder: '50,000',
+    min: 0,
+  },
+]
 
 export default function FIREQuiz() {
   const navigate = useNavigate()
   const [step, setStep] = useState(0)
   const [answers, setAnswers] = useState<QuizAnswers>({})
-  const [recommendation, setRecommendation] = useState<Recommendation | null>(null)
+  const [personalize, setPersonalize] = useState<boolean>()
+  const [recommendation, setRecommendation] = useState<FireQuizRecommendation>()
+  const [validationMessage, setValidationMessage] = useState('')
+  const currentQuestion = questions[step]
 
-  const seoComponent = <SEO {...calculatorSEO.quiz} />
+  const currentValue = currentQuestion.id === 'personalize'
+    ? personalize === undefined ? undefined : personalize ? 'yes' : 'no'
+    : answers[currentQuestion.id as keyof QuizAnswers]
 
-  const questions = [
-    {
-      id: 'currentAge',
-      title: 'How old are you?',
-      subtitle: 'This helps us understand your timeline',
-      type: 'number',
-      placeholder: '30',
-      min: 18,
-      max: 80,
-    },
-    {
-      id: 'retirementAge',
-      title: 'When do you want to achieve financial independence?',
-      subtitle: 'Your target age for FIRE',
-      type: 'number',
-      placeholder: '50',
-      min: (answers.currentAge || 18) + 1,
-      max: 80,
-    },
-    {
-      id: 'currentSavings',
-      title: 'How much do you currently have saved/invested?',
-      subtitle: 'Include all retirement accounts and investments',
-      type: 'currency',
-      placeholder: '100,000',
-    },
-    {
-      id: 'annualIncome',
-      title: 'What\'s your current annual household income?',
-      subtitle: 'Before taxes',
-      type: 'currency',
-      placeholder: '80,000',
-    },
-    {
-      id: 'annualExpenses',
-      title: 'What are your current annual expenses?',
-      subtitle: 'Or what you expect to spend in retirement',
-      type: 'currency',
-      placeholder: '50,000',
-    },
-    {
-      id: 'lifestyle',
-      title: 'What lifestyle do you want in retirement?',
-      subtitle: 'This impacts your target savings amount',
-      type: 'choice',
-      choices: [
-        { value: 'minimal', label: 'Minimal/Frugal', desc: 'Living simply, $30K-$40K/year' },
-        { value: 'moderate', label: 'Moderate', desc: 'Comfortable basics, $40K-$70K/year' },
-        { value: 'comfortable', label: 'Comfortable', desc: 'No major sacrifices, $70K-$100K/year' },
-        { value: 'luxury', label: 'Luxury/Fat', desc: 'High-end lifestyle, $100K+/year' },
-      ],
-    },
-    {
-      id: 'workPreference',
-      title: 'What\'s your ideal work situation after reaching FI?',
-      subtitle: 'How you want to spend your time',
-      type: 'choice',
-      choices: [
-        { value: 'quit-completely', label: 'Quit Completely', desc: 'Never work again' },
-        { value: 'part-time', label: 'Part-Time Work', desc: 'Work for benefits or extra income' },
-        { value: 'coast', label: 'Coast Mode', desc: 'Low-stress job covering expenses' },
-        { value: 'flexible', label: 'Stay Flexible', desc: 'Keep options open' },
-      ],
-    },
-    {
-      id: 'primaryGoal',
-      title: 'What\'s most important to you?',
-      subtitle: 'Your primary motivation for FIRE',
-      type: 'choice',
-      choices: [
-        { value: 'retire-early', label: 'Retire ASAP', desc: 'Leave workforce as early as possible' },
-        { value: 'financial-security', label: 'Financial Security', desc: 'Peace of mind and freedom' },
-        { value: 'maintain-lifestyle', label: 'Maintain Lifestyle', desc: 'Retire without sacrifice' },
-        { value: 'flexibility', label: 'Flexibility', desc: 'Options and work-life balance' },
-      ],
-    },
-  ]
+  const showRecommendation = (nextAnswers = answers) => {
+    setRecommendation(recommendFirePaths(nextAnswers))
+    window.scrollTo({ top: 0 })
+  }
 
-  const calculateRecommendation = (): Recommendation => {
-    const { lifestyle, workPreference, primaryGoal, currentAge, retirementAge, annualExpenses } = answers
-    
-    // Calculate years to retirement
-    const yearsToFIRE = (retirementAge || 65) - (currentAge || 30)
-    
-    // Determine expense level
-    const expenseLevel = annualExpenses || 50000
-
-    // Lean FIRE logic
-    if (lifestyle === 'minimal' || (expenseLevel < 40000 && primaryGoal === 'retire-early')) {
-      return {
-        path: '/lean',
-        title: 'Lean FIRE',
-        icon: '🌿',
-        reason: 'Your minimalist lifestyle and lower expenses make Lean FIRE achievable',
-        description: 'Achieve FI faster by living frugally. Requires less savings but demands lifestyle discipline.',
-        benefits: [
-          'Retire years earlier than traditional FIRE',
-          'Need less total savings to reach your goal',
-          'Forces intentional spending habits',
-          'Freedom with minimalist lifestyle',
-        ],
-      }
+  const selectChoice = (questionId: ChoiceId, value: string) => {
+    setValidationMessage('')
+    if (questionId === 'personalize') {
+      setPersonalize(value === 'yes')
+      return
     }
+    setAnswers(previous => ({ ...previous, [questionId]: value }))
+  }
 
-    // Fat FIRE logic
-    if (lifestyle === 'luxury' || (expenseLevel >= 100000 && primaryGoal === 'maintain-lifestyle')) {
-      return {
-        path: '/fat',
-        title: 'Fat FIRE',
-        icon: '💎',
-        reason: 'Your desire for a comfortable lifestyle without compromise aligns with Fat FIRE',
-        description: 'Achieve FI while maintaining a luxurious or upper-middle-class lifestyle. Requires more savings but no sacrifices.',
-        benefits: [
-          'Retire without lifestyle changes',
-          'Extra buffer for market downturns',
-          'Travel, dining, and experiences without worry',
-          'Help family and leave a legacy',
-        ],
-      }
-    }
+  const setNumericAnswer = (questionId: NumericId, value: string) => {
+    setValidationMessage('')
+    setAnswers(previous => ({
+      ...previous,
+      [questionId]: value === '' ? undefined : Number(value),
+    }))
+  }
 
-    // Barista FIRE logic
-    if (workPreference === 'part-time' || (yearsToFIRE < 10 && primaryGoal === 'flexibility')) {
-      return {
-        path: '/barista',
-        title: 'Barista FIRE',
-        icon: '☕',
-        reason: 'Your interest in part-time work makes Barista FIRE an ideal stepping stone',
-        description: 'Blend portfolio income with part-time work. Reach FI faster while maintaining health benefits and social connections.',
-        benefits: [
-          'Quit corporate job years earlier',
-          'Part-time work covers some expenses',
-          'Health insurance from employer',
-          'Stay active and socially engaged',
-        ],
-      }
+  const validateNumericAnswer = (question: NumericQuestion) => {
+    const value = answers[question.id]
+    if (value === undefined) return true
+    if (!Number.isFinite(value) || value < question.min || (question.max !== undefined && value > question.max)) {
+      setValidationMessage(
+        question.max === undefined
+          ? `Enter an amount of ${question.min.toLocaleString()} or more, or choose “Not sure.”`
+          : `Enter a value from ${question.min} to ${question.max}, or choose “Not sure.”`,
+      )
+      return false
     }
-
-    // Coast FIRE logic
-    if (workPreference === 'coast' || (currentAge || 30) < 35 && yearsToFIRE > 20) {
-      return {
-        path: '/coast',
-        title: 'Coast FIRE',
-        icon: '⛵',
-        reason: 'Your timeline and age make Coast FIRE a strategic approach',
-        description: 'Save aggressively now, then let compound growth do the work. Perfect for young savers wanting flexibility.',
-        benefits: [
-          'Save hard early, then ease off',
-          'Compound growth does the heavy lifting',
-          'Take lower-paying but fulfilling work',
-          'Reduces pressure in your 30s-40s',
-        ],
-      }
+    if (question.id === 'retirementAge' && answers.currentAge !== undefined && value <= answers.currentAge) {
+      setValidationMessage('Your target FI age must be after your current age, or choose “Not sure.”')
+      return false
     }
-
-    // Reverse FIRE logic
-    if (primaryGoal === 'retire-early' && yearsToFIRE < 15) {
-      return {
-        path: '/reverse',
-        title: 'Reverse FIRE',
-        icon: '🔄',
-        reason: 'Your specific retirement age goal calls for a targeted savings strategy',
-        description: 'Work backwards from your target age to calculate exactly what you need to save monthly.',
-        benefits: [
-          'Clear monthly savings target',
-          'Goal-oriented approach',
-          'Adjust timeline or savings as needed',
-          'Perfect for deadline-driven planners',
-        ],
-      }
-    }
-
-    // Savings Rate focus
-    if (primaryGoal === 'financial-security') {
-      return {
-        path: '/savings-rate',
-        title: 'Savings Rate Calculator',
-        icon: '🧮',
-        reason: 'Understanding your savings rate is the foundation for all FIRE paths',
-        description: 'Your savings rate is the most important metric in FIRE. This calculator shows exactly how it impacts your timeline.',
-        benefits: [
-          'See direct impact of saving more',
-          'Most important FIRE metric',
-          'Works for any income level',
-          'Clear path to financial freedom',
-        ],
-      }
-    }
-
-    // Default to Standard FIRE
-    return {
-      path: '/standard',
-      title: 'Standard FIRE',
-      icon: '🎯',
-      reason: 'The classic FIRE approach fits your balanced goals and timeline',
-      description: 'The traditional 25x expenses rule. A proven, balanced approach to financial independence.',
-      benefits: [
-        'Time-tested 4% withdrawal rule',
-        'Balanced approach for most people',
-        'Comprehensive planning framework',
-        'Retire at traditional age or earlier',
-      ],
-    }
+    return true
   }
 
   const handleNext = () => {
-    if (step < questions.length - 1) {
-      setStep(step + 1)
-    } else {
-      // Calculate recommendation
-      const rec = calculateRecommendation()
-      setRecommendation(rec)
+    if (currentQuestion.type === 'choice' && currentValue === undefined) return
+    if (currentQuestion.type !== 'choice' && !validateNumericAnswer(currentQuestion)) return
+    if (currentQuestion.id === 'personalize' && personalize === false) {
+      showRecommendation()
+      return
     }
-  }
-
-  const handlePrevious = () => {
-    if (step > 0) {
-      setStep(step - 1)
+    if (step === questions.length - 1) {
+      showRecommendation()
+      return
     }
+    setStep(previous => previous + 1)
+    setValidationMessage('')
   }
 
-  const handleAnswer = (value: any) => {
-    const question = questions[step]
-    setAnswers({ ...answers, [question.id]: value })
+  const skipNumericQuestion = () => {
+    if (currentQuestion.type === 'choice') return
+    const nextAnswers = { ...answers, [currentQuestion.id]: undefined }
+    setAnswers(nextAnswers)
+    setValidationMessage('')
+    if (step === questions.length - 1) showRecommendation(nextAnswers)
+    else setStep(previous => previous + 1)
   }
 
-  const handleGoToCalculator = () => {
-    if (!recommendation) return
-
-    // Build query params from answers
+  const openCalculator = (match: FireQuizMatch) => {
     const params = new URLSearchParams()
-    if (answers.currentAge) params.set('currentAge', answers.currentAge.toString())
-    if (answers.retirementAge) params.set('retirementAge', answers.retirementAge.toString())
-    if (answers.currentSavings) params.set('currentSavings', answers.currentSavings.toString())
-    if (answers.annualExpenses) params.set('annualExpenses', answers.annualExpenses.toString())
-    
-    // Calculate annual contribution from income and expenses
-    if (answers.annualIncome && answers.annualExpenses) {
-      const contribution = Math.max(0, answers.annualIncome - answers.annualExpenses)
-      params.set('annualContribution', contribution.toString())
+    if (answers.currentAge !== undefined) params.set('age', answers.currentAge.toString())
+    if (answers.retirementAge !== undefined) params.set('retire', answers.retirementAge.toString())
+    if (answers.currentSavings !== undefined) params.set('savings', answers.currentSavings.toString())
+    if (answers.annualIncome !== undefined) params.set('income', answers.annualIncome.toString())
+    if (answers.annualExpenses !== undefined) params.set('expenses', answers.annualExpenses.toString())
+    if (answers.annualIncome !== undefined && answers.annualExpenses !== undefined) {
+      params.set('contrib', Math.max(0, answers.annualIncome - answers.annualExpenses).toString())
     }
-
-    navigate(`${recommendation.path}?${params.toString()}`)
+    navigate(`${match.path}${params.size > 0 ? `?${params}` : ''}`)
   }
 
-  const handleStartOver = () => {
+  const startOver = () => {
     setStep(0)
     setAnswers({})
-    setRecommendation(null)
+    setPersonalize(undefined)
+    setRecommendation(undefined)
+    setValidationMessage('')
   }
 
-  const currentQuestion = questions[step]
-  const currentAnswer = answers[currentQuestion?.id as keyof QuizAnswers]
-  const canProceed = currentAnswer !== undefined && currentAnswer !== null
-
-  // Results view
   if (recommendation) {
+    const primaryMetadata = getCalculatorByPath(recommendation.primary.path)
     return (
       <>
-        {seoComponent}
-        <div className="max-w-3xl mx-auto space-y-6">
-          {/* Header */}
-          <div className="text-center">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-              Your Recommended Path
-            </h1>
-            <p className="text-gray-600 dark:text-gray-400">
-              Based on your answers, here's the best FIRE strategy for you
+        <SEO {...calculatorSEO.quiz} />
+        <main className="mx-auto max-w-3xl space-y-8">
+          <header className="text-center">
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">Your best FIRE starting point</h1>
+            <p className="mx-auto mt-3 max-w-2xl text-gray-600 dark:text-gray-400">
+              This is an educational match based on your priorities—not a prediction or financial advice.
             </p>
-          </div>
+          </header>
 
-          {/* Recommendation Card */}
-          <Card className="border-2 border-fire-200 dark:border-fire-800">
-            <CardContent className="p-8">
-              <div className="text-center mb-6">
-              <span className="text-6xl mb-4 block">{recommendation.icon}</span>
-              <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-                {recommendation.title}
-              </h2>
-              <p className="text-lg text-fire-600 dark:text-fire-400 font-medium">
-                {recommendation.reason}
-              </p>
-            </div>
-
-            <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-6 mb-6">
-              <p className="text-gray-700 dark:text-gray-300">
-                {recommendation.description}
-              </p>
-            </div>
-
-            <div className="mb-6">
-              <h3 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">
-                Why this path works for you:
-              </h3>
-              <ul className="space-y-2">
-                {recommendation.benefits.map((benefit, index) => (
-                  <li key={index} className="flex items-start gap-2 text-gray-600 dark:text-gray-400">
-                    <svg className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    {benefit}
+          <Card className="border-2 border-fire-300 dark:border-fire-700">
+            <CardContent className="p-6 sm:p-8">
+              <div className="text-center">
+                <span className="block text-5xl" aria-hidden="true">{primaryMetadata?.icon ?? '🎯'}</span>
+                <h2 className="mt-4 text-3xl font-bold text-gray-900 dark:text-gray-100">{recommendation.primary.title}</h2>
+                <p className="mt-3 text-lg font-medium text-fire-700 dark:text-fire-300">{recommendation.primary.reason}</p>
+              </div>
+              <p className="mx-auto mt-6 max-w-2xl text-gray-700 dark:text-gray-300">{recommendation.primary.description}</p>
+              <ul className="mx-auto mt-5 max-w-2xl space-y-2">
+                {recommendation.primary.benefits.map(benefit => (
+                  <li key={benefit} className="flex gap-3 text-gray-700 dark:text-gray-300">
+                    <span className="font-bold text-green-600 dark:text-green-400" aria-hidden="true">✓</span>
+                    <span>{benefit}</span>
                   </li>
                 ))}
               </ul>
-            </div>
-
-            <div className="flex gap-4">
               <button
-                onClick={handleGoToCalculator}
-                className="flex-1 bg-fire-600 hover:bg-fire-700 text-white font-medium py-3 px-6 rounded-lg transition-colors"
+                type="button"
+                onClick={() => openCalculator(recommendation.primary)}
+                className="mt-7 w-full rounded-lg bg-fire-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-fire-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fire-600"
               >
-                Go to {recommendation.title} Calculator →
+                Start with {recommendation.primary.title}
               </button>
-              <button
-                onClick={handleStartOver}
-                className="px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-              >
-                Start Over
-              </button>
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
 
-        {/* Other Options */}
-        <Card>
-          <CardHeader>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              Want to explore other paths?
-            </h3>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-              All FIRE paths can work depending on your circumstances. Feel free to explore multiple calculators to find what resonates with you.
+          <section aria-labelledby="alternative-paths-heading">
+            <h2 id="alternative-paths-heading" className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+              Two paths worth comparing
+            </h2>
+            <p className="mt-2 text-gray-600 dark:text-gray-400">
+              FIRE paths overlap. These alternatives emphasize different tradeoffs in your answers.
             </p>
-            <button
-              onClick={() => navigate('/')}
-              className="text-fire-600 dark:text-fire-400 hover:underline"
-            >
-              View All Calculators
-            </button>
-          </CardContent>
-        </Card>
-      </div>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              {recommendation.alternatives.map(match => {
+                const metadata = getCalculatorByPath(match.path)
+                return (
+                  <article key={match.path} className="rounded-xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-900">
+                    <div className="flex items-center gap-3">
+                      <span className="text-2xl" aria-hidden="true">{metadata?.icon ?? '🎯'}</span>
+                      <h3 className="text-lg font-bold text-gray-900 dark:text-gray-100">{match.title}</h3>
+                    </div>
+                    <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">{match.reason}</p>
+                    <button
+                      type="button"
+                      onClick={() => openCalculator(match)}
+                      className="mt-5 font-semibold text-fire-700 underline-offset-4 hover:underline dark:text-fire-300"
+                    >
+                      Explore {match.title}
+                    </button>
+                  </article>
+                )
+              })}
+            </div>
+          </section>
+
+          <button
+            type="button"
+            onClick={startOver}
+            className="mx-auto block rounded-lg border border-gray-300 px-5 py-3 font-medium text-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Retake the quiz
+          </button>
+        </main>
       </>
     )
   }
 
-  // Quiz view
+  const isOptionalStage = step >= 5
+  const stageStep = isOptionalStage ? step - 4 : step + 1
+  const stageTitle = isOptionalStage ? 'Optional detail' : 'Core question'
+  const stageProgress = stageStep / 5
+
   return (
     <>
-      {seoComponent}
-      <div className="max-w-2xl mx-auto space-y-6">
-        {/* Progress */}
-        <div>
-          <div className="flex justify-between items-center mb-2">
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-              Question {step + 1} of {questions.length}
-            </span>
-            <span className="text-sm text-gray-500 dark:text-gray-400">
-              {Math.round(((step + 1) / questions.length) * 100)}% complete
-            </span>
+      <SEO {...calculatorSEO.quiz} />
+      <main className="mx-auto max-w-2xl space-y-6">
+        <header>
+          <div className="flex items-center justify-between gap-4 text-sm">
+            <span className="font-semibold text-gray-700 dark:text-gray-300">{stageTitle} {stageStep} of 5</span>
+            <span className="text-gray-500 dark:text-gray-400">{isOptionalStage ? 'Skip anything you do not know' : 'About 2 minutes'}</span>
           </div>
-          <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
-            <div
-              className="h-full bg-gradient-to-r from-fire-500 to-fire-600 transition-all duration-300"
-              style={{ width: `${((step + 1) / questions.length) * 100}%` }}
-          />
-        </div>
-      </div>
-
-      {/* Question Card */}
-      <Card>
-        <CardContent className="p-8">
-          <div className="mb-6">
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-              {currentQuestion.title}
-            </h2>
-            <p className="text-gray-600 dark:text-gray-400">
-              {currentQuestion.subtitle}
-            </p>
+          <div
+            className="mt-2 h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-gray-700"
+            role="progressbar"
+            aria-label={`${stageTitle} progress`}
+            aria-valuemin={0}
+            aria-valuemax={5}
+            aria-valuenow={stageStep}
+          >
+            <div className="h-full bg-fire-600 transition-[width] motion-reduce:transition-none" style={{ width: `${stageProgress * 100}%` }} />
           </div>
+        </header>
 
-          {/* Input based on type */}
-          {currentQuestion.type === 'number' && (
-            <div>
-              <input
-                type="number"
-                value={currentAnswer || ''}
-                onChange={(e) => handleAnswer(e.target.value ? Number(e.target.value) : undefined)}
-                placeholder={currentQuestion.placeholder}
-                min={currentQuestion.min}
-                max={currentQuestion.max}
-                className="w-full px-4 py-3 text-lg border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-fire-500 focus:border-transparent"
-              />
-            </div>
-          )}
+        <Card>
+          <CardContent className="p-6 sm:p-8">
+            <h1 id="quiz-question" className="text-2xl font-bold text-gray-900 dark:text-gray-100">{currentQuestion.title}</h1>
+            <p id="quiz-question-help" className="mt-2 text-gray-600 dark:text-gray-400">{currentQuestion.subtitle}</p>
 
-          {currentQuestion.type === 'currency' && (
-            <div className="relative">
-              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-500 dark:text-gray-400 text-lg">
-                $
-              </span>
-              <input
-                type="number"
-                value={currentAnswer || ''}
-                onChange={(e) => handleAnswer(e.target.value ? Number(e.target.value) : undefined)}
-                placeholder={currentQuestion.placeholder}
-                className="w-full pl-8 pr-4 py-3 text-lg border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-fire-500 focus:border-transparent"
-              />
-            </div>
-          )}
-
-          {currentQuestion.type === 'choice' && (
-            <div className="space-y-3">
-              {currentQuestion.choices?.map((choice) => (
+            {currentQuestion.type === 'choice' ? (
+              <fieldset className="mt-6 space-y-3">
+                <legend className="sr-only">{currentQuestion.title}</legend>
+                {currentQuestion.choices.map(choice => {
+                  const selected = currentValue === choice.value
+                  return (
+                    <label
+                      key={choice.value}
+                      className={`block cursor-pointer rounded-lg border-2 p-4 transition-colors focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-fire-600 ${
+                        selected
+                          ? 'border-fire-500 bg-fire-50 dark:bg-fire-950/40'
+                          : 'border-gray-200 hover:border-gray-400 dark:border-gray-700 dark:hover:border-gray-500'
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name={currentQuestion.id}
+                        value={choice.value}
+                        checked={selected}
+                        onChange={() => selectChoice(currentQuestion.id, choice.value)}
+                        className="sr-only"
+                      />
+                      <span className="block font-semibold text-gray-900 dark:text-gray-100">{choice.label}</span>
+                      <span className="mt-1 block text-sm text-gray-600 dark:text-gray-400">{choice.description}</span>
+                    </label>
+                  )
+                })}
+              </fieldset>
+            ) : (
+              <div className="mt-6">
+                <div className="relative">
+                  {currentQuestion.type === 'currency' && (
+                    <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-lg text-gray-500 dark:text-gray-400" aria-hidden="true">$</span>
+                  )}
+                  <input
+                    id={`quiz-${currentQuestion.id}`}
+                    type="number"
+                    inputMode={currentQuestion.type === 'currency' ? 'decimal' : 'numeric'}
+                    value={currentValue ?? ''}
+                    onChange={event => setNumericAnswer(currentQuestion.id, event.target.value)}
+                    placeholder={currentQuestion.placeholder}
+                    min={currentQuestion.min}
+                    max={currentQuestion.max}
+                    aria-labelledby="quiz-question"
+                    aria-describedby={`quiz-question-help${validationMessage ? ' quiz-validation' : ''}`}
+                    aria-invalid={Boolean(validationMessage)}
+                    className={`w-full rounded-lg border bg-white py-3 pr-4 text-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-fire-500 dark:bg-gray-800 dark:text-gray-100 ${
+                      currentQuestion.type === 'currency' ? 'pl-8' : 'pl-4'
+                    } ${validationMessage ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'}`}
+                  />
+                </div>
+                {validationMessage && (
+                  <p id="quiz-validation" role="alert" className="mt-2 text-sm font-medium text-red-700 dark:text-red-300">
+                    {validationMessage}
+                  </p>
+                )}
                 <button
-                  key={choice.value}
-                  onClick={() => handleAnswer(choice.value)}
-                  className={`w-full text-left p-4 rounded-lg border-2 transition-all ${
-                    currentAnswer === choice.value
-                      ? 'border-fire-500 bg-fire-50 dark:bg-fire-900/20'
-                      : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
-                  }`}
+                  type="button"
+                  onClick={skipNumericQuestion}
+                  className="mt-3 font-medium text-gray-600 underline-offset-4 hover:underline dark:text-gray-300"
                 >
-                  <div className="font-semibold text-gray-900 dark:text-gray-100">
-                    {choice.label}
-                  </div>
-                  <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                    {choice.desc}
-                  </div>
+                  I’m not sure
                 </button>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
-      {/* Navigation */}
-      <div className="flex gap-4">
-        <button
-          onClick={handlePrevious}
-          disabled={step === 0}
-          className="px-6 py-3 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          ← Previous
-        </button>
-        <button
-          onClick={handleNext}
-          disabled={!canProceed}
-          className="flex-1 bg-fire-600 hover:bg-fire-700 text-white font-medium py-3 px-6 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {step === questions.length - 1 ? 'Get Recommendation' : 'Next →'}
-        </button>
-      </div>
-    </div>
+        <nav className="flex gap-3" aria-label="Quiz questions">
+          <button
+            type="button"
+            onClick={() => {
+              setStep(previous => Math.max(0, previous - 1))
+              setValidationMessage('')
+            }}
+            disabled={step === 0}
+            className="rounded-lg border border-gray-300 px-5 py-3 font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-40 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Previous
+          </button>
+          <button
+            type="button"
+            onClick={handleNext}
+            disabled={currentQuestion.type === 'choice' && currentValue === undefined}
+            className="flex-1 rounded-lg bg-fire-600 px-6 py-3 font-semibold text-white hover:bg-fire-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {currentQuestion.id === 'personalize' && personalize === false
+              ? 'Show my matches'
+              : step === questions.length - 1
+                ? 'Show my matches'
+                : 'Continue'}
+          </button>
+        </nav>
+        <p className="text-center text-xs text-gray-500 dark:text-gray-400">
+          Estimates only—not financial advice. Your answers stay in this browser.
+        </p>
+      </main>
     </>
   )
 }

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -63,7 +63,7 @@ export default function Home() {
             Not sure which calculator to use?
           </h2>
           <p className="text-base text-gray-600 dark:text-gray-400 mb-4">
-            Take our quick quiz to find the perfect FIRE path for your situation. 
+            Take our quick quiz to find a FIRE starting point and compare nearby alternatives.
             Answer a few questions and we'll recommend the best calculator with your information pre-filled.
           </p>
           <Link

--- a/web/src/utils/quizRecommendations.ts
+++ b/web/src/utils/quizRecommendations.ts
@@ -1,0 +1,211 @@
+export type FireLifestyle = 'minimal' | 'moderate' | 'comfortable' | 'luxury' | 'not-sure'
+export type FireWorkPreference = 'quit-completely' | 'part-time' | 'coast' | 'flexible' | 'not-sure'
+export type FireTimeline = 'within-5' | '5-10' | '10-20' | '20-plus' | 'not-sure'
+export type FirePrimaryGoal = 'retire-early' | 'financial-security' | 'maintain-lifestyle' | 'flexibility' | 'not-sure'
+
+export interface QuizAnswers {
+  lifestyle?: FireLifestyle
+  workPreference?: FireWorkPreference
+  timeline?: FireTimeline
+  primaryGoal?: FirePrimaryGoal
+  currentAge?: number
+  retirementAge?: number
+  currentSavings?: number
+  annualIncome?: number
+  annualExpenses?: number
+}
+
+export interface FireQuizMatch {
+  path: string
+  title: string
+  reason: string
+  description: string
+  benefits: string[]
+  reasonIds: string[]
+  score: number
+}
+
+export interface FireQuizRecommendation {
+  primary: FireQuizMatch
+  alternatives: FireQuizMatch[]
+  confidence: 'low' | 'medium' | 'high'
+}
+
+interface Candidate {
+  path: string
+  title: string
+  description: string
+  benefits: string[]
+  score: number
+  reasonIds: string[]
+}
+
+const tieBreakOrder = ['/standard', '/coast', '/barista', '/reverse', '/lean', '/fat']
+
+const pathDefinitions: Omit<Candidate, 'score' | 'reasonIds'>[] = [
+  {
+    path: '/standard',
+    title: 'Standard FIRE',
+    description: 'Build a complete retirement portfolio using a balanced spending and withdrawal plan.',
+    benefits: ['Plan for full financial independence', 'Balance lifestyle and timing', 'Adjust assumptions as life changes'],
+  },
+  {
+    path: '/lean',
+    title: 'Lean FIRE',
+    description: 'Reach financial independence with intentional spending and a smaller portfolio target.',
+    benefits: ['Lower the portfolio target', 'Prioritize an earlier timeline', 'Keep spending intentional'],
+  },
+  {
+    path: '/fat',
+    title: 'Fat FIRE',
+    description: 'Build a larger portfolio target to support more spending and additional financial margin.',
+    benefits: ['Maintain a higher-spending lifestyle', 'Create a larger market buffer', 'Preserve room for travel and family goals'],
+  },
+  {
+    path: '/barista',
+    title: 'Barista FIRE',
+    description: 'Blend portfolio income with part-time work to leave full-time work sooner.',
+    benefits: ['Leave full-time work earlier', 'Cover some expenses with earned income', 'Keep flexibility and social connection'],
+  },
+  {
+    path: '/coast',
+    title: 'Coast FIRE',
+    description: "Let invested savings grow toward retirement while current work covers today's expenses.",
+    benefits: ['Front-load retirement savings', 'Give compound growth more time', 'Create room for lower-stress work'],
+  },
+  {
+    path: '/reverse',
+    title: 'Reverse FIRE',
+    description: 'Work backward from a target timeline to find the savings required to reach it.',
+    benefits: ['Set a clear savings target', 'Compare timeline and contribution tradeoffs', 'Plan around a firm deadline'],
+  },
+]
+
+const reasonText: Record<string, string> = {
+  'balanced-lifestyle': 'your balanced lifestyle goal',
+  'comfortable-lifestyle': 'your preference for comfort without the highest spending target',
+  'full-retirement': 'your goal of fully leaving paid work',
+  'security-first': 'your focus on long-term financial security',
+  'balanced-timeline': 'your flexible mid-to-long-term timeline',
+  'minimal-lifestyle': 'your lower-spending lifestyle',
+  'early-priority': 'your priority to reach financial independence sooner',
+  'lower-expenses': 'the lower annual expenses you shared',
+  'luxury-lifestyle': 'your higher-spending lifestyle goal',
+  'maintain-lifestyle': 'your priority to preserve your lifestyle',
+  'higher-expenses': 'the higher annual expenses you shared',
+  'part-time-work': 'your interest in part-time work',
+  'work-flexibility': 'your desire to keep work options open',
+  'near-term-transition': 'your near-term transition goal',
+  'coast-work': 'your preference to let investments grow while work covers current expenses',
+  'long-horizon': 'your longer time horizon',
+  'deadline-focus': 'your firm, near-term timeline',
+  'retire-early': 'your goal to retire as early as practical',
+  'balanced-start': 'a balanced starting point while you refine your preferences',
+}
+
+export function recommendFirePaths(answers: QuizAnswers): FireQuizRecommendation {
+  const candidates = new Map<string, Candidate>(
+    pathDefinitions.map(definition => [
+      definition.path,
+      { ...definition, score: 0, reasonIds: [] as string[] },
+    ]),
+  )
+
+  const add = (path: string, score: number, reasonId: string) => {
+    const candidate = candidates.get(path)
+    if (!candidate) throw new Error(`Unknown FIRE path: ${path}`)
+    candidate.score += score
+    if (!candidate.reasonIds.includes(reasonId)) candidate.reasonIds.push(reasonId)
+  }
+
+  add('/standard', 1, 'balanced-start')
+
+  if (answers.lifestyle === 'minimal') add('/lean', 6, 'minimal-lifestyle')
+  if (answers.lifestyle === 'moderate') add('/standard', 4, 'balanced-lifestyle')
+  if (answers.lifestyle === 'comfortable') {
+    add('/standard', 3, 'comfortable-lifestyle')
+    add('/fat', 1, 'comfortable-lifestyle')
+  }
+  if (answers.lifestyle === 'luxury') add('/fat', 6, 'luxury-lifestyle')
+
+  if (answers.workPreference === 'quit-completely') {
+    add('/standard', 2, 'full-retirement')
+    add('/reverse', 1, 'full-retirement')
+  }
+  if (answers.workPreference === 'part-time') add('/barista', 7, 'part-time-work')
+  if (answers.workPreference === 'coast') add('/coast', 7, 'coast-work')
+  if (answers.workPreference === 'flexible') {
+    add('/barista', 2, 'work-flexibility')
+    add('/coast', 2, 'work-flexibility')
+    add('/standard', 1, 'work-flexibility')
+  }
+
+  if (answers.timeline === 'within-5') {
+    add('/reverse', 5, 'deadline-focus')
+    add('/barista', 2, 'near-term-transition')
+    add('/lean', 1, 'near-term-transition')
+  }
+  if (answers.timeline === '5-10') {
+    add('/reverse', 3, 'deadline-focus')
+    add('/barista', 1, 'near-term-transition')
+    add('/lean', 1, 'near-term-transition')
+  }
+  if (answers.timeline === '10-20') {
+    add('/standard', 2, 'balanced-timeline')
+    add('/coast', 1, 'long-horizon')
+  }
+  if (answers.timeline === '20-plus') {
+    add('/coast', 3, 'long-horizon')
+    add('/standard', 1, 'balanced-timeline')
+  }
+
+  if (answers.primaryGoal === 'retire-early') {
+    add('/reverse', 4, 'retire-early')
+    add('/lean', 2, 'early-priority')
+  }
+  if (answers.primaryGoal === 'financial-security') add('/standard', 4, 'security-first')
+  if (answers.primaryGoal === 'maintain-lifestyle') {
+    add('/fat', 2, 'maintain-lifestyle')
+    add('/standard', 2, 'maintain-lifestyle')
+  }
+  if (answers.primaryGoal === 'flexibility') {
+    add('/coast', 2, 'work-flexibility')
+    add('/barista', 2, 'work-flexibility')
+  }
+
+  if (answers.annualExpenses !== undefined && answers.annualExpenses < 40_000) {
+    add('/lean', 2, 'lower-expenses')
+  } else if (answers.annualExpenses !== undefined && answers.annualExpenses >= 100_000) {
+    add('/fat', 3, 'higher-expenses')
+  }
+
+  const ranked = [...candidates.values()]
+    .sort((a, b) => b.score - a.score || tieBreakOrder.indexOf(a.path) - tieBreakOrder.indexOf(b.path))
+    .map(candidate => {
+      const meaningfulReasons = candidate.reasonIds
+        .filter(reasonId => reasonId !== 'balanced-start' || candidate.reasonIds.length === 1)
+        .slice(0, 2)
+        .map(reasonId => reasonText[reasonId])
+      const reason = meaningfulReasons.length === 0
+        ? 'This is a useful path to compare with your leading match.'
+        : meaningfulReasons.length === 1
+          ? `This path aligns with ${meaningfulReasons[0]}.`
+          : `This path aligns with ${meaningfulReasons[0]} and ${meaningfulReasons[1]}.`
+      return { ...candidate, reason }
+    })
+
+  const knownCoreAnswers = [
+    answers.lifestyle && answers.lifestyle !== 'not-sure',
+    answers.workPreference && answers.workPreference !== 'not-sure',
+    answers.timeline && answers.timeline !== 'not-sure',
+    answers.primaryGoal && answers.primaryGoal !== 'not-sure',
+  ].filter(Boolean).length
+  const margin = ranked[0].score - ranked[1].score
+  const confidence = knownCoreAnswers >= 4 && margin >= 3
+    ? 'high'
+    : knownCoreAnswers >= 2 && margin >= 2
+      ? 'medium'
+      : 'low'
+
+  return { primary: ranked[0], alternatives: ranked.slice(1, 3), confidence }
+}


### PR DESCRIPTION
The quiz previously forced exact financial answers, returned one order-dependent result, and duplicated inputs already captured during mobile onboarding. This change makes it a lower-pressure starting-point guide that reflects a user's timeline and preferences while keeping Standard FIRE a first-class recommendation.

## What changed

- Rank Standard, Lean, Fat, Coast, Barista, and Reverse FIRE with transparent weighted signals and deterministic tie-breaking.
- Present one primary starting point plus two alternatives, with concise reasons and tradeoffs.
- Add `Not sure yet` choices and make the FI timeline a primary recommendation input.
- Simplify the mobile quiz to four preference questions and reuse saved calculator defaults when opening a recommendation.
- Improve choice alignment, semantics, responsive web behavior, dark mode, reduced motion, and onboarding/SEO copy.
- Add recommendation coverage proving every FIRE path can rank first, including unknown-answer and tie cases.

## Validation

- 87 .NET tests pass.
- Web production build passes.
- iOS and Mac Catalyst builds pass.
- Updated non-DevFlow iOS app launches successfully on the iPhone 17 Pro simulator.