### PR TITLE
Fix debt payoff calculator double-charging interest every month

### DIFF
--- a/app/MyFireNumber.Core/Calculations/FinancialCalculator.cs
+++ b/app/MyFireNumber.Core/Calculations/FinancialCalculator.cs
@@ -326,6 +326,16 @@ public static class FinancialCalculator
             Round(CalculateHealthcareSubsidy(75_000, annualCost)));
     }
 
+    /// <summary>
+    /// Core debt payoff calculation logic.
+    /// </summary>
+    /// <remarks>
+    /// Each month interest accrues exactly once per debt before any payment is applied, then the
+    /// available budget pays minimums in priority order and any remainder goes to the highest
+    /// priority debt as pure principal. Payments never exceed the available budget, so a budget
+    /// that cannot cover the minimums results in growing balances instead of silent overpayment.
+    /// This mirrors <c>calculateDebtPayoff</c> in the web app's <c>calculations.ts</c>.
+    /// </remarks>
     private static DebtPayoffResult CalculateDebtPayoff(IEnumerable<DebtItem> debts, double totalMonthlyPayment, double extraPayment)
     {
         var remainingDebts = debts.Select(debt => new MutableDebt(debt)).ToList();
@@ -341,32 +351,50 @@ public static class FinancialCalculator
         {
             month++;
             var monthlyBudget = totalMonthlyPayment + extraPayment;
-            var monthPrincipal = 0d;
+            var monthPayments = 0d;
             var monthInterest = 0d;
             var paidOffThisMonth = new List<string>();
 
-            foreach (var debt in remainingDebts.Where(debt => debt.CurrentBalance > 0))
+            // 1. Accrue interest exactly once per debt, before any payment is applied.
+            foreach (var debt in remainingDebts)
             {
+                if (debt.CurrentBalance <= 0)
+                {
+                    continue;
+                }
+
                 var interestCharge = debt.CurrentBalance * (debt.Rate / 12);
-                var minimumPayment = Math.Min(debt.MinimumPayment, debt.CurrentBalance + interestCharge);
-                var principalPayment = Math.Max(0, minimumPayment - interestCharge);
-                debt.CurrentBalance -= principalPayment;
-                monthlyBudget -= minimumPayment;
-                monthPrincipal += principalPayment;
+                debt.CurrentBalance += interestCharge;
                 monthInterest += interestCharge;
+            }
+
+            // 2. Pay minimums in priority order, never spending more than the available budget.
+            foreach (var debt in remainingDebts)
+            {
+                if (debt.CurrentBalance <= 0 || monthlyBudget <= 0)
+                {
+                    continue;
+                }
+
+                var payment = Math.Min(debt.MinimumPayment, Math.Min(debt.CurrentBalance, monthlyBudget));
+                debt.CurrentBalance -= payment;
+                monthlyBudget -= payment;
+                monthPayments += payment;
                 MarkPaidOff(debt, month, paidOffThisMonth, payoffOrder, debtMilestones);
             }
 
-            if (monthlyBudget > 0 && remainingDebts.FirstOrDefault(debt => debt.CurrentBalance > 0) is { } targetDebt)
+            // 3. Apply any remaining budget to the highest priority debt as pure principal.
+            while (monthlyBudget > 0 && remainingDebts.FirstOrDefault(debt => debt.CurrentBalance > 0) is { } targetDebt)
             {
-                var additionalInterest = targetDebt.CurrentBalance * (targetDebt.Rate / 12);
-                var actualPayment = Math.Min(monthlyBudget, targetDebt.CurrentBalance + additionalInterest);
-                var additionalPrincipal = Math.Max(0, actualPayment - additionalInterest);
-                targetDebt.CurrentBalance -= additionalPrincipal;
-                monthPrincipal += additionalPrincipal;
-                monthInterest += additionalInterest;
+                var payment = Math.Min(monthlyBudget, targetDebt.CurrentBalance);
+                targetDebt.CurrentBalance -= payment;
+                monthlyBudget -= payment;
+                monthPayments += payment;
                 MarkPaidOff(targetDebt, month, paidOffThisMonth, payoffOrder, debtMilestones);
             }
+
+            // Balances already include this month's interest, so principal is what is left of the payments.
+            var monthPrincipal = monthPayments - monthInterest;
 
             cumulativePrincipal += monthPrincipal;
             cumulativeInterest += monthInterest;

--- a/app/MyFireNumber.Tests/Calculations/FinancialCalculatorTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/FinancialCalculatorTests.cs
@@ -205,6 +205,89 @@ public class FinancialCalculatorTests
     }
 
     [Fact]
+    public void SnowballPayoff_WithInterest_ChargesInterestOncePerMonth()
+    {
+        var debt = new DebtItem("card", "Credit card", 10_000, 0.20, 250);
+
+        var result = FinancialCalculator.CalculateSnowballPayoff([debt], 500);
+
+        Assert.Equal(25, result.TotalMonths);
+        Assert.Equal(2_266, result.TotalInterest);
+        Assert.Equal(10_000, result.TotalPrincipal);
+
+        // $10,000 at 20% APR accrues $166.67 in month one, not $333.33.
+        var firstMonth = result.Projections[0];
+        Assert.Equal(167, firstMonth.InterestPaid);
+        Assert.Equal(333, firstMonth.PrincipalPaid);
+        Assert.Equal(9_667, firstMonth.TotalBalance);
+
+        Assert.Equal(0, result.Projections[^1].TotalBalance);
+        Assert.Equal(10_000, result.Projections[^1].CumulativePrincipal);
+    }
+
+    [Fact]
+    public void AvalanchePayoff_NeverCostsMoreInterestThanSnowball()
+    {
+        DebtItem[] debts =
+        [
+            new("small", "Small balance", 2_000, 0.06, 50),
+            new("big", "High rate", 8_000, 0.22, 200)
+        ];
+
+        var snowball = FinancialCalculator.CalculateSnowballPayoff(debts, 600);
+        var avalanche = FinancialCalculator.CalculateAvalanchePayoff(debts, 600);
+
+        Assert.True(
+            avalanche.TotalInterest <= snowball.TotalInterest,
+            $"Avalanche interest {avalanche.TotalInterest} should not exceed snowball interest {snowball.TotalInterest}.");
+
+        Assert.Equal(20, snowball.TotalMonths);
+        Assert.Equal(1_930, snowball.TotalInterest);
+        Assert.Equal(["Small balance", "High rate"], snowball.PayoffOrder);
+
+        Assert.Equal(20, avalanche.TotalMonths);
+        Assert.Equal(1_543, avalanche.TotalInterest);
+        Assert.Equal(["High rate", "Small balance"], avalanche.PayoffOrder);
+    }
+
+    [Fact]
+    public void DebtPayoff_WithBudgetBelowMinimums_DoesNotSpendMoreThanBudget()
+    {
+        DebtItem[] debts =
+        [
+            new("small", "Small balance", 2_000, 0.06, 50),
+            new("big", "High rate", 8_000, 0.22, 200)
+        ];
+
+        var result = FinancialCalculator.CalculateSnowballPayoff(debts, 100);
+
+        foreach (var month in result.Projections)
+        {
+            Assert.True(
+                month.PrincipalPaid + month.InterestPaid <= 100,
+                $"Month {month.Month} spent {month.PrincipalPaid + month.InterestPaid} against a $100 budget.");
+        }
+
+        // A budget that cannot cover minimums never retires the debt instead of silently overpaying.
+        Assert.Equal(600, result.TotalMonths);
+        Assert.DoesNotContain("High rate", result.PayoffOrder);
+        Assert.True(result.Projections[^1].TotalBalance > 8_000);
+    }
+
+    [Fact]
+    public void DebtTimeline_UsesCorrectedInterestWhenSolvingForPayment()
+    {
+        var debt = new DebtItem("card", "Credit card", 10_000, 0.20, 250);
+
+        var timeline = FinancialCalculator.CalculateDebtPayoffByTimeline([debt], 24, useSnowball: true);
+
+        Assert.NotNull(timeline);
+        Assert.Equal(509, timeline.RequiredPayment);
+        Assert.True(timeline.Result.TotalMonths <= 24);
+        Assert.Equal(2_212, timeline.Result.TotalInterest);
+    }
+
+    [Fact]
     public void ReverseFire_MatchesWebDefaultRequirement()
     {
         var result = FinancialCalculator.CalculateReverseFire(DefaultInputs);

--- a/web/src/utils/calculations.ts
+++ b/web/src/utils/calculations.ts
@@ -659,7 +659,12 @@ export function calculateAvalanchePayoff(
 }
 
 /**
- * Core debt payoff calculation logic
+ * Core debt payoff calculation logic.
+ *
+ * Each month interest accrues exactly once per debt before any payment is applied, then the
+ * available budget pays minimums in priority order and any remainder goes to the highest
+ * priority debt as pure principal. Payments never exceed the available budget, so a budget
+ * that cannot cover the minimums results in growing balances instead of silent overpayment.
  */
 function calculateDebtPayoff(
   sortedDebts: DebtItem[],
@@ -684,56 +689,53 @@ function calculateDebtPayoff(
     month++
     
     let monthlyBudget = availablePayment
-    let monthPrincipal = 0
+    let monthPayments = 0
     let monthInterest = 0
     const paidOffThisMonth: string[] = []
     
-    // First, pay minimum payments on all debts
+    const markPaidOff = (debt: { name: string; currentBalance: number }) => {
+      if (debt.currentBalance > 0) return
+      debt.currentBalance = 0
+      if (paidOffThisMonth.includes(debt.name)) return
+      paidOffThisMonth.push(debt.name)
+      payoffOrder.push(debt.name)
+      debtMilestones.push({ month, debtName: debt.name })
+    }
+    
+    // 1. Accrue interest exactly once per debt, before any payment is applied
     for (const debt of remainingDebts) {
       if (debt.currentBalance <= 0) continue
       
-      const monthlyRate = debt.rate / 12
-      const interestCharge = debt.currentBalance * monthlyRate
-      const minPaymentNeeded = Math.min(debt.minPayment, debt.currentBalance + interestCharge)
-      const principalPayment = Math.max(0, minPaymentNeeded - interestCharge)
-      
-      debt.currentBalance -= principalPayment
-      monthlyBudget -= minPaymentNeeded
-      monthPrincipal += principalPayment
+      const interestCharge = debt.currentBalance * (debt.rate / 12)
+      debt.currentBalance += interestCharge
       monthInterest += interestCharge
-      
-      if (debt.currentBalance <= 0) {
-        debt.currentBalance = 0
-        paidOffThisMonth.push(debt.name)
-        payoffOrder.push(debt.name)
-        debtMilestones.push({ month, debtName: debt.name })
-      }
     }
     
-    // Apply remaining budget to highest priority debt
-    if (monthlyBudget > 0) {
-      const targetDebt = remainingDebts.find(d => d.currentBalance > 0)
-      if (targetDebt) {
-        const monthlyRate = targetDebt.rate / 12
-        const additionalInterest = targetDebt.currentBalance * monthlyRate
-        const maxPayment = targetDebt.currentBalance + additionalInterest
-        const actualPayment = Math.min(monthlyBudget, maxPayment)
-        const additionalPrincipal = Math.max(0, actualPayment - additionalInterest)
-        
-        targetDebt.currentBalance -= additionalPrincipal
-        monthPrincipal += additionalPrincipal
-        monthInterest += additionalInterest
-        
-        if (targetDebt.currentBalance <= 0) {
-          targetDebt.currentBalance = 0
-          if (!paidOffThisMonth.includes(targetDebt.name)) {
-            paidOffThisMonth.push(targetDebt.name)
-            payoffOrder.push(targetDebt.name)
-            debtMilestones.push({ month, debtName: targetDebt.name })
-          }
-        }
-      }
+    // 2. Pay minimums in priority order, never spending more than the available budget
+    for (const debt of remainingDebts) {
+      if (debt.currentBalance <= 0 || monthlyBudget <= 0) continue
+      
+      const payment = Math.min(debt.minPayment, debt.currentBalance, monthlyBudget)
+      debt.currentBalance -= payment
+      monthlyBudget -= payment
+      monthPayments += payment
+      markPaidOff(debt)
     }
+    
+    // 3. Apply any remaining budget to the highest priority debt as pure principal
+    while (monthlyBudget > 0) {
+      const targetDebt = remainingDebts.find(d => d.currentBalance > 0)
+      if (!targetDebt) break
+      
+      const payment = Math.min(monthlyBudget, targetDebt.currentBalance)
+      targetDebt.currentBalance -= payment
+      monthlyBudget -= payment
+      monthPayments += payment
+      markPaidOff(targetDebt)
+    }
+    
+    // Balances already include this month's interest, so principal is what is left of the payments
+    const monthPrincipal = monthPayments - monthInterest
     
     cumulativePrincipal += monthPrincipal
     cumulativeInterest += monthInterest


### PR DESCRIPTION
Fixes #45

## Problem

The core debt payoff loop charged interest on the priority debt **twice in the same month** — once in the minimum-payment pass, then again in the extra-budget pass. Present identically in `calculateDebtPayoff()` (web) and `CalculateDebtPayoff()` (MAUI).

This inflated total interest, extended payoff timelines, and **inverted the snowball vs. avalanche recommendation**, so the "Method comparison" panel was giving actively wrong financial guidance.

## Fix

Restructured the monthly loop in both implementations so each month:

1. Interest accrues **exactly once** per debt, before any payment is applied.
2. Minimum payments are applied in priority order, capped by the available budget.
3. Any remaining budget goes to the highest priority debt as **pure principal** — no second interest charge.

Per-month `principalPaid` is now derived as `payments - interest`, so `cumulativePrincipal` reconciles exactly to `totalPrincipal`.

### Also in scope

- **Budget below minimums is handled explicitly.** Payments are capped at the available budget instead of silently paying every minimum regardless. See the note below on how to read that result.
- **Leftover budget cascades.** If the extra payment retires the priority debt mid-month, the remainder now rolls to the next debt instead of being discarded. This was a second, separate bug not described in #45.
- **Timeline solvers verified.** `calculateDebtPayoffByTimeline` / `CalculateDebtPayoffByTimeline` binary-search on the core loop, so their inflated required-payment estimates are corrected by this change (test added). No bound changes were needed: the per-debt payment is capped at the *balance*, so debts smaller than their own minimum payment still clear in one month.

> [!IMPORTANT]
> **How to read a 600-month result.** Because payments are now capped at the available budget, a budget that cannot cover the sum of minimum payments **negatively amortizes** — balances grow every month and the simulation runs out to the 600-month (50 year) safety cap. A `totalMonths` of 600 therefore means *"this budget never pays the debt off"*, *not* a real 50-year payoff schedule. Callers should treat 600 as a sentinel, not a projection, and should not render its `projections` array as a payoff plan.
>
> This path is defensive only: the web page blocks it via `canCalculate` in `DebtPayoff.tsx` and the MAUI `DebtPayoffViewModel` rejects it in both `TryCalculate` and `ShareAsync`. It is reachable only by calling the calculation functions directly. The previous behavior was worse — it silently paid every minimum regardless of budget and reported a payoff the user could not actually afford.

## Before / after

Single debt: $10,000 balance, 20% APR, $250 minimum, $500/mo budget.

| | Months | Total interest | Month-1 interest |
|---|---|---|---|
| Before | 34 | $6,617 | $333.33 |
| After | **25** | **$2,266** | **$166.67** |

Two debts — Small: $2,000 @ 6%, $50 min · Big: $8,000 @ 22%, $200 min · $600/mo budget.

| | Snowball | Avalanche |
|---|---|---|
| Before | 24 mo / $3,740 | 23 mo / $3,763 ❌ *higher than snowball* |
| After | **20 mo / $1,930** | **20 mo / $1,543** ✅ |

Timeline mode, $10,000 @ 20% APR, 24-month target: required payment is now **$509/mo** (24 months, $2,212 interest).

## Cross-platform parity

Compiled `web/src/utils/calculations.ts` and ran the same scenarios against it; the web output matches the MAUI test expectations digit for digit — 25/$2,266, month-1 $167/$333/$9,667, snowball 20/$1,930, avalanche 20/$1,543, timeline $509, and the underfunded case capping spend at exactly $100/mo. The pre-existing 0%-rate case still returns 2 months / $0.

## Tests

`FinancialCalculatorTests.cs:185` (`SnowballPayoff_AppliesMinimumThenRemainingBudget`) used a 0% rate, which is exactly why this bug survived. Added nonzero-rate coverage:

- `SnowballPayoff_WithInterest_ChargesInterestOncePerMonth` — asserts 25 months, $2,266 interest, and month-1 interest of $167 on $10,000 @ 20% APR.
- `AvalanchePayoff_NeverCostsMoreInterestThanSnowball` — asserts avalanche interest ≤ snowball interest at a fixed budget, plus exact months/interest/payoff order for both.
- `DebtPayoff_WithBudgetBelowMinimums_DoesNotSpendMoreThanBudget` — asserts no month spends more than the budget, and that the high-rate debt is never retired (600-month sentinel).
- `DebtTimeline_UsesCorrectedInterestWhenSolvingForPayment` — asserts the corrected $509 required payment.

## Validation

- `dotnet test app/MyFireNumber.Tests/MyFireNumber.Tests.csproj` → **96 passed, 0 failed**
- `cd web && npm run build` → succeeds (tsc + vite)

No API surface changes, so the Excel exports, charts, and view models are untouched. Deliberately did **not** add a `budgetCoversMinimums` flag to `DebtPayoffResult`: `prepareResultsForExport` (`excelExport.ts:370-377`) skips only arrays and objects, so a scalar boolean would flow into `values[key]` and add a junk row to every debt payoff Excel export.
