### PR TITLE
Add web test coverage and shared cross-platform parity fixtures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,79 @@
+name: Tests
+
+# The web app had no test runner at all, and `dotnet test` only ran on push to main inside the
+# Android packaging workflow — so nothing verified either engine on a pull request. This runs both
+# suites on every PR.
+#
+# Both jobs also trigger on changes to shared/parity/**, because that fixture is the artifact
+# pinning the two implementations together: editing it must re-run both sides, not just one.
+
+on:
+  pull_request:
+    paths:
+      - 'web/**'
+      - 'app/**'
+      - 'shared/parity/**'
+      - 'MyFireNumber.slnx'
+      - '.github/workflows/tests.yml'
+  push:
+    branches: ['main']
+    paths:
+      - 'web/**'
+      - 'app/**'
+      - 'shared/parity/**'
+      - 'MyFireNumber.slnx'
+      - '.github/workflows/tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  web:
+    name: Web (Vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Test
+        run: npm test
+        working-directory: web
+
+      # The tests live under src/, so `tsc` type-checks them as part of the build. That is what makes
+      # a wrong call signature a build failure rather than a confidently wrong assertion.
+      - name: Build
+        run: npm run build
+        working-directory: web
+
+  core:
+    name: Core (xUnit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # MyFireNumber.Core, .Storage and .Tests all target plain net10.0, so the shared calculation
+      # suite runs on Linux without the MAUI workload or a macOS runner.
+      - name: Test
+        run: dotnet test app/MyFireNumber.Tests/MyFireNumber.Tests.csproj --configuration Release

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.tsbuildinfo
 
 # Editor directories and files
 .vscode/*

--- a/app/MyFireNumber.Tests/Calculations/SharedParityFixtureTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/SharedParityFixtureTests.cs
@@ -1,0 +1,488 @@
+using System.Text.Json;
+
+using MyFireNumber.Core.Calculations;
+
+namespace MyFireNumber.Tests.Calculations;
+
+/// <summary>
+/// Drives <see cref="FinancialCalculator"/> from <c>shared/parity/fire-parity-cases.json</c>, the same
+/// file the web suite reads.
+///
+/// <para><b>Why this exists.</b> Both platforms previously asserted against constants that had each
+/// been copied from the other at some point in the past. That pins nothing: if one side drifts, its
+/// own tests drift with it and stay green. This file and the Vitest suite read one artifact, so a
+/// change on either platform that is not matched by the other turns a test red on that platform.</para>
+///
+/// <para><b>Where the numbers came from.</b> Not from this C# code, and not from running the shipped
+/// TypeScript and pasting the output either. Every case carries a <c>derivation</c> field stating the
+/// closed form or recurrence it was computed from, and the web suite's <c>fixtureSelfCheck.test.ts</c>
+/// re-derives the algebraically checkable ones from independently written oracles. If a fixture value
+/// is ever regenerated from an implementation, that self-check is what catches it.</para>
+///
+/// <para><b>Do not "fix" a failure here by editing the fixture.</b> A red test means the two
+/// implementations disagree, or one of them disagrees with the algebra. Find out which before
+/// touching a number.</para>
+///
+/// <para>Argument order deliberately does not travel in the fixture: the web engine takes eight
+/// positional arguments for Coast FIRE while this side takes a single <see cref="FireInputs"/>
+/// record. Inputs are named semantically and each platform adapts them locally, so a positional
+/// mismatch cannot silently produce a plausible-looking wrong answer.</para>
+/// </summary>
+public class SharedParityFixtureTests
+{
+    /// <summary>
+    /// Rounded currency and count fields are compared exactly; both platforms round them the same way,
+    /// so any difference at all is drift.
+    /// </summary>
+    private const double ExactTolerance = 0.0;
+
+    /// <summary>
+    /// Unrounded ratios carry double accumulation from two different runtimes. 1e-9 is far tighter
+    /// than any real formula difference and far looser than IEEE noise over these magnitudes.
+    /// </summary>
+    private const double RatioTolerance = 1e-9;
+
+    /// <summary>
+    /// Unrounded currency accumulates over as many as 60 compounding steps on values above $1M, so the
+    /// absolute error budget scales with the magnitude rather than being a flat epsilon.
+    /// </summary>
+    private const double CurrencyTolerance = 1e-6;
+
+    private static readonly IReadOnlyList<ParityCase> Cases = LoadCases();
+
+    public static TheoryData<string> FireCaseIds => IdsOfKind("fire");
+
+    public static TheoryData<string> DebtCaseIds => IdsOfKind("debt");
+
+    public static TheoryData<string> WithdrawalCaseIds => IdsOfKind("withdrawal");
+
+    public static TheoryData<string> InvestmentCaseIds => IdsOfKind("investment");
+
+    public static TheoryData<string> HealthcareCaseIds => IdsOfKind("healthcare");
+
+    [Fact]
+    public void FixtureLoads_AndEveryCaseDocumentsItsDerivation()
+    {
+        Assert.NotEmpty(Cases);
+
+        foreach (var parityCase in Cases)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(parityCase.Id));
+            Assert.False(string.IsNullOrWhiteSpace(parityCase.Kind));
+
+            // A case without a stated derivation is a screenshot of whatever the code did that day.
+            // The review surface for this fixture is that every number can be traced to an argument.
+            Assert.False(
+                string.IsNullOrWhiteSpace(parityCase.Derivation),
+                $"Case '{parityCase.Id}' has no derivation. Every fixture value must state how it was obtained.");
+        }
+
+        Assert.Equal(Cases.Select(c => c.Id).Distinct().Count(), Cases.Count);
+    }
+
+    [Theory]
+    [MemberData(nameof(FireCaseIds))]
+    public void StandardFire_MatchesSharedFixture(string caseId)
+    {
+        var parityCase = Case(caseId);
+        var inputs = ToFireInputs(parityCase.Inputs);
+        var expected = parityCase.Expected;
+
+        var result = FinancialCalculator.CalculateStandardFire(inputs);
+
+        Assert.Equal(Number(expected, "fireNumber"), result.FireNumber, ExactTolerance);
+        Assert.Equal(Number(expected, "yearsToFire"), result.YearsToFire, ExactTolerance);
+        Assert.Equal(Number(expected, "fireAge"), result.FireAge, ExactTolerance);
+        Assert.Equal(Number(expected, "coastFireNumber"), result.CoastFireNumber, ExactTolerance);
+        Assert.Equal(Number(expected, "savingsRate"), result.SavingsRate, RatioTolerance);
+        Assert.Equal(Number(expected, "monthlyContribution"), result.MonthlyContribution, CurrencyTolerance);
+        Assert.Equal((int)Number(expected, "projectionCount"), result.Projections.Count);
+
+        foreach (var sample in expected.GetProperty("projectionSamples").EnumerateArray())
+        {
+            var index = sample.GetProperty("year").GetInt32();
+            var point = result.Projections[index];
+
+            Assert.Equal(sample.GetProperty("age").GetDouble(), point.Age, ExactTolerance);
+            Assert.Equal(sample.GetProperty("portfolio").GetDouble(), point.Portfolio, ExactTolerance);
+            Assert.Equal(sample.GetProperty("inflationAdjusted").GetDouble(), point.InflationAdjusted, ExactTolerance);
+            Assert.Equal(sample.GetProperty("totalContributions").GetDouble(), point.TotalContributions, ExactTolerance);
+            Assert.Equal(sample.GetProperty("contributions").GetDouble(), point.Contributions, CurrencyTolerance);
+        }
+    }
+
+    /// <summary>
+    /// Issue #46 was the headline FIRE age and the projection chart disagreeing: the number on the card
+    /// said one year and the line crossed the target in another. The two are computed by different code
+    /// paths, so this asserts the relationship between them rather than either one's value.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(FireCaseIds))]
+    public void HeadlineFireAge_MatchesWhereTheProjectionCrossesTheTarget(string caseId)
+    {
+        var parityCase = Case(caseId);
+        var result = FinancialCalculator.CalculateStandardFire(ToFireInputs(parityCase.Inputs));
+
+        if (double.IsInfinity(result.YearsToFire))
+        {
+            // Unreachable is a legitimate answer, and it means no crossing exists to compare against.
+            // What must hold is that the projection genuinely never gets there.
+            Assert.All(result.Projections, point => Assert.True(point.InflationAdjusted < result.FireNumber));
+            return;
+        }
+
+        var years = result.YearsToFire;
+
+        if (years <= 0)
+        {
+            Assert.True(result.Projections[0].InflationAdjusted >= result.FireNumber);
+            return;
+        }
+
+        var before = (int)Math.Floor(years);
+        var after = (int)Math.Ceiling(years);
+
+        if (after >= result.Projections.Count)
+        {
+            // fire-degenerate-zero-real-return reaches its target in year 60, but the projection series
+            // is capped at 50 points, so the crossing is off the end of the chart and cannot be
+            // observed here. Documented in that case's derivation.
+            return;
+        }
+
+        Assert.True(
+            result.Projections[before].InflationAdjusted < result.FireNumber,
+            $"Case '{caseId}': projection at year {before} already met the target, so the headline age is late.");
+
+        if (before != after)
+        {
+            Assert.True(
+                result.Projections[after].InflationAdjusted >= result.FireNumber,
+                $"Case '{caseId}': projection at year {after} had not met the target, so the headline age is early.");
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(FireCaseIds))]
+    public void ReverseFire_MatchesSharedFixture(string caseId)
+    {
+        var parityCase = Case(caseId);
+        var expected = parityCase.Expected.GetProperty("reverse");
+
+        var result = FinancialCalculator.CalculateReverseFire(ToFireInputs(parityCase.Inputs));
+
+        Assert.Equal(Number(expected, "requiredAnnualSavings"), result.RequiredAnnualSavings, CurrencyTolerance);
+        Assert.Equal(Number(expected, "requiredMonthlySavings"), result.RequiredMonthlySavings, CurrencyTolerance);
+        Assert.Equal(Number(expected, "currentWillGrowTo"), result.CurrentWillGrowTo, ExactTolerance);
+        Assert.Equal(expected.GetProperty("alreadyAchievable").GetBoolean(), result.AlreadyAchievable);
+    }
+
+    [Theory]
+    [MemberData(nameof(DebtCaseIds))]
+    public void DebtPayoff_MatchesSharedFixture(string caseId)
+    {
+        var parityCase = Case(caseId);
+        var inputs = parityCase.Inputs;
+        var expected = parityCase.Expected;
+
+        var debts = inputs.GetProperty("debts").EnumerateArray()
+            .Select(d => new DebtItem(
+                d.GetProperty("id").GetString()!,
+                d.GetProperty("name").GetString()!,
+                d.GetProperty("balance").GetDouble(),
+                d.GetProperty("rate").GetDouble(),
+                d.GetProperty("minPayment").GetDouble()))
+            .ToList();
+
+        var monthlyPayment = inputs.GetProperty("monthlyPayment").GetDouble();
+        var extraPayment = inputs.GetProperty("extraPayment").GetDouble();
+        var strategy = inputs.GetProperty("strategy").GetString();
+
+        var result = strategy == "avalanche"
+            ? FinancialCalculator.CalculateAvalanchePayoff(debts, monthlyPayment, extraPayment)
+            : FinancialCalculator.CalculateSnowballPayoff(debts, monthlyPayment, extraPayment);
+
+        Assert.Equal((int)Number(expected, "totalMonths"), result.TotalMonths);
+        Assert.Equal(Number(expected, "totalInterest"), result.TotalInterest, ExactTolerance);
+        Assert.Equal(Number(expected, "totalPrincipal"), result.TotalPrincipal, ExactTolerance);
+        Assert.Equal(Number(expected, "monthlyPayment"), result.MonthlyPayment, CurrencyTolerance);
+
+        Assert.Equal(
+            expected.GetProperty("payoffOrder").EnumerateArray().Select(e => e.GetString()).ToArray(),
+            result.PayoffOrder.ToArray());
+
+        // Month one must be charged interest exactly once. Charging it twice is what made a 25 month
+        // payoff report as 34 months before #45, and a rounded total is too coarse to catch that.
+        //
+        // The fixture stores the exact arithmetic value (10000 * 0.20/12 = 166.666...), while both
+        // implementations round the per-month projection field to whole dollars. Comparing through the
+        // same rounding keeps this a parity assertion rather than a rounding assertion; the doubled
+        // charge it guards against would read 333, which this still catches. The unrounded arithmetic
+        // is pinned exactly in FirstMonthInterest_IsChargedExactlyOnce below.
+        var expectedFirstMonthInterest = Number(expected, "firstMonthInterest");
+        Assert.Equal(Math.Round(expectedFirstMonthInterest), result.Projections[0].InterestPaid, ExactTolerance);
+
+        // Exact invariant: you repay precisely what you borrowed, no more and no less. Independent of
+        // strategy, budget and rate, so it holds for every case without a fixture number.
+        Assert.Equal(debts.Sum(d => d.Balance), result.TotalPrincipal, ExactTolerance);
+
+        // The per-month projection fields are each rounded to whole dollars, so their sum can differ
+        // from the reported total by up to half a dollar per month plus half a dollar for the total's
+        // own rounding. That derived bound is the correct tolerance here — a genuine accounting error
+        // would be off by far more than a rounding budget.
+        var roundingBudget = 0.5 * (result.TotalMonths + 1);
+        Assert.Equal(result.TotalInterest, result.Projections.Sum(p => p.InterestPaid), roundingBudget);
+        Assert.Equal(result.TotalPrincipal, result.Projections.Sum(p => p.PrincipalPaid), roundingBudget);
+    }
+
+    /// <summary>
+    /// Pins the month-one interest to exact arithmetic with no rounding in the way. A $12,000 balance
+    /// at 20% APR owes exactly 12,000 * 0.20/12 = $200 in its first month, which is a whole number, so
+    /// the projection's rounding cannot hide a discrepancy. Charging interest twice — the #45 bug —
+    /// would read $400 here.
+    /// </summary>
+    [Fact]
+    public void FirstMonthInterest_IsChargedExactlyOnce()
+    {
+        var debts = new[] { new DebtItem("card", "Card", 12_000, 0.20, 500) };
+
+        var result = FinancialCalculator.CalculateSnowballPayoff(debts, 500);
+
+        Assert.Equal(200.0, result.Projections[0].InterestPaid, ExactTolerance);
+    }
+
+    /// <summary>
+    /// Avalanche targets the highest rate first, so it can never pay more total interest than snowball
+    /// on the same debts and budget. The pre-#45 implementation inverted this, so it is asserted as a
+    /// relationship rather than as two golden totals that could both drift together.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DebtCaseIds))]
+    public void Avalanche_NeverCostsMoreInterestThanSnowball(string caseId)
+    {
+        var inputs = Case(caseId).Inputs;
+
+        var debts = inputs.GetProperty("debts").EnumerateArray()
+            .Select(d => new DebtItem(
+                d.GetProperty("id").GetString()!,
+                d.GetProperty("name").GetString()!,
+                d.GetProperty("balance").GetDouble(),
+                d.GetProperty("rate").GetDouble(),
+                d.GetProperty("minPayment").GetDouble()))
+            .ToList();
+
+        var monthlyPayment = inputs.GetProperty("monthlyPayment").GetDouble();
+        var extraPayment = inputs.GetProperty("extraPayment").GetDouble();
+
+        var avalanche = FinancialCalculator.CalculateAvalanchePayoff(debts, monthlyPayment, extraPayment);
+        var snowball = FinancialCalculator.CalculateSnowballPayoff(debts, monthlyPayment, extraPayment);
+
+        Assert.True(
+            avalanche.TotalInterest <= snowball.TotalInterest,
+            $"Case '{caseId}': avalanche paid {avalanche.TotalInterest} interest against snowball's {snowball.TotalInterest}.");
+        Assert.True(avalanche.TotalMonths <= snowball.TotalMonths);
+    }
+
+    [Theory]
+    [MemberData(nameof(WithdrawalCaseIds))]
+    public void Withdrawal_MatchesSharedFixture(string caseId)
+    {
+        var parityCase = Case(caseId);
+        var inputs = parityCase.Inputs;
+        var expected = parityCase.Expected;
+
+        var result = FinancialCalculator.CalculateWithdrawal(
+            inputs.GetProperty("portfolioValue").GetDouble(),
+            inputs.GetProperty("withdrawalRate").GetDouble(),
+            inputs.GetProperty("expectedReturn").GetDouble(),
+            inputs.GetProperty("inflationRate").GetDouble(),
+            inputs.GetProperty("retirementYears").GetInt32());
+
+        Assert.Equal(Number(expected, "annualWithdrawal"), result.AnnualWithdrawal, CurrencyTolerance);
+        Assert.Equal(Number(expected, "monthlyWithdrawal"), result.MonthlyWithdrawal, ExactTolerance);
+        Assert.Equal(Number(expected, "portfolioLongevity"), result.PortfolioLongevity, ExactTolerance);
+        Assert.Equal(Number(expected, "horizonFundedRatio"), result.HorizonFundedRatio, RatioTolerance);
+        Assert.Equal(Number(expected, "endingBalance"), result.EndingBalance, ExactTolerance);
+
+        var expectedRows = expected.GetProperty("rateAnalysis").EnumerateArray().ToList();
+        Assert.Equal(expectedRows.Count, result.RateAnalysis.Count);
+
+        for (var i = 0; i < expectedRows.Count; i++)
+        {
+            Assert.Equal(expectedRows[i].GetProperty("rate").GetDouble(), result.RateAnalysis[i].Rate, RatioTolerance);
+            Assert.Equal(expectedRows[i].GetProperty("years").GetDouble(), result.RateAnalysis[i].Years, ExactTolerance);
+            Assert.Equal(expectedRows[i].GetProperty("endBalance").GetDouble(), result.RateAnalysis[i].EndBalance, ExactTolerance);
+        }
+
+        // Drawing more can never make a portfolio last longer. Holds regardless of the fixture values.
+        for (var i = 1; i < result.RateAnalysis.Count; i++)
+        {
+            Assert.True(result.RateAnalysis[i].Rate > result.RateAnalysis[i - 1].Rate);
+            Assert.True(result.RateAnalysis[i].Years <= result.RateAnalysis[i - 1].Years);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(InvestmentCaseIds))]
+    public void InvestmentGrowth_MatchesSharedFixture(string caseId)
+    {
+        var parityCase = Case(caseId);
+        var inputs = parityCase.Inputs;
+        var expected = parityCase.Expected;
+
+        var result = FinancialCalculator.CalculateInvestmentGrowth(new InvestmentGrowthInputs(
+            StartingAmount: inputs.GetProperty("startingAmount").GetDouble(),
+            ContributionAmount: inputs.GetProperty("contributionAmount").GetDouble(),
+            ContributionFrequency: inputs.GetProperty("contributionFrequency").GetString() switch
+            {
+                "monthly" => ContributionFrequency.Monthly,
+                "yearly" => ContributionFrequency.Yearly,
+                var other => throw new FormatException($"Unrecognised contributionFrequency '{other}'."),
+            },
+            YearsInvesting: inputs.GetProperty("yearsInvesting").GetInt32(),
+            ExpectedReturn: inputs.GetProperty("expectedReturn").GetDouble(),
+            InflationRate: inputs.GetProperty("inflationRate").GetDouble(),
+            AnnualIncome: inputs.GetProperty("annualIncome").GetDouble(),
+            CurrentAge: inputs.GetProperty("currentAge").GetDouble(),
+            ContributionGrowth: ToContributionGrowth(inputs)));
+
+        Assert.Equal(Number(expected, "annualContribution"), result.AnnualContribution, CurrencyTolerance);
+        Assert.Equal(Number(expected, "monthlyContribution"), result.MonthlyContribution, CurrencyTolerance);
+        Assert.Equal(Number(expected, "savingsRate"), result.SavingsRate, RatioTolerance);
+        Assert.Equal(Number(expected, "finalNominalBalance"), result.FinalNominalBalance, 1e-6);
+        Assert.Equal(Number(expected, "finalInflationAdjustedBalance"), result.FinalInflationAdjustedBalance, 1e-6);
+        Assert.Equal(Number(expected, "totalInvested"), result.TotalInvested, 1e-6);
+        Assert.Equal(Number(expected, "totalGrowth"), result.TotalGrowth, 1e-6);
+        Assert.Equal(Number(expected, "inflationImpact"), result.InflationImpact, 1e-6);
+
+        // Definitional identities that hold for any inputs at all.
+        Assert.Equal(result.FinalNominalBalance - result.TotalInvested, result.TotalGrowth, 1e-6);
+        Assert.Equal(
+            result.FinalNominalBalance - result.FinalInflationAdjustedBalance,
+            result.InflationImpact,
+            1e-6);
+    }
+
+    [Theory]
+    [MemberData(nameof(HealthcareCaseIds))]
+    public void HealthcareGap_MatchesSharedFixture(string caseId)
+    {
+        var parityCase = Case(caseId);
+        var inputs = parityCase.Inputs;
+        var expected = parityCase.Expected;
+
+        var result = FinancialCalculator.CalculateHealthcareGap(new HealthcareGapInputs(
+            CurrentAge: inputs.GetProperty("currentAge").GetInt32(),
+            EarlyRetirementAge: inputs.GetProperty("earlyRetirementAge").GetInt32(),
+            MedicareAge: 65,
+            MonthlyPremium: inputs.GetProperty("monthlyPremium").GetDouble(),
+            AnnualDeductible: inputs.GetProperty("annualDeductible").GetDouble(),
+            AnnualOutOfPocket: inputs.GetProperty("annualOutOfPocket").GetDouble(),
+            InflationRate: inputs.GetProperty("inflationRate").GetDouble()));
+
+        Assert.Equal((int)Number(expected, "gapYears"), result.GapYears);
+        Assert.Equal(Number(expected, "annualCost"), result.AnnualCost, CurrencyTolerance);
+        Assert.Equal(Number(expected, "totalCost"), result.TotalCost, ExactTolerance);
+        Assert.Equal(Number(expected, "avgAnnualCost"), result.AverageAnnualCost, ExactTolerance);
+
+        Assert.Equal(result.GapYears, result.YearlyBreakdown.Count);
+    }
+
+    // ---- fixture plumbing ------------------------------------------------------------------
+
+    private sealed record ParityCase(string Id, string Kind, string Derivation, JsonElement Inputs, JsonElement Expected);
+
+    private static ParityCase Case(string id) => Cases.Single(c => c.Id == id);
+
+    private static TheoryData<string> IdsOfKind(string kind)
+    {
+        var data = new TheoryData<string>();
+        foreach (var parityCase in Cases.Where(c => c.Kind == kind))
+        {
+            data.Add(parityCase.Id);
+        }
+
+        return data;
+    }
+
+    private static IReadOnlyList<ParityCase> LoadCases()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "SharedParity", "fire-parity-cases.json");
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"Shared parity fixture not found at '{path}'. It is copied from shared/parity by MyFireNumber.Tests.csproj.",
+                path);
+        }
+
+        // Held as JsonDocument rather than deserialized into records so that the "Infinity" sentinel and
+        // the differently-shaped inputs per kind stay readable without a converter per case type.
+        var document = JsonDocument.Parse(File.ReadAllText(path));
+
+        return document.RootElement.GetProperty("cases").EnumerateArray()
+            .Select(c => new ParityCase(
+                c.GetProperty("id").GetString()!,
+                c.GetProperty("kind").GetString()!,
+                c.GetProperty("derivation").GetString()!,
+                c.GetProperty("inputs"),
+                c.GetProperty("expected")))
+            .ToList();
+    }
+
+    /// <summary>
+    /// JSON has no literal for infinity, and emitting a bare <c>Infinity</c> token produces a file that
+    /// <c>JSON.parse</c> rejects, so unreachable results are stored as the string "Infinity". These are
+    /// real, correct answers — the target is never reached — not placeholders for a missing value.
+    /// </summary>
+    private static double Number(JsonElement parent, string property)
+    {
+        var element = parent.GetProperty(property);
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.String => element.GetString() switch
+            {
+                "Infinity" => double.PositiveInfinity,
+                "-Infinity" => double.NegativeInfinity,
+                "NaN" => double.NaN,
+                var other => throw new FormatException($"Unrecognised non-finite sentinel '{other}' for '{property}'."),
+            },
+            _ => throw new FormatException($"Expected a number for '{property}' but found {element.ValueKind}."),
+        };
+    }
+
+    private static ContributionGrowth ToContributionGrowth(JsonElement inputs)
+    {
+        // Deliberately strict. A silent fallback would let a typo in the fixture quietly test the
+        // wrong contribution model and still pass.
+        if (!inputs.TryGetProperty("contributionGrowth", out var growth))
+        {
+            throw new FormatException("Case is missing contributionGrowth.");
+        }
+
+        return growth.GetString() switch
+        {
+            "inflation" => ContributionGrowth.Inflation,
+            "flat" => ContributionGrowth.Flat,
+            var other => throw new FormatException($"Unrecognised contributionGrowth '{other}'."),
+        };
+    }
+
+    /// <summary>
+    /// Maps the fixture's semantic input names onto this platform's call shape. The web engine takes
+    /// these same values as positional arguments in a different order; keeping the mapping here is what
+    /// makes an argument-order mistake impossible to share between the two suites.
+    /// </summary>
+    private static FireInputs ToFireInputs(JsonElement inputs) => new(
+        CurrentAge: inputs.GetProperty("currentAge").GetDouble(),
+        RetirementAge: inputs.GetProperty("retirementAge").GetDouble(),
+        CurrentSavings: inputs.GetProperty("currentSavings").GetDouble(),
+        AnnualContribution: inputs.GetProperty("annualContribution").GetDouble(),
+        AnnualIncome: inputs.GetProperty("annualIncome").GetDouble(),
+        ExpectedReturn: inputs.GetProperty("expectedReturn").GetDouble(),
+        InflationRate: inputs.GetProperty("inflationRate").GetDouble(),
+        WithdrawalRate: inputs.GetProperty("withdrawalRate").GetDouble(),
+        AnnualExpenses: inputs.GetProperty("annualExpenses").GetDouble(),
+        ContributionGrowth: ToContributionGrowth(inputs));
+}

--- a/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
+++ b/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
@@ -23,4 +23,11 @@
     <ProjectReference Include="..\MyFireNumber.Storage\MyFireNumber.Storage.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Same file the web Vitest suite reads, so both platforms are pinned to one set of numbers. -->
+    <None Include="..\..\shared\parity\fire-parity-cases.json"
+          Link="SharedParity\fire-parity-cases.json"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/shared/parity/README.md
+++ b/shared/parity/README.md
@@ -1,0 +1,77 @@
+# Shared parity fixtures
+
+`fire-parity-cases.json` is the single set of numbers that both front ends are pinned to.
+
+- The web app reads it from `web/src/utils/__tests__/parityFixtures.ts` (Vitest).
+- The MAUI app reads it from `app/MyFireNumber.Tests/Calculations/SharedParityFixtureTests.cs` (xUnit).
+
+It lives here, outside both `web/` and `app/`, because neither platform owns it. Before this file
+existed, "web and MAUI agree" was enforced by review alone: the MAUI suite asserted
+`FinancialCalculator.cs` against constants that had *once* been copied from the web, so a change to
+`calculations.ts` that silently diverged would pass CI cleanly. That is issue #54.
+
+## The rule that makes this worth having
+
+**Never regenerate an expected value by running either implementation and pasting the output.**
+
+A test that asserts whatever the code currently prints is a screenshot, not a test. Two of the bugs
+the cross-platform audit fixed (#45's double-charged interest, #46's projection that disagreed with
+its own headline) shipped precisely because the behaviour looked intentional — nothing independent
+contradicted it.
+
+Every case therefore carries a **`derivation`** field stating how its numbers were obtained: the
+closed form, the hand arithmetic, or the invariant. A case without a real derivation is not
+reviewable and should not be merged.
+
+`web/src/utils/__tests__/fixtureSelfCheck.test.ts` enforces this mechanically. It re-derives the
+closed-form-checkable values a third time, in TypeScript, from `oracles.ts` — a module forbidden
+from importing the code under test — and fails if a fixture value has drifted toward an
+implementation. So the chain is:
+
+```
+independent algebra  ===  this fixture  ===  web implementation
+                                        ===  MAUI implementation
+```
+
+## Case shape
+
+```jsonc
+{
+  "id": "fire-defaults-inflation",
+  "kind": "fire",                  // fire | debt | withdrawal | investment | healthcare
+  "description": "Shipped web defaults with inflation-escalated contributions.",
+  "derivation": "rho = 1.07/1.03 - 1 = 0.038834951456...; n = ln((C + T*rho)/(C + PV*rho))/ln(1+rho) = 24.3838964605, so fireAge = 54.4.",
+  "inputs":   { "currentAge": 30, "currentSavings": 100000, ... },
+  "expected": { "fireNumber": 1200000, "fireAge": 54.4, ... }
+}
+```
+
+Inputs are named **semantically**, never positionally. The two platforms genuinely disagree on
+argument order — web's `calculateCoastFIRE` takes eight positional arguments with `annualExpenses`
+*before* `withdrawalRate`, while MAUI takes a single `FireInputs` record — so each side keeps a thin
+adapter that maps these names onto its own call shape. Encoding positions here would bake one
+platform's ordering into a supposedly neutral artifact.
+
+### Conventions
+
+- Percentages are decimals (`0.07` is 7%), currency is dollars, consistent with the rest of the repo.
+- Values the app rounds for display are stored rounded, matching JS `Math.round` and C#
+  `MidpointRounding.AwayFromZero`. Values it does not round are stored at full `double` precision
+  and compared with a tolerance.
+- `Infinity` is carried as the **string** `"Infinity"`, because JSON has no infinity literal. Both
+  consumers decode the sentinel explicitly. An unreachable target is a correct answer — a 2% return
+  against 5% inflation converges to a $700,000 fixed point and can never reach $1.25M — so it is
+  asserted, not treated as a missing value.
+- `year` is deliberately **not** in any expectation. The web derives calendar years from
+  `new Date().getFullYear()` while MAUI takes an explicit `ProjectionStartYear`, so calendar
+  behaviour is covered per-platform instead of pretending it is shared.
+
+## Adding a case
+
+1. Derive the expected values independently — closed form, hand arithmetic, or an invariant.
+2. Write the `derivation` field so a reviewer can check it without running anything.
+3. Add oracle coverage in `fixtureSelfCheck.test.ts` if the case is closed-form-checkable.
+4. Run `npm test` in `web/` **and** `dotnet test app/MyFireNumber.Tests`. Both must pass.
+
+Editing this file triggers both CI jobs in `.github/workflows/tests.yml`; the path filters are there
+so a fixture change cannot land without re-running both suites.

--- a/shared/parity/fire-parity-cases.json
+++ b/shared/parity/fire-parity-cases.json
@@ -1,0 +1,759 @@
+{
+  "cases": [
+    {
+      "id": "fire-defaults-inflation",
+      "kind": "fire",
+      "description": "Shipped web defaults with inflation-escalated contributions.",
+      "derivation": "rho = 1.07/1.03 - 1 = 0.03883495145631066. n = ln((C + T*rho)/(C + PV*rho))/ln(1+rho) = ln(70601.9417/27883.4951)/ln(1.03883495) = 24.3838964605, so fireAge = 54.4. The projection crosses the 1.2M target between age 54 (1,173,603) and age 55 (1,243,180) in today's dollars, which is the crossing invariant from issue #46.",
+      "inputs": {
+        "currentAge": 30,
+        "retirementAge": 55,
+        "currentSavings": 100000,
+        "annualContribution": 24000,
+        "annualIncome": 72000,
+        "expectedReturn": 0.07,
+        "inflationRate": 0.03,
+        "withdrawalRate": 0.04,
+        "annualExpenses": 48000,
+        "contributionGrowth": "inflation"
+      },
+      "expected": {
+        "fireNumber": 1200000,
+        "yearsToFire": 24.4,
+        "fireAge": 54.4,
+        "coastFireNumber": 462932,
+        "savingsRate": 0.3333333333333333,
+        "monthlyContribution": 2000.0,
+        "projectionCount": 36,
+        "projectionSamples": [
+          {
+            "year": 0,
+            "age": 30,
+            "portfolio": 100000,
+            "inflationAdjusted": 100000,
+            "totalContributions": 100000,
+            "contributions": 100000
+          },
+          {
+            "year": 10,
+            "age": 40,
+            "portfolio": 581874,
+            "inflationAdjusted": 432969,
+            "totalContributions": 383387,
+            "contributions": 32253.993104258934
+          },
+          {
+            "year": 24,
+            "age": 54,
+            "portfolio": 2385693,
+            "inflationAdjusted": 1173603,
+            "totalContributions": 951022,
+            "contributions": 48787.0585550497
+          },
+          {
+            "year": 25,
+            "age": 55,
+            "portfolio": 2602942,
+            "inflationAdjusted": 1243180,
+            "totalContributions": 1001273,
+            "contributions": 50250.670311701186
+          }
+        ],
+        "reverse": {
+          "requiredAnnualSavings": 22946.80026660227,
+          "requiredMonthlySavings": 1912.2333555501891,
+          "currentWillGrowTo": 259217,
+          "alreadyAchievable": false
+        }
+      }
+    },
+    {
+      "id": "fire-defaults-flat",
+      "kind": "fire",
+      "description": "Shipped web defaults with flat nominal contributions, whose purchasing power erodes.",
+      "derivation": "No closed form exists in today's dollars for a flat nominal contribution, so the deflated path (PV(1+r)^n + C((1+r)^n - 1)/r)/(1+i)^n is solved by bisection. Flat contributions must always reach FIRE no earlier than inflation-escalated ones.",
+      "inputs": {
+        "currentAge": 30,
+        "retirementAge": 55,
+        "currentSavings": 100000,
+        "annualContribution": 24000,
+        "annualIncome": 72000,
+        "expectedReturn": 0.07,
+        "inflationRate": 0.03,
+        "withdrawalRate": 0.04,
+        "annualExpenses": 48000,
+        "contributionGrowth": "flat"
+      },
+      "expected": {
+        "fireNumber": 1200000,
+        "yearsToFire": 29.2,
+        "fireAge": 59.2,
+        "coastFireNumber": 462932,
+        "savingsRate": 0.3333333333333333,
+        "monthlyContribution": 2000.0,
+        "projectionCount": 41,
+        "projectionSamples": [
+          {
+            "year": 0,
+            "age": 30,
+            "portfolio": 100000,
+            "inflationAdjusted": 100000,
+            "totalContributions": 100000,
+            "contributions": 100000
+          },
+          {
+            "year": 10,
+            "age": 40,
+            "portfolio": 528310,
+            "inflationAdjusted": 393112,
+            "totalContributions": 340000,
+            "contributions": 24000
+          },
+          {
+            "year": 24,
+            "age": 54,
+            "portfolio": 1903477,
+            "inflationAdjusted": 936384,
+            "totalContributions": 676000,
+            "contributions": 24000
+          },
+          {
+            "year": 25,
+            "age": 55,
+            "portfolio": 2060720,
+            "inflationAdjusted": 984211,
+            "totalContributions": 700000,
+            "contributions": 24000
+          }
+        ],
+        "reverse": {
+          "requiredAnnualSavings": 31143.402693590488,
+          "requiredMonthlySavings": 2595.2835577992073,
+          "currentWillGrowTo": 259217,
+          "alreadyAchievable": false
+        }
+      }
+    },
+    {
+      "id": "fire-non-default-inflation",
+      "kind": "fire",
+      "description": "A scenario sharing no defaults with any other case, inflation-escalated.",
+      "derivation": "rho = 1.06/1.025 - 1. Same closed form as the defaults case; chosen so a drift in either implementation cannot hide behind a value that happens to be a shared default.",
+      "inputs": {
+        "currentAge": 42,
+        "retirementAge": 60,
+        "currentSavings": 250000,
+        "annualContribution": 18000,
+        "annualIncome": 95000,
+        "expectedReturn": 0.06,
+        "inflationRate": 0.025,
+        "withdrawalRate": 0.035,
+        "annualExpenses": 70000,
+        "contributionGrowth": "inflation"
+      },
+      "expected": {
+        "fireNumber": 2000000,
+        "yearsToFire": 35.1,
+        "fireAge": 77.1,
+        "coastFireNumber": 1092833,
+        "savingsRate": 0.18947368421052632,
+        "monthlyContribution": 1500.0,
+        "projectionCount": 47,
+        "projectionSamples": [
+          {
+            "year": 0,
+            "age": 42,
+            "portfolio": 250000,
+            "inflationAdjusted": 250000,
+            "totalContributions": 250000,
+            "contributions": 250000
+          },
+          {
+            "year": 18,
+            "age": 60,
+            "portfolio": 1396066,
+            "inflationAdjusted": 895110,
+            "totalContributions": 663028,
+            "contributions": 28073.85691871705
+          },
+          {
+            "year": 35,
+            "age": 77,
+            "portfolio": 4722169,
+            "inflationAdjusted": 1989786,
+            "totalContributions": 1263425,
+            "contributions": 42717.69334919227
+          },
+          {
+            "year": 36,
+            "age": 78,
+            "portfolio": 5049285,
+            "inflationAdjusted": 2075729,
+            "totalContributions": 1307211,
+            "contributions": 43785.63568292207
+          }
+        ],
+        "reverse": {
+          "requiredAnnualSavings": 63449.60980843576,
+          "requiredMonthlySavings": 5287.467484036313,
+          "currentWillGrowTo": 457526,
+          "alreadyAchievable": false
+        }
+      }
+    },
+    {
+      "id": "fire-non-default-flat",
+      "kind": "fire",
+      "description": "The same non-default scenario with flat nominal contributions.",
+      "derivation": "Bisection on the deflated flat path, as in fire-defaults-flat.",
+      "inputs": {
+        "currentAge": 42,
+        "retirementAge": 60,
+        "currentSavings": 250000,
+        "annualContribution": 18000,
+        "annualIncome": 95000,
+        "expectedReturn": 0.06,
+        "inflationRate": 0.025,
+        "withdrawalRate": 0.035,
+        "annualExpenses": 70000,
+        "contributionGrowth": "flat"
+      },
+      "expected": {
+        "fireNumber": 2000000,
+        "yearsToFire": 40.1,
+        "fireAge": 82.1,
+        "coastFireNumber": 1092833,
+        "savingsRate": 0.18947368421052632,
+        "monthlyContribution": 1500.0,
+        "projectionCount": 51,
+        "projectionSamples": [
+          {
+            "year": 0,
+            "age": 42,
+            "portfolio": 250000,
+            "inflationAdjusted": 250000,
+            "totalContributions": 250000,
+            "contributions": 250000
+          },
+          {
+            "year": 18,
+            "age": 60,
+            "portfolio": 1269887,
+            "inflationAdjusted": 814208,
+            "totalContributions": 574000,
+            "contributions": 18000
+          },
+          {
+            "year": 40,
+            "age": 82,
+            "portfolio": 5357145,
+            "inflationAdjusted": 1995165,
+            "totalContributions": 970000,
+            "contributions": 18000
+          },
+          {
+            "year": 41,
+            "age": 83,
+            "portfolio": 5696574,
+            "inflationAdjusted": 2069833,
+            "totalContributions": 988000,
+            "contributions": 18000
+          }
+        ],
+        "reverse": {
+          "requiredAnnualSavings": 77841.18595800038,
+          "requiredMonthlySavings": 6486.765496500032,
+          "currentWillGrowTo": 457526,
+          "alreadyAchievable": false
+        }
+      }
+    },
+    {
+      "id": "fire-degenerate-zero-real-return",
+      "kind": "fire",
+      "description": "Return exactly equals inflation, so the real return is zero and the annuity factor is 0/0.",
+      "derivation": "r = i = 0.05 gives rho = 0 exactly. The closed form ((1+rho)^n - 1)/rho is undefined and its limit as rho -> 0 is the linear solution: 50,000 + 20,000n = 1,250,000 gives n = 60 exactly, so fireAge = 90. This is a live divide-by-zero that is currently special-cased correctly and must stay that way. Note the projection series is capped at 50 years, so it stops 10 years short of the crossing and the crossing invariant is not checkable here.",
+      "inputs": {
+        "currentAge": 30,
+        "retirementAge": 60,
+        "currentSavings": 50000,
+        "annualContribution": 20000,
+        "annualIncome": 100000,
+        "expectedReturn": 0.05,
+        "inflationRate": 0.05,
+        "withdrawalRate": 0.04,
+        "annualExpenses": 50000,
+        "contributionGrowth": "inflation"
+      },
+      "expected": {
+        "fireNumber": 1250000,
+        "yearsToFire": 60.0,
+        "fireAge": 90.0,
+        "coastFireNumber": 1250000,
+        "savingsRate": 0.2,
+        "monthlyContribution": 1666.6666666666667,
+        "projectionCount": 51,
+        "projectionSamples": [
+          {
+            "year": 0,
+            "age": 30,
+            "portfolio": 50000,
+            "inflationAdjusted": 50000,
+            "totalContributions": 50000,
+            "contributions": 50000
+          },
+          {
+            "year": 30,
+            "age": 60,
+            "portfolio": 2809263,
+            "inflationAdjusted": 650000,
+            "totalContributions": 1445216,
+            "contributions": 86438.84750301336
+          },
+          {
+            "year": 49,
+            "age": 79,
+            "portfolio": 11248973,
+            "inflationAdjusted": 1030000,
+            "totalContributions": 4216960,
+            "contributions": 218426.66258578477
+          },
+          {
+            "year": 50,
+            "age": 80,
+            "portfolio": 12040770,
+            "inflationAdjusted": 1050000,
+            "totalContributions": 4446308,
+            "contributions": 229347.995715074
+          }
+        ],
+        "reverse": {
+          "requiredAnnualSavings": 40000.0,
+          "requiredMonthlySavings": 3333.3333333333335,
+          "currentWillGrowTo": 50000,
+          "alreadyAchievable": false
+        }
+      }
+    },
+    {
+      "id": "fire-unreachable-negative-real-return",
+      "kind": "fire",
+      "description": "A 2% return against 5% inflation. The target is genuinely unreachable, so Infinity is correct.",
+      "derivation": "rho = 1.02/1.05 - 1 = -0.02857142857142858 < 0, so B_{k+1} = B_k(1+rho) + C has a stable fixed point at B* = -C/rho = 20000/0.02857142857142858 = 700,000 exactly. The target is 50,000/0.04 = 1,250,000 > 700,000, so no finite n reaches it. Infinity is the mathematically correct answer and must not be 'fixed'.",
+      "inputs": {
+        "currentAge": 30,
+        "retirementAge": 60,
+        "currentSavings": 100000,
+        "annualContribution": 20000,
+        "annualIncome": 100000,
+        "expectedReturn": 0.02,
+        "inflationRate": 0.05,
+        "withdrawalRate": 0.04,
+        "annualExpenses": 50000,
+        "contributionGrowth": "inflation"
+      },
+      "expected": {
+        "fireNumber": 1250000,
+        "yearsToFire": "Infinity",
+        "fireAge": "Infinity",
+        "coastFireNumber": 2982523,
+        "savingsRate": 0.2,
+        "monthlyContribution": 1666.6666666666667,
+        "projectionCount": 51,
+        "projectionSamples": [
+          {
+            "year": 0,
+            "age": 30,
+            "portfolio": 100000,
+            "inflationAdjusted": 100000,
+            "totalContributions": 100000,
+            "contributions": 100000
+          },
+          {
+            "year": 30,
+            "age": 60,
+            "portfolio": 1938543,
+            "inflationAdjusted": 448535,
+            "totalContributions": 1495216,
+            "contributions": 86438.84750301336
+          },
+          {
+            "year": 50,
+            "age": 80,
+            "portfolio": 6412227,
+            "inflationAdjusted": 559170,
+            "totalContributions": 4496308,
+            "contributions": 229347.995715074
+          }
+        ],
+        "reverse": {
+          "requiredAnnualSavings": 59420.4203852185,
+          "requiredMonthlySavings": 4951.701698768208,
+          "currentWillGrowTo": 41911,
+          "alreadyAchievable": false
+        }
+      }
+    },
+    {
+      "id": "fire-already-funded",
+      "kind": "fire",
+      "description": "Current savings already exceed the FIRE number.",
+      "derivation": "PV >= target short-circuits to n = 0, so fireAge equals currentAge and no solving happens.",
+      "inputs": {
+        "currentAge": 45,
+        "retirementAge": 55,
+        "currentSavings": 2000000,
+        "annualContribution": 24000,
+        "annualIncome": 72000,
+        "expectedReturn": 0.07,
+        "inflationRate": 0.03,
+        "withdrawalRate": 0.04,
+        "annualExpenses": 48000,
+        "contributionGrowth": "inflation"
+      },
+      "expected": {
+        "fireNumber": 1200000,
+        "yearsToFire": 0.0,
+        "fireAge": 45.0,
+        "coastFireNumber": 819815,
+        "savingsRate": 0.3333333333333333,
+        "monthlyContribution": 2000.0,
+        "projectionCount": 11,
+        "projectionSamples": [
+          {
+            "year": 0,
+            "age": 45,
+            "portfolio": 2000000,
+            "inflationAdjusted": 2000000,
+            "totalContributions": 2000000,
+            "contributions": 2000000
+          },
+          {
+            "year": 5,
+            "age": 50,
+            "portfolio": 2955449,
+            "inflationAdjusted": 2549396,
+            "totalContributions": 2131242,
+            "contributions": 27822.577783200002
+          }
+        ],
+        "reverse": {
+          "requiredAnnualSavings": 0.0,
+          "requiredMonthlySavings": 0.0,
+          "currentWillGrowTo": 2927491,
+          "alreadyAchievable": true
+        }
+      }
+    },
+    {
+      "id": "debt-single-20pct-apr",
+      "kind": "debt",
+      "description": "$10,000 at 20% APR with a $500/month budget.",
+      "derivation": "Month-one interest is exactly 10000 * 0.20/12 = 166.666..., charged once and only once. Cross-checked against the amortization closed form n = -ln(1 - P*m/A)/ln(1+m) = 24.53, so 25 months. Pre-fix (#45) this wrongly reported 34 months, $6,617 of interest and $333.33 of month-one interest because interest was charged twice per month.",
+      "inputs": {
+        "debts": [
+          {
+            "id": "card",
+            "name": "Card",
+            "balance": 10000,
+            "rate": 0.2,
+            "minPayment": 500
+          }
+        ],
+        "monthlyPayment": 500,
+        "extraPayment": 0,
+        "strategy": "snowball"
+      },
+      "expected": {
+        "totalMonths": 25,
+        "totalInterest": 2266,
+        "totalPrincipal": 10000,
+        "monthlyPayment": 500,
+        "firstMonthInterest": 166.66666666666666,
+        "payoffOrder": [
+          "Card"
+        ]
+      }
+    },
+    {
+      "id": "debt-multi-snowball",
+      "kind": "debt",
+      "description": "Three debts cleared smallest-balance-first.",
+      "derivation": "Snowball orders by balance ascending, so the $1,500 debt clears first even though it carries the lowest rate. Total interest must be >= the avalanche case below.",
+      "inputs": {
+        "debts": [
+          {
+            "id": "a",
+            "name": "Card A",
+            "balance": 8000,
+            "rate": 0.24,
+            "minPayment": 160
+          },
+          {
+            "id": "b",
+            "name": "Card B",
+            "balance": 1500,
+            "rate": 0.09,
+            "minPayment": 40
+          },
+          {
+            "id": "c",
+            "name": "Loan C",
+            "balance": 12000,
+            "rate": 0.16,
+            "minPayment": 250
+          }
+        ],
+        "monthlyPayment": 900,
+        "extraPayment": 0,
+        "strategy": "snowball"
+      },
+      "expected": {
+        "totalMonths": 30,
+        "totalInterest": 5336,
+        "totalPrincipal": 21500,
+        "monthlyPayment": 900,
+        "firstMonthInterest": 331.25,
+        "payoffOrder": [
+          "Card B",
+          "Card A",
+          "Loan C"
+        ]
+      }
+    },
+    {
+      "id": "debt-multi-avalanche",
+      "kind": "debt",
+      "description": "The same three debts cleared highest-rate-first.",
+      "derivation": "Avalanche orders by rate descending. Directing every spare dollar at the most expensive balance can never cost more total interest than any other ordering, so this must come in at or below debt-multi-snowball. A pre-fix bug inverted exactly this relationship.",
+      "inputs": {
+        "debts": [
+          {
+            "id": "a",
+            "name": "Card A",
+            "balance": 8000,
+            "rate": 0.24,
+            "minPayment": 160
+          },
+          {
+            "id": "b",
+            "name": "Card B",
+            "balance": 1500,
+            "rate": 0.09,
+            "minPayment": 40
+          },
+          {
+            "id": "c",
+            "name": "Loan C",
+            "balance": 12000,
+            "rate": 0.16,
+            "minPayment": 250
+          }
+        ],
+        "monthlyPayment": 900,
+        "extraPayment": 0,
+        "strategy": "avalanche"
+      },
+      "expected": {
+        "totalMonths": 30,
+        "totalInterest": 4957,
+        "totalPrincipal": 21500,
+        "monthlyPayment": 900,
+        "firstMonthInterest": 331.25,
+        "payoffOrder": [
+          "Card A",
+          "Loan C",
+          "Card B"
+        ]
+      }
+    },
+    {
+      "id": "withdrawal-surviving-portfolio",
+      "kind": "withdrawal",
+      "description": "$1M at 4% with a 7% return and 3% inflation, over a 30 year horizon.",
+      "derivation": "The 3.88% real return roughly matches the 4% real draw, so the portfolio outlives the horizon and longevity is capped at retirementYears. The comparison table applies its own 50 year cap, so here the two legitimately report different caps rather than disagreeing.",
+      "inputs": {
+        "portfolioValue": 1000000,
+        "withdrawalRate": 0.04,
+        "expectedReturn": 0.07,
+        "inflationRate": 0.03,
+        "retirementYears": 30
+      },
+      "expected": {
+        "annualWithdrawal": 40000,
+        "monthlyWithdrawal": 3333,
+        "portfolioLongevity": 30,
+        "horizonFundedRatio": 1,
+        "endingBalance": 2427262,
+        "rateAnalysis": [
+          {
+            "rate": 0.03,
+            "years": 50,
+            "endBalance": 10652186
+          },
+          {
+            "rate": 0.035,
+            "years": 50,
+            "endBalance": 7518046
+          },
+          {
+            "rate": 0.04,
+            "years": 50,
+            "endBalance": 4383906
+          },
+          {
+            "rate": 0.045,
+            "years": 50,
+            "endBalance": 1249766
+          },
+          {
+            "rate": 0.05,
+            "years": 42,
+            "endBalance": 0
+          }
+        ]
+      }
+    },
+    {
+      "id": "withdrawal-depleting-portfolio",
+      "kind": "withdrawal",
+      "description": "$1M at 5% with a 3% return and 3% inflation, over a 40 year horizon.",
+      "derivation": "Withdrawals grow at inflation while the portfolio grows at the same 3%, so the balance declines and is exhausted well before either cap binds. With neither cap active the headline longevity and the 5% row of the comparison table must agree exactly.",
+      "inputs": {
+        "portfolioValue": 1000000,
+        "withdrawalRate": 0.05,
+        "expectedReturn": 0.03,
+        "inflationRate": 0.03,
+        "retirementYears": 40
+      },
+      "expected": {
+        "annualWithdrawal": 50000,
+        "monthlyWithdrawal": 4167,
+        "portfolioLongevity": 20,
+        "horizonFundedRatio": 0.5,
+        "endingBalance": 52605,
+        "rateAnalysis": [
+          {
+            "rate": 0.03,
+            "years": 34,
+            "endBalance": 0
+          },
+          {
+            "rate": 0.035,
+            "years": 29,
+            "endBalance": 0
+          },
+          {
+            "rate": 0.04,
+            "years": 25,
+            "endBalance": 0
+          },
+          {
+            "rate": 0.045,
+            "years": 22,
+            "endBalance": 0
+          },
+          {
+            "rate": 0.05,
+            "years": 20,
+            "endBalance": 0
+          }
+        ]
+      }
+    },
+    {
+      "id": "investment-defaults",
+      "kind": "investment",
+      "description": "Shipped Savings & Investment defaults: $100k plus $500/month for 30 years.",
+      "derivation": "Deflated closed form PV(1+rho)^30 + C((1+rho)^30 - 1)/rho with C = 6,000 and rho = 0.03883495145631066 gives 643,649.7392030944 in today's dollars; multiplying by 1.03^30 gives the 1,562,306.8565586845 nominal figure. The nominal recurrence B_k = B_{k-1}(1.07) + 6000(1.03)^k reproduces both to floating-point noise, which is what makes this an identity rather than an approximation.",
+      "inputs": {
+        "startingAmount": 100000,
+        "contributionAmount": 500,
+        "contributionFrequency": "monthly",
+        "yearsInvesting": 30,
+        "expectedReturn": 0.07,
+        "inflationRate": 0.03,
+        "annualIncome": 72000,
+        "currentAge": 30,
+        "contributionGrowth": "inflation"
+      },
+      "expected": {
+        "annualContribution": 6000,
+        "monthlyContribution": 500.0,
+        "savingsRate": 0.08333333333333333,
+        "finalNominalBalance": 1562306.8565586861,
+        "finalInflationAdjustedBalance": 643649.7392030951,
+        "totalInvested": 394016.0690650701,
+        "totalGrowth": 1168290.7874936159,
+        "inflationImpact": 918657.117355591
+      }
+    },
+    {
+      "id": "investment-flat-contributions",
+      "kind": "investment",
+      "description": "The same plan with flat nominal contributions.",
+      "derivation": "B_k = B_{k-1}(1.07) + 6000 with no escalation, deflated by 1.03^30 at the end. Total invested is exactly 100,000 + 30*6,000 = 280,000 because nothing escalates.",
+      "inputs": {
+        "startingAmount": 100000,
+        "contributionAmount": 500,
+        "contributionFrequency": "monthly",
+        "yearsInvesting": 30,
+        "expectedReturn": 0.07,
+        "inflationRate": 0.03,
+        "annualIncome": 72000,
+        "currentAge": 30,
+        "contributionGrowth": "flat"
+      },
+      "expected": {
+        "annualContribution": 6000,
+        "monthlyContribution": 500.0,
+        "savingsRate": 0.08333333333333333,
+        "finalNominalBalance": 1327990.222208664,
+        "finalInflationAdjustedBalance": 547114.388316556,
+        "totalInvested": 280000,
+        "totalGrowth": 1047990.222208664,
+        "inflationImpact": 780875.833892108
+      }
+    },
+    {
+      "id": "healthcare-default-gap",
+      "kind": "healthcare",
+      "description": "Retiring at 55 with Medicare at 65 leaves a 10 year self-funded gap.",
+      "derivation": "annualCost = 600*12 + 2,500 + 2,000 = 11,700. Costs inflate from year zero, so the total is the geometric sum A*((1+i)^n - 1)/i = 11,700*(1.03^10 - 1)/0.03 = 134,126.6, which rounds to 134,127.",
+      "inputs": {
+        "currentAge": 30,
+        "earlyRetirementAge": 55,
+        "monthlyPremium": 600,
+        "annualDeductible": 2500,
+        "annualOutOfPocket": 2000,
+        "inflationRate": 0.03
+      },
+      "expected": {
+        "gapYears": 10,
+        "annualCost": 11700,
+        "totalCost": 134127,
+        "avgAnnualCost": 13413
+      }
+    },
+    {
+      "id": "healthcare-no-gap",
+      "kind": "healthcare",
+      "description": "Retiring at or after Medicare eligibility leaves no gap at all.",
+      "derivation": "gapYears = max(0, 65 - 67) = 0, so the total is an empty sum and the average is defined as zero rather than a division by zero.",
+      "inputs": {
+        "currentAge": 60,
+        "earlyRetirementAge": 67,
+        "monthlyPremium": 600,
+        "annualDeductible": 2500,
+        "annualOutOfPocket": 2000,
+        "inflationRate": 0.03
+      },
+      "expected": {
+        "gapYears": 0,
+        "annualCost": 11700,
+        "totalCost": 0,
+        "avgAnnualCost": 0
+      }
+    }
+  ]
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,7 +24,8 @@
         "@vitejs/plugin-react": "^5.1.2",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -2817,6 +2818,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2878,6 +2890,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2943,6 +2962,149 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -3150,6 +3312,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -3468,6 +3640,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chainsaw": {
       "version": "0.1.0",
@@ -4092,6 +4274,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4235,6 +4424,16 @@
       },
       "engines": {
         "node": ">=8.3.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-csv": {
@@ -5855,6 +6054,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5941,6 +6154,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6698,6 +6918,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6762,6 +6989,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -7088,6 +7329,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7102,6 +7360,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -7554,6 +7822,106 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -7669,6 +8037,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workbox-background-sync": {

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.18",
@@ -25,7 +27,8 @@
     "@vitejs/plugin-react": "^5.1.2",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/web/src/components/ui/__tests__/ResultCard.test.tsx
+++ b/web/src/components/ui/__tests__/ResultCard.test.tsx
@@ -1,0 +1,153 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import ResultCard from '../ResultCard'
+import { calculateStandardFIRE } from '../../../utils/calculations'
+import type { FIREInputs } from '../../../utils/calculations'
+
+/**
+ * `Infinity` returns from the engine are mathematically correct — they mean the target is never
+ * reached under the given assumptions — so they must NOT be "fixed" in the calculations. What must
+ * hold is that they never reach the user as "Infinity years" or "$∞". `ResultCard` is the single
+ * guard for that, and this file proves the guard actually fires.
+ *
+ * Rendered with `react-dom/server`'s renderToStaticMarkup, which runs in plain Node. No jsdom, no
+ * testing-library, no new dependency.
+ */
+
+const render = (element: Parameters<typeof renderToStaticMarkup>[0]) => renderToStaticMarkup(element)
+
+const UNREACHABLE_TEXT = 'Not reachable'
+const UNREACHABLE_SUBTEXT = 'The current return, inflation and contribution assumptions never reach this target.'
+
+describe('finite values render through their format', () => {
+  it.each([
+    ['currency', 1_200_000, '$1,200,000'],
+    ['years', 24.4, '24.4 years'],
+    ['percent', 0.335, '33.5%'],
+  ] as const)('formats a %s value', (format, value, expected) => {
+    expect(render(<ResultCard label="L" value={value} format={format} />)).toContain(expected)
+  })
+
+  it('renders a plain number with locale grouping when no format is given', () => {
+    expect(render(<ResultCard label="L" value={1_234_567} />)).toContain('1,234,567')
+  })
+
+  it('passes a string value through untouched', () => {
+    expect(render(<ResultCard label="L" value="Already there" format="currency" />)).toContain('Already there')
+  })
+
+  it('renders zero rather than treating it as absent', () => {
+    // 0 is falsy; a naive `value && ...` guard would drop it. $0 is a real, meaningful result.
+    expect(render(<ResultCard label="L" value={0} format="currency" />)).toContain('$0')
+  })
+
+  it('renders the label, subtext and icon', () => {
+    const html = render(<ResultCard label="FIRE Number" value={1} subtext="at 4% SWR" icon="🔥" />)
+    expect(html).toContain('FIRE Number')
+    expect(html).toContain('at 4% SWR')
+    expect(html).toContain('🔥')
+  })
+})
+
+describe('unreachable values are guarded', () => {
+  it.each([
+    ['Infinity', Infinity],
+    ['-Infinity', -Infinity],
+    ['NaN', NaN],
+  ] as const)('replaces %s with wording, for every format', (_label, value) => {
+    for (const format of ['currency', 'years', 'percent', 'none'] as const) {
+      const html = render(<ResultCard label="L" value={value} format={format} />)
+      expect(html).toContain(UNREACHABLE_TEXT)
+      // The exact strings a broken guard would leak.
+      expect(html).not.toContain('Infinity')
+      expect(html).not.toContain('NaN')
+      expect(html).not.toContain('∞')
+    }
+  })
+
+  it('swaps the subtext for an explanation instead of showing the caller-supplied one', () => {
+    const html = render(<ResultCard label="L" value={Infinity} format="years" subtext="on track" />)
+    expect(html).toContain(UNREACHABLE_SUBTEXT)
+    expect(html).not.toContain('on track')
+  })
+
+  it('honours caller overrides for both the value and the subtext', () => {
+    const html = render(
+      <ResultCard
+        label="L"
+        value={Infinity}
+        format="currency"
+        unreachableText="Never"
+        unreachableSubtext="Increase contributions."
+      />,
+    )
+    expect(html).toContain('Never')
+    expect(html).toContain('Increase contributions.')
+    expect(html).not.toContain(UNREACHABLE_TEXT)
+  })
+
+  it('shows the explanation even when the caller passed no subtext at all', () => {
+    expect(render(<ResultCard label="L" value={Infinity} />)).toContain(UNREACHABLE_SUBTEXT)
+  })
+
+  it('does not treat the literal string "Infinity" as unreachable', () => {
+    // The guard is `typeof value === 'number'`, so a string is passed through. Documents that the
+    // guard is type-directed, not text-matching.
+    expect(render(<ResultCard label="L" value="Infinity" />)).toContain('Infinity')
+  })
+})
+
+describe('end to end from the engine', () => {
+  it('renders an genuinely unreachable engine result without leaking Infinity', () => {
+    // 2% nominal return against 5% inflation is a negative real rate. The deflated balance converges
+    // to the fixed point -C/rho = 20000 / 0.0285714... = $700,000, which is below the $1.25M target,
+    // so the target is never reached and Infinity is the correct answer. Derived algebraically, not
+    // read from the code.
+    const inputs: FIREInputs = {
+      currentAge: 30,
+      retirementAge: 55,
+      currentSavings: 50_000,
+      annualContribution: 20_000,
+      annualIncome: 72_000,
+      expectedReturn: 0.02,
+      inflationRate: 0.05,
+      withdrawalRate: 0.04,
+      annualExpenses: 50_000,
+      contributionGrowth: 'inflation',
+    }
+    const result = calculateStandardFIRE(inputs)
+    expect(result.fireNumber).toBe(1_250_000)
+    expect(result.yearsToFIRE).toBe(Infinity)
+    expect(result.fireAge).toBe(Infinity)
+
+    const html = render(
+      <>
+        <ResultCard label="FIRE Number" value={result.fireNumber} format="currency" />
+        <ResultCard label="Years to FIRE" value={result.yearsToFIRE} format="years" />
+        <ResultCard label="FIRE Age" value={result.fireAge} format="years" />
+      </>,
+    )
+    expect(html).toContain('$1,250,000')
+    expect(html).not.toContain('Infinity')
+    expect(html).not.toContain('∞')
+  })
+
+  it('renders the shipped-default result with its real numbers', () => {
+    // Shipped defaults reach FIRE at age 54.4 (rho = 1.07/1.03 - 1; n = 24.3839 -> 24.4).
+    const result = calculateStandardFIRE({
+      currentAge: 30,
+      retirementAge: 55,
+      currentSavings: 100_000,
+      annualContribution: 24_000,
+      annualIncome: 72_000,
+      expectedReturn: 0.07,
+      inflationRate: 0.03,
+      withdrawalRate: 0.04,
+      annualExpenses: 48_000,
+      contributionGrowth: 'inflation',
+    })
+    const html = render(<ResultCard label="FIRE Age" value={result.fireAge} format="years" />)
+    expect(html).toContain('54.4 years')
+  })
+})

--- a/web/src/utils/__tests__/calculations.core.test.ts
+++ b/web/src/utils/__tests__/calculations.core.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  contributionForYear,
+  formatCurrency,
+  formatPercent,
+  futureValue,
+  presentValue,
+  realReturn,
+  yearsToFIRETarget,
+  yearsToTarget,
+} from '../calculations'
+import { realBalanceClosedForm, realRate, yearsToTargetClosedForm } from './oracles'
+
+/**
+ * Algebraic identities on the primitives every calculator is built from.
+ *
+ * These are properties, not recorded outputs: each one states a relationship that must hold for any
+ * inputs, so they fail on a wrong formula rather than merely on a changed one.
+ */
+
+const RATES = [0, 0.01, 0.04, 0.07, 0.12]
+const INFLATIONS = [0, 0.02, 0.03, 0.05]
+const YEARS = [1, 5, 17, 30, 45]
+
+describe('realReturn', () => {
+  it.each(
+    RATES.flatMap((r) => INFLATIONS.map((i) => [r, i] as const)),
+  )('satisfies the Fisher relation (1+rho)(1+i) = (1+r) for r=%s i=%s', (r, i) => {
+    expect((1 + realReturn(r, i)) * (1 + i)).toBeCloseTo(1 + r, 12)
+  })
+
+  it('is zero exactly when the return equals inflation', () => {
+    // The degenerate case the annuity closed form divides by. It must be exactly 0, not merely
+    // near it, or the divide-by-zero guard downstream will not trigger.
+    expect(realReturn(0.05, 0.05)).toBe(0)
+    expect(realReturn(0.03, 0.03)).toBe(0)
+  })
+
+  it('is negative when inflation outruns the return', () => {
+    expect(realReturn(0.02, 0.05)).toBeLessThan(0)
+  })
+})
+
+describe('futureValue / presentValue', () => {
+  it.each(
+    RATES.flatMap((r) => YEARS.map((n) => [r, n] as const)),
+  )('round trips: presentValue(futureValue(PV, 0, r, n), r, n) = PV for r=%s n=%s', (r, n) => {
+    const pv = 250_000
+    expect(presentValue(futureValue(pv, 0, r, n), r, n)).toBeCloseTo(pv, 6)
+  })
+
+  it.each(
+    RATES.flatMap((r) => YEARS.map((n) => [r, n] as const)),
+  )('matches an independent annuity closed form for r=%s n=%s', (r, n) => {
+    // FV = PV(1+r)^n + C((1+r)^n - 1)/r, with the r = 0 limit being PV + Cn.
+    expect(futureValue(100_000, 12_000, r, n)).toBeCloseTo(
+      realBalanceClosedForm(100_000, 12_000, r, 0, n),
+      6,
+    )
+  })
+
+  it('handles the zero-rate limit as simple accumulation', () => {
+    // lim_{r->0} C((1+r)^n - 1)/r = Cn, so 10 years of 12,000 with no growth is exactly 120,000.
+    expect(futureValue(0, 12_000, 0, 10)).toBe(120_000)
+    expect(futureValue(50_000, 20_000, 0, 60)).toBe(1_250_000)
+  })
+
+  it('treats a non-positive horizon as no discounting', () => {
+    expect(presentValue(1_000, 0.07, 0)).toBe(1_000)
+    expect(presentValue(1_000, 0.07, -5)).toBe(1_000)
+  })
+})
+
+describe('yearsToTarget', () => {
+  it.each(
+    [0.01, 0.04, 0.07].flatMap((r) => [500_000, 1_200_000, 3_000_000].map((t) => [r, t] as const)),
+  )('is the inverse of futureValue for r=%s target=%s', (r, target) => {
+    // The defining property: growing for exactly the returned number of years lands on the target.
+    const n = yearsToTarget(100_000, 24_000, r, target)
+    expect(Number.isFinite(n)).toBe(true)
+    expect(futureValue(100_000, 24_000, r, n)).toBeCloseTo(target, 4)
+  })
+
+  it.each(
+    [0.01, 0.04, 0.07].map((r) => [r] as const),
+  )('matches n = ln((C + T*r)/(C + PV*r))/ln(1+r) for r=%s', (r) => {
+    const exact = yearsToTargetClosedForm(100_000, 24_000, r, 1_200_000)
+    expect(exact).not.toBeNull()
+    expect(yearsToTarget(100_000, 24_000, r, 1_200_000)).toBeCloseTo(exact!, 10)
+  })
+
+  it('returns 0 when the target is already met', () => {
+    expect(yearsToTarget(1_500_000, 24_000, 0.05, 1_200_000)).toBe(0)
+    expect(yearsToTarget(1_200_000, 24_000, 0.05, 1_200_000)).toBe(0)
+  })
+
+  it('solves the zero-rate case linearly and exactly', () => {
+    // 50,000 + 20,000n = 1,250,000 has the exact integer solution n = 60.
+    expect(yearsToTarget(50_000, 20_000, 0, 1_250_000)).toBe(60)
+  })
+
+  it('is Infinity when there is no growth and no contribution', () => {
+    expect(yearsToTarget(1_000, 0, 0, 5_000)).toBe(Infinity)
+  })
+
+  it('is Infinity when the balance converges below the target', () => {
+    // rho < 0 gives the stable fixed point B* = -C/rho. With C = 20,000 and rho = -0.0285714...
+    // that ceiling is exactly 700,000, so a 1,250,000 target is unreachable for any n. Infinity is
+    // the mathematically correct answer, not a failure to converge.
+    const rho = realRate(0.02, 0.05)
+    expect(-20_000 / rho).toBeCloseTo(700_000, 6)
+    expect(yearsToTarget(100_000, 20_000, rho, 1_250_000)).toBe(Infinity)
+  })
+
+  it('never reports a target as reached before the balance covers it', () => {
+    // Monotone consistency: one year short of the answer must still be under the target.
+    const n = yearsToTarget(100_000, 24_000, 0.04, 1_200_000)
+    expect(futureValue(100_000, 24_000, 0.04, n - 1)).toBeLessThan(1_200_000)
+  })
+})
+
+describe('yearsToFIRETarget', () => {
+  it.each(
+    [
+      [0.07, 0.03],
+      [0.06, 0.02],
+      [0.09, 0.04],
+    ] as const,
+  )('with inflation growth equals the real-rate closed form for r=%s i=%s', (r, i) => {
+    const exact = yearsToTargetClosedForm(100_000, 24_000, realRate(r, i), 1_200_000)
+    expect(exact).not.toBeNull()
+    expect(yearsToFIRETarget(100_000, 24_000, r, i, 1_200_000, 'inflation')).toBeCloseTo(exact!, 10)
+  })
+
+  it.each(
+    [
+      [0.07, 0.03],
+      [0.06, 0.02],
+      [0.09, 0.04],
+    ] as const,
+  )('with flat growth the solved year lands on the target for r=%s i=%s', (r, i) => {
+    // The flat path has no closed form, so the property asserted is the defining one: the deflated
+    // balance at the returned time is the target. Verified against an independently simulated
+    // nominal series, deflated, rather than against the solver's own internals.
+    const years = yearsToFIRETarget(100_000, 24_000, r, i, 1_200_000, 'flat')
+    expect(Number.isFinite(years)).toBe(true)
+
+    let nominal = 100_000
+    const whole = Math.floor(years)
+    for (let k = 0; k < whole; k++) nominal = nominal * (1 + r) + 24_000
+    const atFloor = nominal / Math.pow(1 + i, whole)
+    const atCeil = (nominal * (1 + r) + 24_000) / Math.pow(1 + i, whole + 1)
+
+    expect(atFloor).toBeLessThan(1_200_000)
+    expect(atCeil).toBeGreaterThanOrEqual(1_200_000)
+  })
+
+  it('flat contributions always take at least as long as inflation-matched ones', () => {
+    // A flat nominal contribution loses purchasing power every year, so it cannot reach a
+    // today's-dollars target sooner than one that holds its value.
+    for (const [r, i] of [
+      [0.07, 0.03],
+      [0.08, 0.02],
+      [0.05, 0.04],
+    ] as const) {
+      const flat = yearsToFIRETarget(100_000, 24_000, r, i, 1_200_000, 'flat')
+      const inflation = yearsToFIRETarget(100_000, 24_000, r, i, 1_200_000, 'inflation')
+      expect(flat).toBeGreaterThanOrEqual(inflation)
+    }
+  })
+
+  it('returns 0 when already funded, for both growth modes', () => {
+    expect(yearsToFIRETarget(1_300_000, 24_000, 0.07, 0.03, 1_200_000, 'inflation')).toBe(0)
+    expect(yearsToFIRETarget(1_300_000, 24_000, 0.07, 0.03, 1_200_000, 'flat')).toBe(0)
+  })
+})
+
+describe('contributionForYear', () => {
+  it('holds purchasing power constant under inflation growth', () => {
+    // The convention the whole inflation identity rests on: the nominal contribution in year k is
+    // C(1+i)^k, so deflating it by (1+i)^k returns exactly C for every k.
+    for (const k of [0, 1, 7, 30]) {
+      const nominal = contributionForYear(24_000, 0.03, k, 'inflation')
+      expect(nominal / Math.pow(1.03, k)).toBeCloseTo(24_000, 8)
+    }
+  })
+
+  it('keeps the nominal amount fixed under flat growth', () => {
+    for (const k of [0, 1, 7, 30]) {
+      expect(contributionForYear(24_000, 0.03, k, 'flat')).toBe(24_000)
+    }
+  })
+
+  it('defaults to inflation growth', () => {
+    expect(contributionForYear(24_000, 0.03, 5)).toBe(contributionForYear(24_000, 0.03, 5, 'inflation'))
+  })
+})
+
+describe('formatters', () => {
+  it('renders whole-dollar currency', () => {
+    expect(formatCurrency(1_234_567)).toBe('$1,234,567')
+    expect(formatCurrency(0)).toBe('$0')
+  })
+
+  it('renders decimals as percentages', () => {
+    expect(formatPercent(0.07)).toBe('7.0%')
+    expect(formatPercent(0.335)).toBe('33.5%')
+    expect(formatPercent(0)).toBe('0.0%')
+  })
+})

--- a/web/src/utils/__tests__/debtPayoff.test.ts
+++ b/web/src/utils/__tests__/debtPayoff.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from 'vitest'
+
+import type { DebtItem } from '../calculations'
+import {
+  calculateAvalanchePayoff,
+  calculateDebtPayoffByTimeline,
+  calculateSnowballPayoff,
+} from '../calculations'
+import { amortize, monthsToPayOffClosedForm } from './oracles'
+
+/**
+ * Debt payoff.
+ *
+ * Issue #45: interest was accrued more than once per month, so a $10,000 card at 20% APR paid at
+ * $500/mo was reported as 34 months and $6,617 of interest, with a first month of $333.33 — exactly
+ * double the correct $166.67. The oracle here is the standard amortization closed form
+ *
+ *   n = -ln(1 - P*m/A) / ln(1+m),   m = APR/12
+ *
+ * cross-checked against a from-scratch monthly recurrence that accrues interest exactly once.
+ */
+
+const card = (balance: number, rate: number, minPayment: number, name = 'Card'): DebtItem => ({
+  id: name.toLowerCase().replace(/\s+/g, '-'),
+  name,
+  balance,
+  rate,
+  minPayment,
+})
+
+describe('single debt', () => {
+  it('matches the closed-form month count across a parameter table', () => {
+    const table: [number, number, number][] = [
+      [10_000, 0.2, 500],
+      [10_000, 0.2, 1_000],
+      [25_000, 0.18, 800],
+      [5_000, 0.24, 250],
+      [40_000, 0.06, 900],
+      [15_000, 0.1499, 400],
+    ]
+    for (const [balance, rate, payment] of table) {
+      const exact = monthsToPayOffClosedForm(balance, rate, payment)
+      expect(exact, `unreachable payoff for ${balance}/${rate}/${payment}`).not.toBeNull()
+      const result = calculateSnowballPayoff([card(balance, rate, payment)], payment)
+      // The lender charges interest before the payment lands, so a fractional month still needs a
+      // whole payment to clear.
+      expect(result.totalMonths).toBe(Math.ceil(exact!))
+    }
+  })
+
+  it('reproduces the $10,000 at 20% APR anchor exactly', () => {
+    // n = -ln(1 - 10000*(0.2/12)/500)/ln(1 + 0.2/12) = 24.53 months, so 25 payments.
+    // Total interest from the once-per-month recurrence is $2,266.
+    const result = calculateSnowballPayoff([card(10_000, 0.2, 500)], 500)
+    expect(result.totalMonths).toBe(25)
+    expect(result.totalInterest).toBe(2_266)
+    expect(result.totalPrincipal).toBe(10_000)
+  })
+
+  it('charges interest exactly once in the first month', () => {
+    // Chosen so the exact monthly interest is a whole number and rounding cannot hide a factor of
+    // two: 12,000 * 0.20/12 = 200 exactly. The #45 defect would report 400 here.
+    const result = calculateSnowballPayoff([card(12_000, 0.2, 500)], 500)
+    expect(result.projections[0].interestPaid).toBe(200)
+  })
+
+  it.each([
+    [10_000, 0.2, 500],
+    [12_000, 0.2, 500],
+    [25_000, 0.18, 800],
+    [5_000, 0.24, 250],
+  ] as const)(
+    'total interest matches an independent recurrence for %s at %s paying %s',
+    (balance, rate, payment) => {
+      const oracle = amortize(balance, rate, payment)
+      const result = calculateSnowballPayoff([card(balance, rate, payment)], payment)
+      expect(result.totalMonths).toBe(oracle.months)
+      expect(result.totalInterest).toBe(Math.round(oracle.totalInterest))
+    },
+  )
+
+  it('accrues no interest at all on a 0% balance', () => {
+    // 6,000 at 0% paying 500 clears in exactly 12 months with nothing added.
+    const result = calculateSnowballPayoff([card(6_000, 0, 500)], 500)
+    expect(result.totalMonths).toBe(12)
+    expect(result.totalInterest).toBe(0)
+  })
+
+  it('a larger payment never costs more interest or takes longer', () => {
+    const results = [400, 500, 750, 1_000, 2_000].map((payment) =>
+      calculateSnowballPayoff([card(10_000, 0.2, payment)], payment),
+    )
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].totalMonths).toBeLessThanOrEqual(results[i - 1].totalMonths)
+      expect(results[i].totalInterest).toBeLessThanOrEqual(results[i - 1].totalInterest)
+    }
+  })
+
+  it('a higher rate never costs less interest', () => {
+    const interest = [0, 0.05, 0.1, 0.2, 0.29].map(
+      (rate) => calculateSnowballPayoff([card(10_000, rate, 500)], 500).totalInterest,
+    )
+    for (let i = 1; i < interest.length; i++) expect(interest[i]).toBeGreaterThanOrEqual(interest[i - 1])
+  })
+})
+
+describe('accounting identities', () => {
+  const debts = [card(10_000, 0.2, 200, 'Card'), card(6_000, 0.08, 150, 'Loan'), card(3_000, 0.26, 100, 'Store')]
+
+  it.each([
+    ['snowball', calculateSnowballPayoff],
+    ['avalanche', calculateAvalanchePayoff],
+  ] as const)('%s repays exactly the principal owed', (_label, run) => {
+    const result = run(debts, 450, 300)
+    expect(result.totalPrincipal).toBe(19_000)
+  })
+
+  it.each([
+    ['snowball', calculateSnowballPayoff],
+    ['avalanche', calculateAvalanchePayoff],
+  ] as const)('%s cumulative totals are the running sums of the monthly rows', (_label, run) => {
+    const result = run(debts, 450, 300)
+    let principal = 0
+    let interest = 0
+    result.projections.forEach((month) => {
+      principal += month.principalPaid
+      interest += month.interestPaid
+      // Rows are individually rounded, so the running sum can drift by well under a dollar a month.
+      expect(Math.abs(month.cumulativePrincipal - principal)).toBeLessThanOrEqual(result.projections.length)
+      expect(Math.abs(month.cumulativeInterest - interest)).toBeLessThanOrEqual(result.projections.length)
+    })
+  })
+
+  it.each([
+    ['snowball', calculateSnowballPayoff],
+    ['avalanche', calculateAvalanchePayoff],
+  ] as const)('%s drives every balance to zero and names every debt exactly once', (_label, run) => {
+    const result = run(debts, 450, 300)
+    const last = result.projections[result.projections.length - 1]
+    expect(last.totalBalance).toBe(0)
+    expect(last.debtsRemaining).toHaveLength(0)
+    expect([...result.payoffOrder].sort()).toEqual(['Card', 'Loan', 'Store'])
+    expect(result.debtMilestones).toHaveLength(3)
+  })
+
+  it.each([
+    ['snowball', calculateSnowballPayoff],
+    ['avalanche', calculateAvalanchePayoff],
+  ] as const)('%s reports the budget it was given', (_label, run) => {
+    expect(run(debts, 450, 300).monthlyPayment).toBe(750)
+  })
+
+  it.each([
+    ['snowball', calculateSnowballPayoff],
+    ['avalanche', calculateAvalanchePayoff],
+  ] as const)('%s numbers months consecutively from one', (_label, run) => {
+    const result = run(debts, 450, 300)
+    result.projections.forEach((month, index) => expect(month.month).toBe(index + 1))
+    expect(result.totalMonths).toBe(result.projections.length)
+  })
+
+  it('total balances fall monotonically', () => {
+    const result = calculateAvalanchePayoff(debts, 450, 300)
+    for (let i = 1; i < result.projections.length; i++) {
+      expect(result.projections[i].totalBalance).toBeLessThanOrEqual(result.projections[i - 1].totalBalance)
+    }
+  })
+})
+
+describe('strategy ordering', () => {
+  const debts = [card(10_000, 0.08, 200, 'Big Low Rate'), card(2_000, 0.26, 100, 'Small High Rate'), card(5_000, 0.15, 150, 'Middle')]
+
+  it('snowball clears the smallest balance first', () => {
+    expect(calculateSnowballPayoff(debts, 450, 300).payoffOrder[0]).toBe('Small High Rate')
+  })
+
+  it('avalanche clears the highest rate first', () => {
+    expect(calculateAvalanchePayoff(debts, 450, 300).payoffOrder[0]).toBe('Small High Rate')
+  })
+
+  it('avalanche orders strictly by descending rate', () => {
+    const ordered = [card(10_000, 0.05, 200, 'A'), card(2_000, 0.3, 100, 'B'), card(5_000, 0.18, 150, 'C')]
+    expect(calculateAvalanchePayoff(ordered, 450, 300).payoffOrder).toEqual(['B', 'C', 'A'])
+  })
+
+  it('snowball orders strictly by ascending balance', () => {
+    const ordered = [card(10_000, 0.05, 200, 'A'), card(2_000, 0.3, 100, 'B'), card(5_000, 0.18, 150, 'C')]
+    expect(calculateSnowballPayoff(ordered, 450, 300).payoffOrder).toEqual(['B', 'C', 'A'])
+  })
+
+  it.each([
+    [[card(10_000, 0.05, 200, 'A'), card(2_000, 0.3, 100, 'B'), card(5_000, 0.18, 150, 'C')], 450, 300],
+    [[card(8_000, 0.07, 150, 'A'), card(12_000, 0.22, 250, 'B')], 400, 0],
+    [[card(3_000, 0.29, 90, 'A'), card(20_000, 0.06, 300, 'B'), card(7_500, 0.14, 180, 'C')], 570, 500],
+    [[card(1_000, 0.1, 50, 'A'), card(1_000, 0.25, 50, 'B'), card(1_000, 0.18, 50, 'C')], 150, 100],
+  ] as const)('avalanche never costs more total interest than snowball (case %#)', (debtSet, minimums, extra) => {
+    // Paying the most expensive balance first is optimal for total interest by an exchange
+    // argument, so the reverse can never hold. The pre-fix bug inverted this.
+    const snowball = calculateSnowballPayoff([...debtSet], minimums, extra)
+    const avalanche = calculateAvalanchePayoff([...debtSet], minimums, extra)
+    expect(avalanche.totalInterest).toBeLessThanOrEqual(snowball.totalInterest)
+  })
+
+  it('the two strategies coincide when every rate is identical', () => {
+    // With no rate differences there is nothing for avalanche to exploit.
+    const flat = [card(9_000, 0.15, 200, 'A'), card(4_000, 0.15, 120, 'B'), card(6_000, 0.15, 150, 'C')]
+    const snowball = calculateSnowballPayoff(flat, 470, 200)
+    const avalanche = calculateAvalanchePayoff(flat, 470, 200)
+    expect(avalanche.totalInterest).toBe(snowball.totalInterest)
+    expect(avalanche.totalMonths).toBe(snowball.totalMonths)
+  })
+
+  it('extra payments never extend the payoff or increase interest', () => {
+    const results = [0, 100, 300, 1_000].map((extra) => calculateAvalanchePayoff(debts, 450, extra))
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].totalMonths).toBeLessThanOrEqual(results[i - 1].totalMonths)
+      expect(results[i].totalInterest).toBeLessThanOrEqual(results[i - 1].totalInterest)
+    }
+  })
+})
+
+describe('calculateDebtPayoffByTimeline', () => {
+  const debts = [card(10_000, 0.2, 200, 'Card'), card(5_000, 0.1, 150, 'Loan')]
+
+  it('finds a payment that clears the debt within the target', () => {
+    const solved = calculateDebtPayoffByTimeline(debts, 24, 'avalanche')
+    expect(solved).not.toBeNull()
+    expect(solved!.result.totalMonths).toBeLessThanOrEqual(24)
+  })
+
+  it('a shorter deadline never requires a smaller payment', () => {
+    const payments = [48, 36, 24, 12].map(
+      (months) => calculateDebtPayoffByTimeline(debts, months, 'avalanche')?.requiredPayment ?? Infinity,
+    )
+    for (let i = 1; i < payments.length; i++) expect(payments[i]).toBeGreaterThanOrEqual(payments[i - 1])
+  })
+
+  it('the payment it reports actually meets the deadline when replayed', () => {
+    // Round trip through the very function the solver is searching over.
+    const solved = calculateDebtPayoffByTimeline(debts, 18, 'snowball')
+    expect(solved).not.toBeNull()
+    const replay = calculateSnowballPayoff(debts, solved!.requiredPayment)
+    expect(replay.totalMonths).toBeLessThanOrEqual(18)
+  })
+})
+
+describe('degenerate inputs', () => {
+  it('reports nothing owed for an empty debt list', () => {
+    const result = calculateSnowballPayoff([], 500)
+    expect(result.totalMonths).toBe(0)
+    expect(result.totalInterest).toBe(0)
+    expect(result.totalPrincipal).toBe(0)
+    expect(result.payoffOrder).toEqual([])
+  })
+
+  it('gives up rather than looping forever when the payment cannot cover interest', () => {
+    // 10,000 at 30% accrues 250/month; paying 100 means the balance grows without bound. The
+    // closed form has no solution here, so the implementation must terminate on its own guard.
+    expect(monthsToPayOffClosedForm(10_000, 0.3, 100)).toBeNull()
+    const result = calculateSnowballPayoff([card(10_000, 0.3, 100)], 100)
+    expect(result.projections.length).toBeGreaterThan(0)
+    expect(Number.isFinite(result.totalMonths)).toBe(true)
+    expect(result.projections[result.projections.length - 1].totalBalance).toBeGreaterThan(10_000)
+  })
+})

--- a/web/src/utils/__tests__/deferredCompensation.test.ts
+++ b/web/src/utils/__tests__/deferredCompensation.test.ts
@@ -1,0 +1,574 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  DeferredCompensationInputs,
+  RetirementAccount,
+  RetirementExpense,
+  RetirementIncomeSource,
+} from '../deferredCompensation'
+import {
+  ORDINARY_INCOME_TAX_RATE,
+  calculateDeferredCompensation,
+  defaultWithdrawalTaxRate,
+} from '../deferredCompensation'
+
+/**
+ * Deferred compensation planner.
+ *
+ * `currentYear` is injectable, so every projection here is deterministic rather than dependent on
+ * the wall clock. Expectations come from the underlying identities: expenses inflate geometrically,
+ * a deferred account distributes its whole balance over its payout window, and every dollar leaving
+ * an account is either spendable income or withdrawal tax.
+ */
+
+const account = (overrides: Partial<RetirementAccount> = {}): RetirementAccount => ({
+  id: 'acct',
+  name: 'Account',
+  type: 'taxable',
+  balance: 500_000,
+  annualContribution: 0,
+  annualReturn: 0.05,
+  availableAge: 0,
+  withdrawalRate: 1,
+  payoutYears: 10,
+  withdrawalTaxRate: 0,
+  ...overrides,
+})
+
+const income = (overrides: Partial<RetirementIncomeSource> = {}): RetirementIncomeSource => ({
+  id: 'job',
+  name: 'Job',
+  type: 'salary',
+  annualAmount: 50_000,
+  startAge: 0,
+  endAge: 200,
+  annualGrowth: 0,
+  isAfterTax: true,
+  taxRate: 0,
+  ...overrides,
+})
+
+const expense = (overrides: Partial<RetirementExpense> = {}): RetirementExpense => ({
+  id: 'extra',
+  name: 'Extra',
+  type: 'custom',
+  annualAmount: 10_000,
+  startAge: 0,
+  ...overrides,
+})
+
+const plan = (overrides: Partial<DeferredCompensationInputs> = {}): DeferredCompensationInputs => ({
+  currentAge: 45,
+  semiRetirementAge: 55,
+  planThroughAge: 90,
+  annualExpenses: 80_000,
+  inflationRate: 0.03,
+  accounts: [account()],
+  incomeSources: [],
+  additionalExpenses: [],
+  withdrawOnlyAfterRetirement: true,
+  reinvestSurplus: false,
+  currentYear: 2025,
+  ...overrides,
+})
+
+describe('defaultWithdrawalTaxRate', () => {
+  it('taxes tax-deferred withdrawals as ordinary income', () => {
+    expect(ORDINARY_INCOME_TAX_RATE).toBe(0.25)
+    expect(defaultWithdrawalTaxRate('deferred')).toBe(0.25)
+    expect(defaultWithdrawalTaxRate('traditional')).toBe(0.25)
+  })
+
+  it('leaves genuinely tax-free and basis-tracked accounts untaxed', () => {
+    // Roth and HSA are tax-free; taxable and savings are zero because the model tracks no cost
+    // basis and taxing the whole withdrawal would overstate it.
+    for (const type of ['roth', 'hsa', 'taxable', 'savings', 'other'] as const) {
+      expect(defaultWithdrawalTaxRate(type)).toBe(0)
+    }
+  })
+})
+
+describe('projection structure', () => {
+  it('covers every age from today through the planning horizon inclusive', () => {
+    const result = calculateDeferredCompensation(plan())
+    expect(result.projections).toHaveLength(46)
+    expect(result.projections[0].age).toBe(45)
+    expect(result.projections.at(-1)!.age).toBe(90)
+  })
+
+  it('derives calendar years from the injected start year', () => {
+    const result = calculateDeferredCompensation(plan({ currentYear: 2030 }))
+    result.projections.forEach((point, index) => expect(point.year).toBe(2030 + index))
+  })
+
+  it('floors fractional ages and never inverts the horizon', () => {
+    const result = calculateDeferredCompensation(
+      plan({ currentAge: 45.9, semiRetirementAge: 40, planThroughAge: 30 }),
+    )
+    expect(result.projections[0].age).toBe(45)
+    expect(result.projections.at(-1)!.age).toBeGreaterThanOrEqual(45)
+  })
+
+  it('reports the starting balance before any growth', () => {
+    expect(calculateDeferredCompensation(plan()).currentBalance).toBe(500_000)
+  })
+
+  it('ignores negative balances rather than subtracting them', () => {
+    const result = calculateDeferredCompensation(
+      plan({ accounts: [account({ balance: -100_000 })] }),
+    )
+    expect(result.currentBalance).toBe(0)
+  })
+})
+
+describe('expense inflation', () => {
+  it('escalates core expenses geometrically from today', () => {
+    const result = calculateDeferredCompensation(plan())
+    result.projections.forEach((point, k) => {
+      expect(point.coreExpenses).toBe(Math.round(80_000 * Math.pow(1.03, k)))
+    })
+  })
+
+  it('starts additional expenses only at their own age, then inflates from today', () => {
+    // The multiplier is anchored to the plan start, not to the expense start, so an expense
+    // beginning at 65 enters at its year-20 inflated value rather than its entered value.
+    const result = calculateDeferredCompensation(
+      plan({ additionalExpenses: [expense({ annualAmount: 10_000, startAge: 65 })] }),
+    )
+    const before = result.projections.find((p) => p.age === 64)!
+    const at = result.projections.find((p) => p.age === 65)!
+    expect(before.additionalExpenses).toBe(0)
+    expect(at.additionalExpenses).toBe(Math.round(10_000 * Math.pow(1.03, 20)))
+  })
+
+  it('totals core and additional expenses', () => {
+    const result = calculateDeferredCompensation(
+      plan({ additionalExpenses: [expense({ startAge: 0 })] }),
+    )
+    result.projections.forEach((point) => {
+      expect(Math.abs(point.expenses - (point.coreExpenses + point.additionalExpenses))).toBeLessThanOrEqual(1)
+    })
+  })
+
+  it('holds expenses flat when inflation is zero', () => {
+    const result = calculateDeferredCompensation(plan({ inflationRate: 0 }))
+    result.projections.forEach((point) => expect(point.coreExpenses).toBe(80_000))
+  })
+})
+
+describe('contribution escalation', () => {
+  it('escalates contributions with inflation while still working', () => {
+    // The #51/#57 fix: contributions are entered in today's dollars, so the nominal amount paid in
+    // year k is C(1+i)^k, matching how expenses are escalated. A balance that grew by only the flat
+    // entered amount would fall short of this by a widening margin.
+    const result = calculateDeferredCompensation(
+      plan({
+        accounts: [account({ balance: 100_000, annualContribution: 20_000, annualReturn: 0.06, withdrawalRate: 0 })],
+        incomeSources: [income({ annualAmount: 500_000 })],
+      }),
+    )
+
+    let balance = 100_000
+    for (let k = 1; k <= 10; k++) {
+      balance = balance * 1.06
+      if (45 + k < 55) balance += 20_000 * Math.pow(1.03, k)
+      const point = result.projections.find((p) => p.age === 45 + k)!
+      expect(point.totalBalance).toBe(Math.round(balance))
+    }
+  })
+
+  it('stops contributing at retirement age', () => {
+    const result = calculateDeferredCompensation(
+      plan({
+        accounts: [account({ balance: 100_000, annualContribution: 20_000, annualReturn: 0, withdrawalRate: 0 })],
+        incomeSources: [income({ annualAmount: 500_000 })],
+      }),
+    )
+    // Ten escalating contributions land at ages 46..54, then nothing further.
+    let expected = 100_000
+    for (let k = 1; k <= 9; k++) expected += 20_000 * Math.pow(1.03, k)
+    expect(result.projections.find((p) => p.age === 54)!.totalBalance).toBe(Math.round(expected))
+    expect(result.projections.find((p) => p.age === 55)!.totalBalance).toBe(Math.round(expected))
+  })
+})
+
+describe('deferred account payouts', () => {
+  const deferred = account({
+    id: 'defcomp',
+    type: 'deferred',
+    balance: 500_000,
+    annualReturn: 0,
+    availableAge: 55,
+    payoutYears: 10,
+    withdrawalTaxRate: 0,
+  })
+
+  it('distributes the whole balance over the payout window, leaving nothing stranded', () => {
+    // With no growth, an even split of 500,000 over 10 years is 50,000 a year and exactly zero left.
+    const result = calculateDeferredCompensation(
+      plan({ accounts: [deferred], incomeSources: [income({ annualAmount: 200_000 })] }),
+    )
+    for (let age = 55; age <= 64; age++) {
+      expect(result.projections.find((p) => p.age === age)!.withdrawals.defcomp).toBe(50_000)
+    }
+    expect(result.projections.find((p) => p.age === 64)!.balances.defcomp).toBe(0)
+    expect(result.projections.find((p) => p.age === 65)!.withdrawals.defcomp).toBe(0)
+  })
+
+  it('pays nothing before the available age or after the window closes', () => {
+    const result = calculateDeferredCompensation(
+      plan({ accounts: [deferred], incomeSources: [income({ annualAmount: 200_000 })] }),
+    )
+    expect(result.projections.find((p) => p.age === 54)!.deferredIncome).toBe(0)
+    expect(result.projections.find((p) => p.age === 65)!.deferredIncome).toBe(0)
+  })
+
+  it('still empties the account when the balance keeps earning', () => {
+    // Each year distributes the remaining balance over the remaining years, so growth is absorbed
+    // into later payments rather than stranded at the end.
+    const result = calculateDeferredCompensation(
+      plan({
+        accounts: [account({ ...deferred, annualReturn: 0.06 })],
+        incomeSources: [income({ annualAmount: 200_000 })],
+      }),
+    )
+    expect(result.projections.find((p) => p.age === 64)!.balances.defcomp).toBe(0)
+  })
+
+  it('pays out over exactly one year when payoutYears is zero or negative', () => {
+    for (const payoutYears of [0, -5]) {
+      const result = calculateDeferredCompensation(
+        plan({
+          accounts: [account({ ...deferred, payoutYears })],
+          incomeSources: [income({ annualAmount: 200_000 })],
+        }),
+      )
+      expect(result.projections.find((p) => p.age === 55)!.withdrawals.defcomp).toBe(500_000)
+      expect(result.projections.find((p) => p.age === 56)!.withdrawals.defcomp).toBe(0)
+    }
+  })
+
+  it('withholds the estimated tax from spendable deferred income', () => {
+    const result = calculateDeferredCompensation(
+      plan({
+        accounts: [account({ ...deferred, withdrawalTaxRate: 0.25 })],
+        incomeSources: [income({ annualAmount: 200_000 })],
+      }),
+    )
+    const point = result.projections.find((p) => p.age === 55)!
+    expect(point.withdrawals.defcomp).toBe(50_000)
+    expect(point.deferredIncome).toBe(37_500)
+    expect(point.withdrawalTaxes).toBe(12_500)
+  })
+
+  it('clamps a nonsensical tax rate into [0, 1]', () => {
+    for (const [rate, expectedNet] of [
+      [-1, 50_000],
+      [2, 0],
+    ] as const) {
+      const result = calculateDeferredCompensation(
+        plan({
+          accounts: [account({ ...deferred, withdrawalTaxRate: rate })],
+          incomeSources: [income({ annualAmount: 200_000 })],
+        }),
+      )
+      expect(result.projections.find((p) => p.age === 55)!.deferredIncome).toBe(expectedNet)
+    }
+  })
+})
+
+describe('income sources', () => {
+  it('pays only between start and end age', () => {
+    const result = calculateDeferredCompensation(
+      plan({ incomeSources: [income({ annualAmount: 40_000, startAge: 62, endAge: 70 })] }),
+    )
+    expect(result.projections.find((p) => p.age === 61)!.outsideIncome).toBe(0)
+    expect(result.projections.find((p) => p.age === 62)!.outsideIncome).toBe(40_000)
+    expect(result.projections.find((p) => p.age === 70)!.outsideIncome).toBe(40_000)
+    expect(result.projections.find((p) => p.age === 71)!.outsideIncome).toBe(0)
+  })
+
+  it('grows by its own rate compounded from today, not from its start age', () => {
+    const result = calculateDeferredCompensation(
+      plan({ incomeSources: [income({ annualAmount: 40_000, startAge: 62, endAge: 70, annualGrowth: 0.02 })] }),
+    )
+    expect(result.projections.find((p) => p.age === 62)!.outsideIncome).toBe(
+      Math.round(40_000 * Math.pow(1.02, 17)),
+    )
+  })
+
+  it('applies the tax rate only to pre-tax sources', () => {
+    const afterTax = calculateDeferredCompensation(
+      plan({ incomeSources: [income({ annualAmount: 40_000, isAfterTax: true, taxRate: 0.3 })] }),
+    )
+    const preTax = calculateDeferredCompensation(
+      plan({ incomeSources: [income({ annualAmount: 40_000, isAfterTax: false, taxRate: 0.3 })] }),
+    )
+    expect(afterTax.projections[0].outsideIncome).toBe(40_000)
+    expect(preTax.projections[0].outsideIncome).toBe(28_000)
+  })
+
+  it('breaks income out by source consistently with the total', () => {
+    const result = calculateDeferredCompensation(
+      plan({
+        incomeSources: [
+          income({ id: 'a', annualAmount: 30_000 }),
+          income({ id: 'b', annualAmount: 12_000 }),
+        ],
+      }),
+    )
+    const point = result.projections[0]
+    const summed = Object.values(point.incomeBySource).reduce((sum, value) => sum + value, 0)
+    expect(Math.abs(summed - point.outsideIncome)).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('gap withdrawals', () => {
+  it('withdraws exactly the shortfall when withdrawals are untaxed', () => {
+    const result = calculateDeferredCompensation(
+      plan({
+        inflationRate: 0,
+        accounts: [account({ balance: 1_000_000, annualReturn: 0, withdrawalRate: 1 })],
+        incomeSources: [income({ annualAmount: 30_000 })],
+      }),
+    )
+    const point = result.projections.find((p) => p.age === 55)!
+    expect(point.expenses).toBe(80_000)
+    expect(point.outsideIncome).toBe(30_000)
+    expect(point.withdrawals.acct).toBe(50_000)
+    expect(point.surplus).toBe(0)
+  })
+
+  it('grosses the withdrawal up so the spendable remainder still covers the gap', () => {
+    // A 50,000 gap at a 20% withdrawal tax needs 62,500 gross: 62,500 * 0.8 = 50,000.
+    const result = calculateDeferredCompensation(
+      plan({
+        inflationRate: 0,
+        accounts: [account({ balance: 1_000_000, annualReturn: 0, withdrawalRate: 1, withdrawalTaxRate: 0.2 })],
+        incomeSources: [income({ annualAmount: 30_000 })],
+      }),
+    )
+    const point = result.projections.find((p) => p.age === 55)!
+    expect(point.withdrawals.acct).toBe(62_500)
+    expect(point.portfolioWithdrawals).toBe(50_000)
+    expect(point.withdrawalTaxes).toBe(12_500)
+    expect(point.surplus).toBe(0)
+  })
+
+  it('takes nothing before retirement when withdrawals are restricted', () => {
+    const result = calculateDeferredCompensation(
+      plan({ withdrawOnlyAfterRetirement: true, accounts: [account({ balance: 1_000_000 })] }),
+    )
+    result.projections
+      .filter((p) => p.age < 55)
+      .forEach((p) => expect(p.portfolioWithdrawals).toBe(0))
+  })
+
+  it('covers a pre-retirement gap when withdrawals are unrestricted', () => {
+    const result = calculateDeferredCompensation(
+      plan({ withdrawOnlyAfterRetirement: false, accounts: [account({ balance: 1_000_000 })] }),
+    )
+    expect(result.projections[0].portfolioWithdrawals).toBeGreaterThan(0)
+  })
+
+  it('respects the per-account availability age', () => {
+    const result = calculateDeferredCompensation(
+      plan({ accounts: [account({ balance: 1_000_000, availableAge: 60 })] }),
+    )
+    expect(result.projections.find((p) => p.age === 59)!.portfolioWithdrawals).toBe(0)
+    expect(result.projections.find((p) => p.age === 60)!.portfolioWithdrawals).toBeGreaterThan(0)
+  })
+
+  it('records what the per-account withdrawal-rate cap held back', () => {
+    // A 4% cap on 1,000,000 releases 40,000 against an 80,000 gap, so 40,000 stays put and is
+    // reported rather than silently dropped.
+    const result = calculateDeferredCompensation(
+      plan({
+        inflationRate: 0,
+        accounts: [account({ balance: 1_000_000, annualReturn: 0, withdrawalRate: 0.04 })],
+      }),
+    )
+    const point = result.projections.find((p) => p.age === 55)!
+    expect(point.withdrawals.acct).toBe(40_000)
+    expect(point.policyLimitedWithdrawals).toBe(40_000)
+    expect(point.surplus).toBe(-40_000)
+  })
+
+  it('never withdraws more than the account holds', () => {
+    const result = calculateDeferredCompensation(
+      plan({ inflationRate: 0, accounts: [account({ balance: 30_000, annualReturn: 0, withdrawalRate: 1 })] }),
+    )
+    const point = result.projections.find((p) => p.age === 55)!
+    expect(point.withdrawals.acct).toBeLessThanOrEqual(30_000)
+    expect(point.balances.acct).toBe(0)
+  })
+
+  it('never reports a negative balance', () => {
+    const result = calculateDeferredCompensation(
+      plan({ accounts: [account({ balance: 100_000, withdrawalRate: 1 })] }),
+    )
+    result.projections.forEach((point) => {
+      expect(point.totalBalance).toBeGreaterThanOrEqual(0)
+      Object.values(point.balances).forEach((balance) => expect(balance).toBeGreaterThanOrEqual(0))
+    })
+  })
+})
+
+describe('accounting identities', () => {
+  const rich = () =>
+    calculateDeferredCompensation(
+      plan({
+        accounts: [
+          account({ id: 'defcomp', type: 'deferred', balance: 400_000, availableAge: 55, payoutYears: 10, withdrawalTaxRate: 0.25 }),
+          account({ id: 'brokerage', balance: 800_000, annualReturn: 0.05, withdrawalRate: 1 }),
+        ],
+        incomeSources: [income({ id: 'ss', annualAmount: 30_000, startAge: 67, endAge: 200 })],
+        additionalExpenses: [expense({ id: 'travel', annualAmount: 12_000, startAge: 55 })],
+      }),
+    )
+
+  it('spendable income is outside income plus after-tax payouts and withdrawals', () => {
+    rich().projections.forEach((point) => {
+      const parts = point.outsideIncome + point.deferredIncome + point.portfolioWithdrawals
+      expect(Math.abs(point.totalIncome - parts)).toBeLessThanOrEqual(2)
+    })
+  })
+
+  it('surplus is income minus expenses', () => {
+    rich().projections.forEach((point) => {
+      expect(Math.abs(point.surplus - (point.totalIncome - point.expenses))).toBeLessThanOrEqual(2)
+    })
+  })
+
+  it('every gross dollar withdrawn is either spendable or tax', () => {
+    // The tax identity: sum(gross) === deferredIncome + portfolioWithdrawals + withdrawalTaxes.
+    rich().projections.forEach((point) => {
+      const gross = Object.values(point.withdrawals).reduce((sum, value) => sum + value, 0)
+      const accounted = point.deferredIncome + point.portfolioWithdrawals + point.withdrawalTaxes
+      expect(Math.abs(gross - accounted)).toBeLessThanOrEqual(3)
+    })
+  })
+
+  it('reports the retirement-year figures as the headline', () => {
+    const result = rich()
+    const atRetirement = result.projections.find((p) => p.age === 55)!
+    expect(result.balanceAtSemiRetirement).toBe(atRetirement.totalBalance)
+    expect(result.firstYearIncome).toBe(atRetirement.totalIncome)
+    expect(result.firstYearSurplus).toBe(atRetirement.surplus)
+    expect(result.endingBalance).toBe(result.projections.at(-1)!.totalBalance)
+  })
+})
+
+describe('funded-year bookkeeping', () => {
+  it('counts every retirement year when the plan never falls short', () => {
+    const result = calculateDeferredCompensation(
+      plan({ incomeSources: [income({ annualAmount: 1_000_000, annualGrowth: 0.1 })] }),
+    )
+    expect(result.firstShortfallAge).toBeNull()
+    expect(result.retirementYears).toBe(36)
+    expect(result.fundedYears).toBe(36)
+    expect(result.yearsFullyCovered).toBe(36)
+  })
+
+  it('stops the consecutive count at the first shortfall', () => {
+    const result = calculateDeferredCompensation(
+      plan({ accounts: [account({ balance: 200_000, annualReturn: 0, withdrawalRate: 1 })] }),
+    )
+    expect(result.firstShortfallAge).not.toBeNull()
+    expect(result.fundedYears).toBe(result.projections.findIndex((p) => p.age === result.firstShortfallAge!) -
+      result.projections.findIndex((p) => p.age === 55))
+  })
+
+  it('never counts consecutive funded years above total covered years', () => {
+    // fundedYears stops at the first gap; yearsFullyCovered keeps counting afterwards, so the
+    // former can never exceed the latter.
+    for (const balance of [50_000, 200_000, 800_000, 5_000_000]) {
+      const result = calculateDeferredCompensation(
+        plan({ accounts: [account({ balance, annualReturn: 0.05, withdrawalRate: 1 })] }),
+      )
+      expect(result.fundedYears).toBeLessThanOrEqual(result.yearsFullyCovered)
+      expect(result.yearsFullyCovered).toBeLessThanOrEqual(result.retirementYears)
+    }
+  })
+
+  it('reports the first shortfall age exactly when one exists', () => {
+    for (const balance of [50_000, 200_000, 800_000, 5_000_000]) {
+      const result = calculateDeferredCompensation(
+        plan({ accounts: [account({ balance, annualReturn: 0.05, withdrawalRate: 1 })] }),
+      )
+      const shortfall = result.projections.find((p) => p.age >= 55 && p.surplus < 0)
+      expect(result.firstShortfallAge).toBe(shortfall?.age ?? null)
+    }
+  })
+
+  it('a larger portfolio never funds fewer consecutive years', () => {
+    const funded = [100_000, 500_000, 1_000_000, 3_000_000].map(
+      (balance) =>
+        calculateDeferredCompensation(
+          plan({ accounts: [account({ balance, annualReturn: 0.05, withdrawalRate: 1 })] }),
+        ).fundedYears,
+    )
+    for (let i = 1; i < funded.length; i++) expect(funded[i]).toBeGreaterThanOrEqual(funded[i - 1])
+  })
+})
+
+describe('surplus reinvestment', () => {
+  it('leaves the balance untouched when reinvestment is off', () => {
+    const off = calculateDeferredCompensation(
+      plan({ reinvestSurplus: false, incomeSources: [income({ annualAmount: 200_000 })] }),
+    )
+    const on = calculateDeferredCompensation(
+      plan({ reinvestSurplus: true, incomeSources: [income({ annualAmount: 200_000 })] }),
+    )
+    expect(on.endingBalance).toBeGreaterThan(off.endingBalance)
+  })
+
+  it('spreads the surplus across accounts in proportion to their balances', () => {
+    const result = calculateDeferredCompensation(
+      plan({
+        inflationRate: 0,
+        reinvestSurplus: true,
+        withdrawOnlyAfterRetirement: false,
+        accounts: [
+          account({ id: 'big', balance: 300_000, annualReturn: 0, withdrawalRate: 0 }),
+          account({ id: 'small', balance: 100_000, annualReturn: 0, withdrawalRate: 0 }),
+        ],
+        incomeSources: [income({ annualAmount: 120_000 })],
+      }),
+    )
+    // A 40,000 surplus splits 3:1, so 30,000 and 10,000.
+    const first = result.projections[0]
+    expect(first.surplus).toBe(40_000)
+    expect(first.balances.big).toBe(330_000)
+    expect(first.balances.small).toBe(110_000)
+  })
+})
+
+describe('degenerate inputs', () => {
+  it('handles a plan with no accounts at all', () => {
+    const result = calculateDeferredCompensation(plan({ accounts: [] }))
+    expect(result.currentBalance).toBe(0)
+    expect(result.endingBalance).toBe(0)
+    expect(result.projections.length).toBeGreaterThan(0)
+    result.projections.forEach((point) => expect(Number.isFinite(point.surplus)).toBe(true))
+  })
+
+  it('produces at least one projection when every age is the same', () => {
+    const result = calculateDeferredCompensation(
+      plan({ currentAge: 60, semiRetirementAge: 60, planThroughAge: 60 }),
+    )
+    expect(result.projections).toHaveLength(1)
+    expect(result.retirementYears).toBe(1)
+  })
+
+  it('does not produce NaN under a -100% return or worse', () => {
+    const result = calculateDeferredCompensation(
+      plan({ accounts: [account({ annualReturn: -5 })], inflationRate: -3 }),
+    )
+    result.projections.forEach((point) => {
+      expect(Number.isNaN(point.totalBalance)).toBe(false)
+      expect(Number.isNaN(point.expenses)).toBe(false)
+      expect(Number.isFinite(point.surplus)).toBe(true)
+    })
+  })
+})

--- a/web/src/utils/__tests__/excelExport.test.ts
+++ b/web/src/utils/__tests__/excelExport.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateBaristaFIRE,
+  calculateCoastFIRE,
+  calculateFatFIRE,
+  calculateInvestmentGrowth,
+  calculateLeanFIRE,
+  calculateReverseFIRE,
+  calculateSnowballPayoff,
+  calculateStandardFIRE,
+  calculateWithdrawal,
+} from '../calculations'
+import type { FIREInputs } from '../calculations'
+import { prepareResultsForExport } from '../excelExport'
+
+/**
+ * `prepareResultsForExport` enumerates every scalar on a result object and picks percent/currency
+ * formatting by substring match on the key name. That design means **any new scalar field on a
+ * result type silently appears in the user's spreadsheet**, formatted by whatever its name happens
+ * to contain.
+ *
+ * It bit the cross-platform audit three separate times: a new boolean leaked a row into the export,
+ * `'rate'` matched while `'ratio'` did not so percent formatting was silently dropped, and a null
+ * field emitted a blank row.
+ *
+ * The key-set guards below are the point of this file. They fail when a result type gains or loses
+ * an exported field, forcing a conscious decision about the workbook rather than letting it change
+ * by accident.
+ */
+
+const DEFAULTS: FIREInputs = {
+  currentAge: 30,
+  retirementAge: 55,
+  currentSavings: 100_000,
+  annualContribution: 24_000,
+  annualIncome: 72_000,
+  expectedReturn: 0.07,
+  inflationRate: 0.03,
+  withdrawalRate: 0.04,
+  annualExpenses: 48_000,
+  contributionGrowth: 'inflation',
+}
+
+describe('exported key sets', () => {
+  // If one of these fails, a result type gained or lost a scalar. Decide whether it belongs in the
+  // user's workbook and update the list deliberately — do not just paste the new set in.
+  it.each([
+    [
+      'StandardFIRE',
+      () => calculateStandardFIRE(DEFAULTS),
+      ['fireNumber', 'yearsToFIRE', 'fireAge', 'savingsRate', 'monthlyContribution', 'coastFireNumber'],
+    ],
+    [
+      'LeanFIRE',
+      () => calculateLeanFIRE(DEFAULTS),
+      ['fireNumber', 'yearsToFIRE', 'fireAge', 'savingsRate', 'monthlyContribution', 'coastFireNumber', 'isLean', 'leanThreshold'],
+    ],
+    [
+      'FatFIRE',
+      () => calculateFatFIRE(DEFAULTS),
+      ['fireNumber', 'yearsToFIRE', 'fireAge', 'savingsRate', 'monthlyContribution', 'coastFireNumber', 'isFat', 'fatThreshold'],
+    ],
+    [
+      'CoastFIRE',
+      () => calculateCoastFIRE(30, 55, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04),
+      ['coastNumber', 'yearsToCoast', 'alreadyCoasting', 'fireNumber'],
+    ],
+    [
+      'BaristaFIRE',
+      () => calculateBaristaFIRE(30, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04, 20_000),
+      ['baristaNumber', 'fullFireNumber', 'yearsToBaristaFIRE', 'partTimeIncomeNeeded', 'savingsFromPartTime'],
+    ],
+    [
+      'Withdrawal',
+      () => calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30),
+      ['portfolioLongevity', 'horizonFundedRatio', 'annualWithdrawal', 'monthlyWithdrawal', 'endingBalance'],
+    ],
+    [
+      'ReverseFIRE',
+      () => calculateReverseFIRE(30, 55, 100_000, 48_000, 0.07, 0.03, 0.04),
+      ['fireNumber', 'yearsToFIRE', 'requiredAnnualSavings', 'requiredMonthlySavings', 'alreadyAchievable', 'currentWillGrowTo'],
+    ],
+    [
+      'InvestmentGrowth',
+      () => calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30),
+      ['savingsRate', 'annualContribution', 'monthlyContribution', 'finalNominalBalance', 'finalInflationAdjustedBalance', 'totalInvested', 'totalGrowth', 'inflationImpact'],
+    ],
+    [
+      'DebtPayoff',
+      () => calculateSnowballPayoff([{ id: '1', name: 'Card', balance: 10_000, rate: 0.2, minPayment: 200 }], 500),
+      ['totalMonths', 'totalInterest', 'totalPrincipal', 'monthlyPayment'],
+    ],
+  ] as const)('%s exports exactly its known scalar fields', (_label, build, expected) => {
+    const { values } = prepareResultsForExport(build())
+    expect(Object.keys(values).sort()).toEqual([...expected].sort())
+  })
+})
+
+describe('structural filtering', () => {
+  it('omits arrays, which belong on their own sheets', () => {
+    const { values } = prepareResultsForExport(calculateStandardFIRE(DEFAULTS))
+    expect(values).not.toHaveProperty('projections')
+  })
+
+  it('omits nested objects', () => {
+    // StandardFIRE carries a `retirementGoal` object that must not be flattened into rows.
+    const { values } = prepareResultsForExport(calculateStandardFIRE(DEFAULTS))
+    expect(values).not.toHaveProperty('retirementGoal')
+  })
+
+  it('omits an empty array as readily as a populated one', () => {
+    const { values } = prepareResultsForExport({ rows: [], total: 5 })
+    expect(Object.keys(values)).toEqual(['total'])
+  })
+})
+
+describe('non-finite values', () => {
+  it('replaces Infinity with wording rather than writing "$∞" into a cell', () => {
+    const unreachable = calculateStandardFIRE({
+      ...DEFAULTS,
+      expectedReturn: 0.02,
+      inflationRate: 0.05,
+      annualContribution: 20_000,
+      annualExpenses: 50_000,
+    })
+    expect(unreachable.fireAge).toBe(Infinity)
+
+    const { values, formats } = prepareResultsForExport(unreachable)
+    expect(values.fireAge).toBe('Not reachable')
+    expect(values.yearsToFIRE).toBe('Not reachable')
+    // No numeric format is attached, so nothing tries to render the text as currency or years.
+    expect(formats).not.toHaveProperty('fireAge')
+    expect(formats).not.toHaveProperty('yearsToFIRE')
+  })
+
+  it('handles -Infinity and NaN the same way', () => {
+    const { values } = prepareResultsForExport({ a: -Infinity, b: NaN, c: 42 })
+    expect(values.a).toBe('Not reachable')
+    expect(values.b).toBe('Not reachable')
+    expect(values.c).toBe(42)
+  })
+
+  it('leaves finite values, including zero and negatives, as numbers', () => {
+    const { values } = prepareResultsForExport({ zero: 0, negative: -1_500 })
+    expect(values.zero).toBe(0)
+    expect(values.negative).toBe(-1_500)
+  })
+})
+
+describe('format inference by key name', () => {
+  it.each([
+    ['withdrawalRate', 'percent'],
+    ['savingsRate', 'percent'],
+    ['horizonFundedRatio', 'percent'],
+    ['percentComplete', 'percent'],
+    ['progress', 'percent'],
+  ] as const)('%s is formatted as a percentage', (key, expected) => {
+    expect(prepareResultsForExport({ [key]: 0.04 }).formats[key]).toBe(expected)
+  })
+
+  it('formats horizonFundedRatio as a percentage', () => {
+    // The audit's second bite: 'rate' matched but 'ratio' did not, so this ratio silently exported
+    // as a bare number. 'ratio' is now in the percent list and must stay there.
+    const { formats } = prepareResultsForExport(calculateWithdrawal(1_000_000, 0.05, 0.03, 0.03, 40))
+    expect(formats.horizonFundedRatio).toBe('percent')
+  })
+
+  it.each([
+    ['fireNumber', 'currency'],
+    ['endingBalance', 'currency'],
+    ['annualWithdrawal', 'currency'],
+    ['totalInterest', 'currency'],
+    ['monthlyPayment', 'currency'],
+    ['requiredAnnualSavings', 'currency'],
+    ['totalCost', 'currency'],
+    ['totalPrincipal', 'currency'],
+    ['portfolioValue', 'currency'],
+  ] as const)('%s is formatted as currency', (key, expected) => {
+    expect(prepareResultsForExport({ [key]: 1_000 }).formats[key]).toBe(expected)
+  })
+
+  it.each([
+    ['yearsToFIRE', 'years'],
+    ['fireAge', 'years'],
+    ['portfolioLongevity', 'years'],
+    ['monthsRemaining', 'years'],
+  ] as const)('%s is formatted as a duration', (key, expected) => {
+    expect(prepareResultsForExport({ [key]: 25 }).formats[key]).toBe(expected)
+  })
+
+  it('falls back to plain number for an unrecognised key', () => {
+    expect(prepareResultsForExport({ mysteryField: 7 }).formats.mysteryField).toBe('number')
+  })
+
+  it('checks percent before currency, so a key matching both is a percentage', () => {
+    // 'savingsRate' contains both 'savings' (currency) and 'rate' (percent). Percent wins because
+    // it is tested first, which is the behaviour the result cards depend on.
+    expect(prepareResultsForExport({ savingsRate: 0.33 }).formats.savingsRate).toBe('percent')
+  })
+
+  it('matches key names case-insensitively', () => {
+    expect(prepareResultsForExport({ TotalInterest: 500 }).formats.TotalInterest).toBe('currency')
+    expect(prepareResultsForExport({ WITHDRAWALRATE: 0.04 }).formats.WITHDRAWALRATE).toBe('percent')
+  })
+
+  it('attaches no format to non-numeric values', () => {
+    const { values, formats } = prepareResultsForExport({ label: 'Standard', flag: true })
+    expect(values.label).toBe('Standard')
+    expect(values.flag).toBe(true)
+    expect(formats).not.toHaveProperty('label')
+    expect(formats).not.toHaveProperty('flag')
+  })
+})
+
+describe('known hazards, pinned as characterization', () => {
+  /*
+   * The two behaviours below are pre-existing and are NOT changed by this test-only work. They are
+   * pinned so the next person sees them stated rather than rediscovering them from a user's
+   * spreadsheet. Both deserve their own issue and their own fix.
+   */
+
+  it('booleans still reach the workbook as untyped rows', () => {
+    // `typeof true` is neither array nor object, so a boolean passes the filter and lands in the
+    // export with no format hint. LeanFIRE, FatFIRE and CoastFIRE all pass raw results containing
+    // isLean / isFat / alreadyCoasting straight through.
+    const lean = prepareResultsForExport(calculateLeanFIRE(DEFAULTS))
+    expect(lean.values.isLean).toBe(false)
+    expect(lean.formats).not.toHaveProperty('isLean')
+
+    const coast = prepareResultsForExport(
+      calculateCoastFIRE(30, 55, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04),
+    )
+    expect(coast.values.alreadyCoasting).toBe(false)
+    expect(coast.formats).not.toHaveProperty('alreadyCoasting')
+  })
+
+  it('null still emits a row', () => {
+    // The guard is `typeof value === 'object' && value !== null`, so null falls through to
+    // `values[key] = null` and produces a blank row. Callers work around this at the call site
+    // (DeferredCompensation.tsx uses `?? 0`) rather than in this helper.
+    const { values, formats } = prepareResultsForExport({ firstShortfallAge: null, fireNumber: 1_200_000 })
+    expect(values).toHaveProperty('firstShortfallAge')
+    expect(values.firstShortfallAge).toBeNull()
+    expect(formats).not.toHaveProperty('firstShortfallAge')
+  })
+
+  it('undefined is dropped, unlike null', () => {
+    // Object.entries skips nothing, but `typeof undefined` is 'undefined', so it is stored as a
+    // value with no format. Pinned to document the asymmetry with null above.
+    const { values } = prepareResultsForExport({ maybe: undefined, sure: 1 })
+    expect(values.maybe).toBeUndefined()
+    expect(values.sure).toBe(1)
+  })
+
+  it('a threshold constant is exported as if it were a result', () => {
+    // leanThreshold / fatThreshold are configuration, not outcomes, but they are scalars on the
+    // result type so they reach the user's workbook. Documented, not changed.
+    const { values, formats } = prepareResultsForExport(calculateLeanFIRE(DEFAULTS))
+    expect(values.leanThreshold).toBe(40_000)
+    expect(formats.leanThreshold).toBe('number')
+  })
+
+  it('totalMonths is exported as CURRENCY, not a duration', () => {
+    /*
+     * FINDING (live, user-visible, pre-existing — reported, deliberately not fixed here).
+     *
+     * This is the same substring-collision class as the 'rate' / 'ratio' bug the audit already hit,
+     * and it is currently shipping.
+     *
+     * 'totalmonths' contains 'total', which is in currencyKeys. currencyKeys is tested BEFORE
+     * timeKeys, so the intended 'months' match in timeKeys is never reached. The 'currency' hint
+     * maps to numFmt '$#,##0' (getExcelFormat), so a debt payoff that takes 25 months is written
+     * into the user's spreadsheet as "$25".
+     *
+     * DebtPayoff.tsx passes the raw result to prepareResultsForExport and forwards the derived
+     * formats to the workbook without overriding them, so nothing downstream corrects this.
+     *
+     * Asserted as the WRONG value on purpose. When this is fixed, this test SHOULD fail — that is
+     * the signal, and the expectation below should flip to 'years'.
+     */
+    const debt = calculateSnowballPayoff([{ id: '1', name: 'Card', balance: 10_000, rate: 0.2, minPayment: 200 }], 500)
+    expect(debt.totalMonths).toBe(25)
+
+    const { formats } = prepareResultsForExport(debt)
+    expect(formats.totalMonths).toBe('currency')
+
+    // The genuinely-currency siblings are unaffected and correct.
+    expect(formats.totalInterest).toBe('currency')
+    expect(formats.totalPrincipal).toBe('currency')
+    expect(formats.monthlyPayment).toBe('currency')
+  })
+})
+
+describe('empty and degenerate input', () => {
+  it('returns empty maps for an empty result object', () => {
+    const { values, formats } = prepareResultsForExport({})
+    expect(values).toEqual({})
+    expect(formats).toEqual({})
+  })
+
+  it('does not invent rows for a result made only of arrays and objects', () => {
+    const { values } = prepareResultsForExport({ rows: [1, 2], nested: { a: 1 } })
+    expect(values).toEqual({})
+  })
+})

--- a/web/src/utils/__tests__/fireVariants.test.ts
+++ b/web/src/utils/__tests__/fireVariants.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'vitest'
+
+import type { FIREInputs, ProjectionPoint } from '../calculations'
+import {
+  calculateBaristaFIRE,
+  calculateCoastFIRE,
+  calculateFatFIRE,
+  calculateLeanFIRE,
+  calculateStandardFIRE,
+  presentValue,
+  realReturn,
+} from '../calculations'
+import { realBalanceClosedForm, realRate, yearsToTargetClosedForm } from './oracles'
+
+/**
+ * FIRE variants: the crossing invariant, threshold classification, and monotonicity.
+ *
+ * The crossing invariant is issue #46's regression guard: the age at which the deflated projection
+ * series crosses the FIRE target must equal the headline FIRE age. A calculator can be wrong in two
+ * independent places, so agreement between them is a real constraint rather than a restatement.
+ */
+
+const DEFAULTS: FIREInputs = {
+  currentAge: 30,
+  retirementAge: 55,
+  currentSavings: 100_000,
+  annualContribution: 24_000,
+  annualIncome: 72_000,
+  expectedReturn: 0.07,
+  inflationRate: 0.03,
+  withdrawalRate: 0.04,
+  annualExpenses: 48_000,
+  contributionGrowth: 'inflation',
+}
+
+/**
+ * Asserts that the projection series brackets `target` exactly at `headlineAge`: the last whole year
+ * before it is short, and the first whole year at or after it is funded.
+ */
+function expectCrossingMatchesHeadline(
+  projections: ProjectionPoint[],
+  headlineAge: number,
+  target: number,
+) {
+  const below = projections.find((p) => p.age === Math.floor(headlineAge))
+  const above = projections.find((p) => p.age === Math.ceil(headlineAge))
+  expect(below, `no projection at age ${Math.floor(headlineAge)}`).toBeDefined()
+  expect(above, `no projection at age ${Math.ceil(headlineAge)}`).toBeDefined()
+  expect(below!.inflationAdjusted).toBeLessThan(target)
+  expect(above!.inflationAdjusted).toBeGreaterThanOrEqual(target)
+}
+
+const SCENARIOS: { label: string; inputs: FIREInputs }[] = [
+  { label: 'shipped defaults', inputs: DEFAULTS },
+  { label: 'flat contributions', inputs: { ...DEFAULTS, contributionGrowth: 'flat' } },
+  { label: 'older saver', inputs: { ...DEFAULTS, currentAge: 42, retirementAge: 60, currentSavings: 250_000, annualContribution: 36_000, annualExpenses: 80_000 } },
+  { label: 'lean spender', inputs: { ...DEFAULTS, annualExpenses: 32_000 } },
+  { label: 'fat spender', inputs: { ...DEFAULTS, annualExpenses: 120_000, annualContribution: 60_000, annualIncome: 200_000 } },
+  { label: 'zero inflation', inputs: { ...DEFAULTS, inflationRate: 0 } },
+  { label: 'high inflation', inputs: { ...DEFAULTS, expectedReturn: 0.09, inflationRate: 0.06 } },
+  { label: 'no starting savings', inputs: { ...DEFAULTS, currentSavings: 0 } },
+]
+
+describe('calculateStandardFIRE', () => {
+  it.each(SCENARIOS.map((s) => [s.label, s.inputs] as const))(
+    '%s: the projection crosses the target exactly at the headline FIRE age',
+    (_label, inputs) => {
+      const result = calculateStandardFIRE(inputs)
+      expect(Number.isFinite(result.fireAge)).toBe(true)
+      expectCrossingMatchesHeadline(result.projections, result.fireAge, result.fireNumber)
+    },
+  )
+
+  it.each(SCENARIOS.map((s) => [s.label, s.inputs] as const))(
+    '%s: fireNumber * withdrawalRate returns annual expenses',
+    (_label, inputs) => {
+      const result = calculateStandardFIRE(inputs)
+      expect(result.fireNumber * inputs.withdrawalRate).toBeCloseTo(inputs.annualExpenses, 6)
+    },
+  )
+
+  it.each(SCENARIOS.map((s) => [s.label, s.inputs] as const))(
+    '%s: fireAge is currentAge plus yearsToFIRE',
+    (_label, inputs) => {
+      const result = calculateStandardFIRE(inputs)
+      expect(result.fireAge).toBeCloseTo(inputs.currentAge + result.yearsToFIRE, 9)
+    },
+  )
+
+  it('savings rate is contribution over income', () => {
+    expect(calculateStandardFIRE(DEFAULTS).savingsRate).toBeCloseTo(24_000 / 72_000, 12)
+  })
+
+  it('savings rate is zero rather than NaN when income is zero', () => {
+    // Guarding the divide-by-zero matters: NaN would propagate into the export and the chart.
+    const result = calculateStandardFIRE({ ...DEFAULTS, annualIncome: 0 })
+    expect(result.savingsRate).toBe(0)
+    expect(Number.isNaN(result.savingsRate)).toBe(false)
+  })
+
+  it('coast number is the FIRE target discounted at the real rate to the target retirement age', () => {
+    const result = calculateStandardFIRE(DEFAULTS)
+    const expected = presentValue(1_200_000, realReturn(0.07, 0.03), 25)
+    expect(result.coastFireNumber).toBe(Math.round(expected))
+  })
+
+  it('matches the closed-form year count with inflation-escalating contributions', () => {
+    // n = ln((C + T*rho)/(C + PV*rho))/ln(1+rho) with rho = 1.07/1.03 - 1.
+    const exact = yearsToTargetClosedForm(100_000, 24_000, realRate(0.07, 0.03), 1_200_000)
+    expect(exact).not.toBeNull()
+    expect(calculateStandardFIRE(DEFAULTS).yearsToFIRE).toBe(Math.round(exact! * 10) / 10)
+  })
+
+  it('reports the shipped-default anchor of 54.4', () => {
+    // Derived, not recorded: rho = 0.038834951456..., n = 24.3838964605..., 30 + n rounds to 54.4.
+    expect(calculateStandardFIRE(DEFAULTS).fireAge).toBe(54.4)
+  })
+
+  it('brackets the anchor crossing between ages 54 and 55', () => {
+    // Closed form in today's dollars: PV(1+rho)^k + C((1+rho)^k - 1)/rho at k = 24 and k = 25.
+    const result = calculateStandardFIRE(DEFAULTS)
+    const at54 = result.projections.find((p) => p.age === 54)!
+    const at55 = result.projections.find((p) => p.age === 55)!
+    expect(at54.inflationAdjusted).toBe(Math.round(realBalanceClosedForm(100_000, 24_000, 0.07, 0.03, 24)))
+    expect(at55.inflationAdjusted).toBe(Math.round(realBalanceClosedForm(100_000, 24_000, 0.07, 0.03, 25)))
+    expect(at54.inflationAdjusted).toBeLessThan(1_200_000)
+    expect(at55.inflationAdjusted).toBeGreaterThan(1_200_000)
+  })
+
+  it('returns 0 years when already funded', () => {
+    const result = calculateStandardFIRE({ ...DEFAULTS, currentSavings: 1_500_000 })
+    expect(result.yearsToFIRE).toBe(0)
+    expect(result.fireAge).toBe(30)
+  })
+
+  it('reports Infinity when the target sits above the reachable ceiling', () => {
+    // 2% return against 5% inflation converges to -C/rho = 700,000, below the 1.25M target.
+    const result = calculateStandardFIRE({
+      ...DEFAULTS,
+      expectedReturn: 0.02,
+      inflationRate: 0.05,
+      annualContribution: 20_000,
+      annualExpenses: 50_000,
+      currentSavings: 100_000,
+    })
+    expect(result.fireAge).toBe(Infinity)
+    expect(result.yearsToFIRE).toBe(Infinity)
+    expect(result.retirementGoal.isOnTrack).toBe(false)
+    expect(result.retirementGoal.message).toContain('not reachable')
+  })
+
+  it('caps the projection horizon at 50 years', () => {
+    const result = calculateStandardFIRE({ ...DEFAULTS, annualContribution: 1_000, currentSavings: 1_000 })
+    expect(result.projections.length).toBeLessThanOrEqual(51)
+  })
+
+  describe('monotonicity', () => {
+    it('a larger contribution never delays FIRE', () => {
+      const ages = [12_000, 18_000, 24_000, 36_000, 60_000].map(
+        (c) => calculateStandardFIRE({ ...DEFAULTS, annualContribution: c }).fireAge,
+      )
+      for (let i = 1; i < ages.length; i++) expect(ages[i]).toBeLessThanOrEqual(ages[i - 1])
+    })
+
+    it('higher expenses never bring FIRE forward', () => {
+      const ages = [30_000, 48_000, 72_000, 96_000].map(
+        (e) => calculateStandardFIRE({ ...DEFAULTS, annualExpenses: e }).fireAge,
+      )
+      for (let i = 1; i < ages.length; i++) expect(ages[i]).toBeGreaterThanOrEqual(ages[i - 1])
+    })
+
+    it('a higher return never delays FIRE', () => {
+      const ages = [0.04, 0.05, 0.07, 0.09].map(
+        (r) => calculateStandardFIRE({ ...DEFAULTS, expectedReturn: r }).fireAge,
+      )
+      for (let i = 1; i < ages.length; i++) expect(ages[i]).toBeLessThanOrEqual(ages[i - 1])
+    })
+
+    it('higher inflation never brings FIRE forward', () => {
+      const ages = [0, 0.02, 0.03, 0.05].map(
+        (i) => calculateStandardFIRE({ ...DEFAULTS, inflationRate: i }).fireAge,
+      )
+      for (let i = 1; i < ages.length; i++) expect(ages[i]).toBeGreaterThanOrEqual(ages[i - 1])
+    })
+
+    it('more starting savings never delays FIRE', () => {
+      const ages = [0, 50_000, 100_000, 400_000].map(
+        (s) => calculateStandardFIRE({ ...DEFAULTS, currentSavings: s }).fireAge,
+      )
+      for (let i = 1; i < ages.length; i++) expect(ages[i]).toBeLessThanOrEqual(ages[i - 1])
+    })
+  })
+
+  describe('retirement goal assessment', () => {
+    it('is on track when FIRE lands at or before the target age', () => {
+      // The shipped defaults reach FIRE at 54.4, which is before the target retirement age of 55.
+      const result = calculateStandardFIRE(DEFAULTS)
+      expect(result.fireAge).toBe(54.4)
+      expect(result.retirementGoal.isOnTrack).toBe(true)
+      expect(result.retirementGoal.targetAgeGap).toBeCloseTo(54.4 - 55, 9)
+      expect(result.retirementGoal.message).toContain('On track')
+    })
+
+    it('is off track when FIRE lands after the target age', () => {
+      // Halving the contribution pushes FIRE past 55.
+      const result = calculateStandardFIRE({ ...DEFAULTS, annualContribution: 12_000 })
+      expect(result.fireAge).toBeGreaterThan(55)
+      expect(result.retirementGoal.isOnTrack).toBe(false)
+      expect(result.retirementGoal.targetAgeGap).toBeCloseTo(result.fireAge - 55, 9)
+      expect(result.retirementGoal.message).toContain('Off track')
+    })
+
+    it('falls back to the calculated age when no retirement age is supplied', () => {
+      const { retirementAge: _omitted, ...withoutTarget } = DEFAULTS
+      const result = calculateStandardFIRE(withoutTarget)
+      expect(result.retirementGoal.targetRetirementAge).toBe(result.fireAge)
+      expect(result.retirementGoal.targetAgeGap).toBe(0)
+      expect(result.retirementGoal.isOnTrack).toBe(true)
+    })
+  })
+})
+
+describe('calculateLeanFIRE', () => {
+  it('classifies at or below the $40k threshold as lean', () => {
+    expect(calculateLeanFIRE({ ...DEFAULTS, annualExpenses: 39_999 }).isLean).toBe(true)
+    expect(calculateLeanFIRE({ ...DEFAULTS, annualExpenses: 40_000 }).isLean).toBe(true)
+    expect(calculateLeanFIRE({ ...DEFAULTS, annualExpenses: 40_001 }).isLean).toBe(false)
+  })
+
+  it('exposes the threshold it used', () => {
+    expect(calculateLeanFIRE(DEFAULTS).leanThreshold).toBe(40_000)
+  })
+
+  it('leaves the standard numbers untouched', () => {
+    const standard = calculateStandardFIRE(DEFAULTS)
+    const lean = calculateLeanFIRE(DEFAULTS)
+    expect(lean.fireNumber).toBe(standard.fireNumber)
+    expect(lean.fireAge).toBe(standard.fireAge)
+    expect(lean.coastFireNumber).toBe(standard.coastFireNumber)
+  })
+
+  it.each(SCENARIOS.map((s) => [s.label, s.inputs] as const))(
+    '%s: crossing invariant still holds',
+    (_label, inputs) => {
+      const result = calculateLeanFIRE(inputs)
+      expectCrossingMatchesHeadline(result.projections, result.fireAge, result.fireNumber)
+    },
+  )
+})
+
+describe('calculateFatFIRE', () => {
+  it('classifies at or above the $100k threshold as fat', () => {
+    expect(calculateFatFIRE({ ...DEFAULTS, annualExpenses: 99_999 }).isFat).toBe(false)
+    expect(calculateFatFIRE({ ...DEFAULTS, annualExpenses: 100_000 }).isFat).toBe(true)
+    expect(calculateFatFIRE({ ...DEFAULTS, annualExpenses: 100_001 }).isFat).toBe(true)
+  })
+
+  it('exposes the threshold it used', () => {
+    expect(calculateFatFIRE(DEFAULTS).fatThreshold).toBe(100_000)
+  })
+
+  it('never classifies the same expenses as both lean and fat', () => {
+    for (const expenses of [10_000, 40_000, 70_000, 100_000, 250_000]) {
+      const lean = calculateLeanFIRE({ ...DEFAULTS, annualExpenses: expenses }).isLean
+      const fat = calculateFatFIRE({ ...DEFAULTS, annualExpenses: expenses }).isFat
+      expect(lean && fat).toBe(false)
+    }
+  })
+})
+
+describe('calculateCoastFIRE', () => {
+  // Signature check, deliberately spelled out: (currentAge, targetRetirementAge, currentSavings,
+  // annualContribution, expectedReturn, inflationRate, annualExpenses, withdrawalRate).
+  // annualExpenses comes BEFORE withdrawalRate. The JSDoc example on this function has the two
+  // reversed, which is a live trap for anyone writing a call from the docs.
+  const coast = () => calculateCoastFIRE(30, 55, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04)
+
+  it('derives the FIRE number from expenses and withdrawal rate, not the reverse', () => {
+    // If the two arguments were swapped this would be 0.04/48000, so the assertion doubles as a
+    // guard against calling this function the way its own example does.
+    expect(coast().fireNumber).toBe(1_200_000)
+  })
+
+  it('coast number is the FIRE target discounted at the real rate over the years remaining', () => {
+    // Coast = FV / (1+rho)^n with rho = 1.07/1.03 - 1 and n = 25.
+    const expected = 1_200_000 / Math.pow(1 + realRate(0.07, 0.03), 25)
+    expect(coast().coastNumber).toBe(Math.round(expected))
+  })
+
+  it('a portfolio at the coast number grows to the FIRE number with no further contributions', () => {
+    // The defining property of coasting. The reported coast number is rounded to whole dollars and
+    // then compounds for 25 years at the real rate, so the half-dollar rounding error is amplified
+    // by (1+rho)^25 ~= 2.59. The tolerance below is that bound, not a fudge factor.
+    const result = coast()
+    const growth = Math.pow(1 + realRate(0.07, 0.03), 25)
+    const grown = result.coastNumber * growth
+    expect(Math.abs(grown - 1_200_000)).toBeLessThanOrEqual(0.5 * growth)
+  })
+
+  it('flags already coasting when savings exceed the coast number', () => {
+    const result = calculateCoastFIRE(30, 55, 900_000, 24_000, 0.07, 0.03, 48_000, 0.04)
+    expect(result.alreadyCoasting).toBe(true)
+    expect(result.yearsToCoast).toBe(0)
+  })
+
+  it('does not flag coasting when savings fall short', () => {
+    const result = coast()
+    expect(result.alreadyCoasting).toBe(false)
+    expect(result.yearsToCoast).toBeGreaterThan(0)
+  })
+
+  it('the no-contribution projection crosses the coast number at the reported coast age', () => {
+    const result = coast()
+    expectCrossingMatchesHeadline(
+      result.projectionsWithContributions,
+      30 + result.yearsToCoast,
+      result.coastNumber,
+    )
+  })
+
+  it('the coast projection makes no contributions after the seed year', () => {
+    const result = coast()
+    result.projections.slice(1).forEach((point) => expect(point.contributions).toBe(0))
+  })
+
+  it('contributing always reaches at least as far as coasting', () => {
+    const result = coast()
+    result.projections.forEach((point, index) =>
+      expect(point.portfolio).toBeLessThanOrEqual(result.projectionsWithContributions[index].portfolio),
+    )
+  })
+
+  it('a later retirement age lowers the coast number', () => {
+    // More compounding time means less is needed today. Strictly monotone for a positive real rate.
+    const numbers = [45, 50, 55, 60, 65].map(
+      (age) => calculateCoastFIRE(30, age, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04).coastNumber,
+    )
+    for (let i = 1; i < numbers.length; i++) expect(numbers[i]).toBeLessThan(numbers[i - 1])
+  })
+
+  it('collapses to the full FIRE number when retirement is today', () => {
+    // No time to compound, so present value equals future value.
+    const result = calculateCoastFIRE(55, 55, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04)
+    expect(result.coastNumber).toBe(1_200_000)
+  })
+})
+
+describe('calculateBaristaFIRE', () => {
+  // Signature check: (currentAge, currentSavings, annualContribution, expectedReturn,
+  // inflationRate, annualExpenses, withdrawalRate, partTimeAnnualIncome). There is NO
+  // retirementAge parameter, unlike every other FIRE entry point.
+  const barista = (partTime: number) =>
+    calculateBaristaFIRE(30, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04, partTime)
+
+  it('reduces the required portfolio by the part-time income capitalised at the withdrawal rate', () => {
+    // Portfolio only funds expenses the job does not: (48,000 - 20,000)/0.04 = 700,000.
+    const result = barista(20_000)
+    expect(result.fullFireNumber).toBe(1_200_000)
+    expect(result.baristaNumber).toBe(700_000)
+    expect(result.savingsFromPartTime).toBe(500_000)
+  })
+
+  it('savingsFromPartTime is partTimeIncome / withdrawalRate', () => {
+    for (const income of [0, 10_000, 20_000, 40_000]) {
+      expect(barista(income).savingsFromPartTime).toBe(Math.round(income / 0.04))
+    }
+  })
+
+  it('equals standard FIRE when there is no part-time income', () => {
+    const result = barista(0)
+    expect(result.baristaNumber).toBe(result.fullFireNumber)
+    expect(result.yearsToBaristaFIRE).toBe(calculateStandardFIRE(DEFAULTS).yearsToFIRE)
+  })
+
+  it('never demands a negative portfolio when part-time income exceeds expenses', () => {
+    // The clamp matters: without it the required number would go negative and the year count
+    // meaningless.
+    const result = barista(60_000)
+    expect(result.baristaNumber).toBe(0)
+    expect(result.yearsToBaristaFIRE).toBe(0)
+  })
+
+  it('more part-time income never delays barista FIRE', () => {
+    const ages = [0, 10_000, 20_000, 30_000].map((income) => barista(income).yearsToBaristaFIRE)
+    for (let i = 1; i < ages.length; i++) expect(ages[i]).toBeLessThanOrEqual(ages[i - 1])
+  })
+
+  it('the projection crosses the barista number at the reported age', () => {
+    const result = barista(20_000)
+    expectCrossingMatchesHeadline(
+      result.projections,
+      30 + result.yearsToBaristaFIRE,
+      result.baristaNumber,
+    )
+  })
+
+  it('reaches barista FIRE no later than full FIRE', () => {
+    expect(barista(20_000).yearsToBaristaFIRE).toBeLessThanOrEqual(
+      calculateStandardFIRE(DEFAULTS).yearsToFIRE,
+    )
+  })
+})

--- a/web/src/utils/__tests__/fixtureSelfCheck.test.ts
+++ b/web/src/utils/__tests__/fixtureSelfCheck.test.ts
@@ -1,0 +1,338 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  amortize,
+  deflate,
+  inflatingSum,
+  monthsToPayOffClosedForm,
+  nominalEscalatingSeries,
+  nominalFlatSeries,
+  realBalanceClosedForm,
+  realFixedPoint,
+  realRate,
+  yearsToTargetClosedForm,
+} from './oracles'
+import {
+  debtCases,
+  decode,
+  fireCases,
+  healthcareCases,
+  investmentCases,
+  parityCases,
+  withdrawalCases,
+} from './parityFixtures'
+
+/**
+ * Oracle === fixture.
+ *
+ * This suite never touches `calculations.ts`. It re-derives the shared fixture's expectations a
+ * third time, from the algebra in `oracles.ts`, so that a fixture value quietly regenerated from
+ * either implementation fails here. Without this layer the fixture would only prove that web and
+ * MAUI agree with each other — which is exactly the failure mode issue #54 describes, since two
+ * implementations can agree on a number that is simply wrong.
+ */
+
+describe('fixture hygiene', () => {
+  it('has unique ids', () => {
+    const ids = parityCases.map((c) => c.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it.each(parityCases.map((c) => [c.id, c] as const))(
+    '%s documents how its expectations were derived',
+    (_id, testCase) => {
+      // A case without a real derivation is unreviewable: nobody can check it without running the
+      // code, and "run the code and see" is the practice this fixture exists to prevent.
+      expect(testCase.derivation.length).toBeGreaterThan(40)
+      expect(testCase.description.length).toBeGreaterThan(10)
+    },
+  )
+})
+
+describe('fire cases match closed-form algebra', () => {
+  it.each(fireCases.map((c) => [c.id, c] as const))(
+    '%s fireNumber is expenses / withdrawalRate',
+    (_id, testCase) => {
+      const { annualExpenses, withdrawalRate } = testCase.inputs
+      expect(testCase.expected.fireNumber).toBeCloseTo(annualExpenses / withdrawalRate, 6)
+    },
+  )
+
+  it.each(fireCases.map((c) => [c.id, c] as const))(
+    '%s yearsToFire matches n = ln((C + T*rho)/(C + PV*rho)) / ln(1+rho)',
+    (_id, testCase) => {
+      const { currentSavings, annualContribution, expectedReturn, inflationRate, contributionGrowth } =
+        testCase.inputs
+      const target = testCase.expected.fireNumber
+      const years = decode(testCase.expected.yearsToFire)
+
+      if (contributionGrowth === 'flat') {
+        // Flat contributions have no closed form in today's dollars, so the oracle is a bisection
+        // over an independently simulated nominal series instead.
+        if (!Number.isFinite(years)) return
+        const atYears = deflate(
+          nominalFlatSeries(currentSavings, annualContribution, expectedReturn, Math.ceil(years))[
+            Math.ceil(years)
+          ],
+          inflationRate,
+          Math.ceil(years),
+        )
+        const before = Math.floor(years)
+        const atBefore = deflate(
+          nominalFlatSeries(currentSavings, annualContribution, expectedReturn, before)[before],
+          inflationRate,
+          before,
+        )
+        expect(atBefore).toBeLessThan(target)
+        expect(atYears).toBeGreaterThanOrEqual(target)
+        return
+      }
+
+      const rho = realRate(expectedReturn, inflationRate)
+      const exact = yearsToTargetClosedForm(currentSavings, annualContribution, rho, target)
+
+      if (exact === null) {
+        expect(years).toBe(Number.POSITIVE_INFINITY)
+        return
+      }
+      // The app rounds the headline to one decimal for display, so the fixture stores it rounded.
+      // Asserting equality against round(exact, 1) is stricter than a tolerance: it pins the exact
+      // decimal a user sees, and still fails if the underlying algebra moves by more than 0.05.
+      expect(years).toBe(Math.round(exact * 10) / 10)
+    },
+  )
+
+  it.each(fireCases.map((c) => [c.id, c] as const))('%s fireAge is currentAge + yearsToFire', (_id, testCase) => {
+    const years = decode(testCase.expected.yearsToFire)
+    const age = decode(testCase.expected.fireAge)
+    if (!Number.isFinite(years)) {
+      expect(age).toBe(Number.POSITIVE_INFINITY)
+      return
+    }
+    // The app rounds the headline age to one decimal for display.
+    expect(age).toBeCloseTo(Math.round((testCase.inputs.currentAge + years) * 10) / 10, 10)
+  })
+
+  it.each(fireCases.map((c) => [c.id, c] as const))(
+    '%s projection samples match the deflated nominal recurrence',
+    (_id, testCase) => {
+      const { currentSavings, annualContribution, expectedReturn, inflationRate, contributionGrowth } =
+        testCase.inputs
+
+      for (const sample of testCase.expected.projectionSamples) {
+        const n = sample.age - testCase.inputs.currentAge
+        const nominal =
+          contributionGrowth === 'flat'
+            ? nominalFlatSeries(currentSavings, annualContribution, expectedReturn, n)[n]
+            : nominalEscalatingSeries(currentSavings, annualContribution, expectedReturn, inflationRate, n)[n]
+
+        expect(sample.portfolio).toBe(Math.round(nominal))
+        expect(sample.inflationAdjusted).toBe(Math.round(deflate(nominal, inflationRate, n)))
+      }
+    },
+  )
+
+  it.each(
+    fireCases
+      .filter((c) => c.inputs.contributionGrowth === 'inflation')
+      .map((c) => [c.id, c] as const),
+  )(
+    '%s deflated projection equals the closed form exactly, not approximately',
+    (_id, testCase) => {
+      // The audit's central identity. Because contributions are entered in today's dollars and
+      // escalate as C(1+i)^k, deflating the nominal recurrence reproduces the closed form exactly.
+      const { currentSavings, annualContribution, expectedReturn, inflationRate } = testCase.inputs
+      for (const sample of testCase.expected.projectionSamples) {
+        const n = sample.age - testCase.inputs.currentAge
+        const closedForm = realBalanceClosedForm(
+          currentSavings,
+          annualContribution,
+          expectedReturn,
+          inflationRate,
+          n,
+        )
+        expect(sample.inflationAdjusted).toBe(Math.round(closedForm))
+      }
+    },
+  )
+
+  it.each(fireCases.map((c) => [c.id, c] as const))(
+    '%s projection brackets the FIRE target at the headline age',
+    (_id, testCase) => {
+      // Issue #46: the chart crossing and the headline number disagreeing.
+      const years = decode(testCase.expected.yearsToFire)
+      if (!Number.isFinite(years) || years <= 0 || Number.isInteger(years)) return
+      const target = testCase.expected.fireNumber
+      const samples = testCase.expected.projectionSamples
+      const below = samples.find((s) => s.age - testCase.inputs.currentAge === Math.floor(years))
+      const above = samples.find((s) => s.age - testCase.inputs.currentAge === Math.ceil(years))
+      if (!below || !above) return
+      expect(below.inflationAdjusted).toBeLessThan(target)
+      expect(above.inflationAdjusted).toBeGreaterThanOrEqual(target)
+    },
+  )
+
+  it('the unreachable case is bounded by its fixed point, so Infinity is correct', () => {
+    const testCase = fireCases.find((c) => c.id === 'fire-unreachable-negative-real-return')
+    expect(testCase).toBeDefined()
+    const { annualContribution, expectedReturn, inflationRate } = testCase!.inputs
+    const rho = realRate(expectedReturn, inflationRate)
+    expect(rho).toBeLessThan(0)
+    const ceiling = realFixedPoint(annualContribution, rho)
+    expect(ceiling).toBeCloseTo(700000, 6)
+    expect(ceiling).toBeLessThan(testCase!.expected.fireNumber)
+    expect(decode(testCase!.expected.fireAge)).toBe(Number.POSITIVE_INFINITY)
+  })
+
+  it('the degenerate rho = 0 case is the exact linear solution', () => {
+    const testCase = fireCases.find((c) => c.id === 'fire-degenerate-zero-real-return')
+    expect(testCase).toBeDefined()
+    const { currentSavings, annualContribution, expectedReturn, inflationRate, currentAge } =
+      testCase!.inputs
+    expect(realRate(expectedReturn, inflationRate)).toBe(0)
+    // 50,000 + 20,000n = 1,250,000  =>  n = 60 exactly.
+    const n = (testCase!.expected.fireNumber - currentSavings) / annualContribution
+    expect(n).toBe(60)
+    expect(decode(testCase!.expected.fireAge)).toBe(currentAge + 60)
+  })
+})
+
+describe('debt cases match the amortization closed form', () => {
+  it.each(debtCases.map((c) => [c.id, c] as const))(
+    '%s first-month interest is balance * rate / 12',
+    (_id, testCase) => {
+      const expected = testCase.inputs.debts.reduce((sum, d) => sum + (d.balance * d.rate) / 12, 0)
+      expect(testCase.expected.firstMonthInterest).toBeCloseTo(expected, 10)
+    },
+  )
+
+  it('the single-debt case matches n = -ln(1 - P*m/A)/ln(1+m)', () => {
+    const testCase = debtCases.find((c) => c.id === 'debt-single-20pct-apr')
+    expect(testCase).toBeDefined()
+    const debt = testCase!.inputs.debts[0]
+    const payment = testCase!.inputs.monthlyPayment + testCase!.inputs.extraPayment
+
+    const exact = monthsToPayOffClosedForm(debt.balance, debt.rate, payment)
+    expect(exact).not.toBeNull()
+    // 24.53 months of payments means the 25th month still has a balance to clear.
+    expect(Math.ceil(exact!)).toBe(testCase!.expected.totalMonths)
+
+    const simulated = amortize(debt.balance, debt.rate, payment)
+    expect(simulated.months).toBe(25)
+    expect(Math.round(simulated.totalInterest)).toBe(testCase!.expected.totalInterest)
+    // Exactly one accrual per month: 10000 * 0.20/12. The #45 defect charged it more than once.
+    expect(simulated.firstMonthInterest).toBeCloseTo(166.66666666666666, 10)
+  })
+
+  it.each(debtCases.map((c) => [c.id, c] as const))(
+    '%s principal repaid equals the sum of balances',
+    (_id, testCase) => {
+      const owed = testCase.inputs.debts.reduce((sum, d) => sum + d.balance, 0)
+      expect(testCase.expected.totalPrincipal).toBe(owed)
+    },
+  )
+
+  it('avalanche never costs more interest than snowball', () => {
+    // The pre-fix bug inverted this. Ordering by rate is optimal for total interest by an exchange
+    // argument, so the reverse can never hold.
+    const snowball = debtCases.find((c) => c.id === 'debt-multi-snowball')
+    const avalanche = debtCases.find((c) => c.id === 'debt-multi-avalanche')
+    expect(snowball).toBeDefined()
+    expect(avalanche).toBeDefined()
+    expect(avalanche!.expected.totalInterest).toBeLessThanOrEqual(snowball!.expected.totalInterest)
+  })
+})
+
+describe('withdrawal cases match the drawdown recurrence', () => {
+  it.each(withdrawalCases.map((c) => [c.id, c] as const))(
+    '%s annual withdrawal is portfolio * rate',
+    (_id, testCase) => {
+      const { portfolioValue, withdrawalRate } = testCase.inputs
+      expect(testCase.expected.annualWithdrawal).toBe(Math.round(portfolioValue * withdrawalRate))
+      expect(testCase.expected.monthlyWithdrawal).toBe(Math.round((portfolioValue * withdrawalRate) / 12))
+    },
+  )
+
+  it.each(withdrawalCases.map((c) => [c.id, c] as const))(
+    '%s rate analysis years are non-increasing as the withdrawal rate rises',
+    (_id, testCase) => {
+      const rows = testCase.expected.rateAnalysis
+      for (let i = 1; i < rows.length; i++) {
+        expect(rows[i].rate).toBeGreaterThan(rows[i - 1].rate)
+        expect(rows[i].years).toBeLessThanOrEqual(rows[i - 1].years)
+      }
+    },
+  )
+})
+
+describe('investment cases match the growth closed form', () => {
+  it.each(investmentCases.map((c) => [c.id, c] as const))(
+    '%s final balances match an independently simulated series',
+    (_id, testCase) => {
+      const {
+        startingAmount,
+        expectedReturn,
+        inflationRate,
+        yearsInvesting,
+        contributionGrowth,
+      } = testCase.inputs
+      const annual = testCase.expected.annualContribution
+
+      const nominal =
+        contributionGrowth === 'flat'
+          ? nominalFlatSeries(startingAmount, annual, expectedReturn, yearsInvesting)[yearsInvesting]
+          : nominalEscalatingSeries(
+              startingAmount,
+              annual,
+              expectedReturn,
+              inflationRate,
+              yearsInvesting,
+            )[yearsInvesting]
+
+      expect(testCase.expected.finalNominalBalance).toBeCloseTo(nominal, 6)
+      expect(testCase.expected.finalInflationAdjustedBalance).toBeCloseTo(
+        deflate(nominal, inflationRate, yearsInvesting),
+        6,
+      )
+    },
+  )
+
+  it.each(investmentCases.map((c) => [c.id, c] as const))(
+    '%s satisfies growth = final - invested and impact = nominal - real',
+    (_id, testCase) => {
+      const e = testCase.expected
+      expect(e.totalGrowth).toBeCloseTo(e.finalNominalBalance - e.totalInvested, 6)
+      expect(e.inflationImpact).toBeCloseTo(e.finalNominalBalance - e.finalInflationAdjustedBalance, 6)
+    },
+  )
+
+  it('the shipped-defaults case reproduces the audit anchor', () => {
+    // PV = 100,000, C = 6,000/yr (500/mo), r = 7%, i = 3%, n = 30. Derived from the recurrence
+    // B_k = B_{k-1}(1.07) + 6000(1.03)^k, then deflated by 1.03^30.
+    const testCase = investmentCases.find((c) => c.id === 'investment-defaults')
+    expect(testCase).toBeDefined()
+    expect(testCase!.expected.finalNominalBalance).toBeCloseTo(1562306.8565586861, 4)
+    expect(testCase!.expected.finalInflationAdjustedBalance).toBeCloseTo(643649.7392030951, 4)
+  })
+})
+
+describe('healthcare cases match the geometric sum', () => {
+  it.each(healthcareCases.map((c) => [c.id, c] as const))(
+    '%s total cost is A((1+i)^n - 1)/i',
+    (_id, testCase) => {
+      const { monthlyPremium, annualDeductible, annualOutOfPocket, inflationRate } = testCase.inputs
+      const annual = monthlyPremium * 12 + annualDeductible + annualOutOfPocket
+      expect(testCase.expected.annualCost).toBe(annual)
+      expect(testCase.expected.totalCost).toBe(
+        Math.round(inflatingSum(annual, inflationRate, testCase.expected.gapYears)),
+      )
+    },
+  )
+
+  it.each(healthcareCases.map((c) => [c.id, c] as const))(
+    '%s gap runs from early retirement to Medicare at 65',
+    (_id, testCase) => {
+      expect(testCase.expected.gapYears).toBe(Math.max(0, 65 - testCase.inputs.earlyRetirementAge))
+    },
+  )
+})

--- a/web/src/utils/__tests__/growthAndHealthcare.test.ts
+++ b/web/src/utils/__tests__/growthAndHealthcare.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest'
+
+import { MEDICARE_AGE, calculateHealthcareGap, calculateInvestmentGrowth } from '../calculations'
+import { deflate, inflatingSum, nominalEscalatingSeries, nominalFlatSeries } from './oracles'
+
+/**
+ * Savings & Investment growth, and the healthcare gap.
+ *
+ * Both have exact closed forms, so nothing here needs a recorded value:
+ *  - growth is the same escalating-contribution recurrence the projections use;
+ *  - the healthcare gap is a plain geometric series, A((1+i)^n - 1)/i.
+ */
+
+describe('calculateInvestmentGrowth', () => {
+  // Signature: (startingAmount, contributionAmount, contributionFrequency, yearsInvesting,
+  // expectedReturn, inflationRate, annualIncome, currentAge, contributionGrowth?)
+  const defaults = () =>
+    calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30, 'inflation')
+
+  it('annualises a monthly contribution by twelve', () => {
+    const result = defaults()
+    expect(result.annualContribution).toBe(6_000)
+    expect(result.monthlyContribution).toBe(500)
+  })
+
+  it('accepts a yearly contribution unchanged', () => {
+    const result = calculateInvestmentGrowth(100_000, 6_000, 'yearly', 30, 0.07, 0.03, 72_000, 30)
+    expect(result.annualContribution).toBe(6_000)
+    expect(result.monthlyContribution).toBe(500)
+  })
+
+  it('treats monthly and yearly contributions of equal annual size identically', () => {
+    // The model compounds annually, so $500/mo and $6,000/yr must produce the same series.
+    const monthly = calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30)
+    const yearly = calculateInvestmentGrowth(100_000, 6_000, 'yearly', 30, 0.07, 0.03, 72_000, 30)
+    expect(yearly.finalNominalBalance).toBe(monthly.finalNominalBalance)
+  })
+
+  it('reproduces the Savings & Investment anchor', () => {
+    // PV = 100,000, C = 6,000, r = 7%, i = 3%, n = 30 under the escalating-contribution recurrence
+    // B_k = B_{k-1}(1.07) + 6000(1.03)^k, then deflated by 1.03^30.
+    const result = defaults()
+    expect(result.finalNominalBalance).toBeCloseTo(1_562_306.8565586861, 4)
+    expect(result.finalInflationAdjustedBalance).toBeCloseTo(643_649.7392030951, 4)
+  })
+
+  it.each([
+    ['inflation', 'inflation'],
+    ['flat', 'flat'],
+  ] as const)('%s growth follows an independently simulated series', (_label, growth) => {
+    const result = calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30, growth)
+    const series =
+      growth === 'flat'
+        ? nominalFlatSeries(100_000, 6_000, 0.07, 30)
+        : nominalEscalatingSeries(100_000, 6_000, 0.07, 0.03, 30)
+    expect(result.finalNominalBalance).toBeCloseTo(series[30], 6)
+    result.projections.forEach((point, k) => expect(point.portfolio).toBe(Math.round(series[k])))
+  })
+
+  it('deflates the final balance by exactly the horizon', () => {
+    const result = defaults()
+    expect(result.finalInflationAdjustedBalance).toBeCloseTo(
+      deflate(result.finalNominalBalance, 0.03, 30),
+      6,
+    )
+  })
+
+  it('satisfies growth = final - invested', () => {
+    for (const years of [1, 10, 30, 45]) {
+      const result = calculateInvestmentGrowth(100_000, 500, 'monthly', years, 0.07, 0.03, 72_000, 30)
+      expect(result.totalGrowth).toBeCloseTo(result.finalNominalBalance - result.totalInvested, 6)
+    }
+  })
+
+  it('satisfies inflationImpact = nominal - real', () => {
+    const result = defaults()
+    expect(result.inflationImpact).toBeCloseTo(
+      result.finalNominalBalance - result.finalInflationAdjustedBalance,
+      6,
+    )
+  })
+
+  it('counts the starting amount as invested capital, not growth', () => {
+    const result = calculateInvestmentGrowth(100_000, 0, 'yearly', 0, 0.07, 0.03, 72_000, 30)
+    expect(result.totalInvested).toBe(100_000)
+    expect(result.totalGrowth).toBe(0)
+    expect(result.finalNominalBalance).toBe(100_000)
+  })
+
+  it('sums every escalating contribution into totalInvested', () => {
+    // 100,000 seed plus sum_{k=1..30} 6000(1.03)^k.
+    const expected = 100_000 + inflatingSum(6_000 * 1.03, 0.03, 30)
+    expect(defaults().totalInvested).toBeCloseTo(expected, 6)
+  })
+
+  it('reports savings rate as contribution over income, and zero when income is zero', () => {
+    expect(defaults().savingsRate).toBeCloseTo(6_000 / 72_000, 12)
+    const noIncome = calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 0, 30)
+    expect(noIncome.savingsRate).toBe(0)
+  })
+
+  it('emits one projection point per year inclusive, with ages advancing by one', () => {
+    const result = defaults()
+    expect(result.projections).toHaveLength(31)
+    result.projections.forEach((point, index) => expect(point.age).toBe(30 + index))
+  })
+
+  it('makes no contribution in the seed year', () => {
+    expect(defaults().projections[0].contributions).toBe(0)
+  })
+
+  it('inflation-matched contributions always end ahead of flat ones in real terms', () => {
+    const inflation = calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30, 'inflation')
+    const flat = calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30, 'flat')
+    expect(flat.finalInflationAdjustedBalance).toBeLessThan(inflation.finalInflationAdjustedBalance)
+  })
+
+  it('a longer horizon never ends with less, at non-negative returns', () => {
+    const balances = [5, 10, 20, 30, 40].map(
+      (years) => calculateInvestmentGrowth(100_000, 500, 'monthly', years, 0.07, 0.03, 72_000, 30).finalNominalBalance,
+    )
+    for (let i = 1; i < balances.length; i++) expect(balances[i]).toBeGreaterThan(balances[i - 1])
+  })
+
+  it('is unaffected by inflation in nominal terms under flat contributions', () => {
+    // A flat nominal contribution never sees the inflation rate, so the nominal path cannot move.
+    const a = calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.02, 72_000, 30, 'flat')
+    const b = calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.05, 72_000, 30, 'flat')
+    expect(a.finalNominalBalance).toBe(b.finalNominalBalance)
+    expect(a.finalInflationAdjustedBalance).toBeGreaterThan(b.finalInflationAdjustedBalance)
+  })
+})
+
+describe('calculateHealthcareGap', () => {
+  // Signature: (currentAge, earlyRetirementAge, monthlyPremium, annualDeductible,
+  // annualOutOfPocket, inflationRate)
+  const defaults = () => calculateHealthcareGap(30, 55, 600, 2_500, 2_000, 0.03)
+
+  it('runs from early retirement to Medicare eligibility', () => {
+    expect(MEDICARE_AGE).toBe(65)
+    expect(defaults().gapYears).toBe(10)
+    expect(calculateHealthcareGap(30, 45, 600, 2_500, 2_000, 0.03).gapYears).toBe(20)
+  })
+
+  it('never reports a negative gap for someone retiring at or after 65', () => {
+    for (const age of [65, 67, 80]) {
+      const result = calculateHealthcareGap(30, age, 600, 2_500, 2_000, 0.03)
+      expect(result.gapYears).toBe(0)
+      expect(result.totalCost).toBe(0)
+      expect(result.avgAnnualCost).toBe(0)
+      expect(result.yearlyBreakdown).toEqual([])
+    }
+  })
+
+  it('sums premium, deductible and out-of-pocket into the annual cost', () => {
+    // 600*12 + 2500 + 2000 = 11,700.
+    expect(defaults().annualCost).toBe(11_700)
+  })
+
+  it('totals the geometric series A((1+i)^n - 1)/i', () => {
+    expect(defaults().totalCost).toBe(Math.round(inflatingSum(11_700, 0.03, 10)))
+  })
+
+  it.each([
+    [55, 0.03],
+    [50, 0.05],
+    [45, 0],
+    [60, 0.02],
+  ] as const)('total matches the closed form for retirement at %s with inflation %s', (age, inflation) => {
+    const result = calculateHealthcareGap(30, age, 600, 2_500, 2_000, inflation)
+    expect(result.totalCost).toBe(Math.round(inflatingSum(11_700, inflation, 65 - age)))
+  })
+
+  it('degenerates to A*n when inflation is zero', () => {
+    // The geometric sum divides by i, so i = 0 must be handled as simple multiplication.
+    const result = calculateHealthcareGap(30, 55, 600, 2_500, 2_000, 0)
+    expect(result.totalCost).toBe(117_000)
+    expect(result.avgAnnualCost).toBe(11_700)
+  })
+
+  it('inflates the first year by nothing and each later year by one more step', () => {
+    const result = defaults()
+    result.yearlyBreakdown.forEach((year, index) => {
+      expect(year.cost).toBe(Math.round(11_700 * Math.pow(1.03, index)))
+      expect(year.premium).toBe(Math.round(7_200 * Math.pow(1.03, index)))
+      expect(year.deductible).toBe(Math.round(2_500 * Math.pow(1.03, index)))
+      expect(year.outOfPocket).toBe(Math.round(2_000 * Math.pow(1.03, index)))
+    })
+    expect(result.yearlyBreakdown[0].cost).toBe(11_700)
+  })
+
+  it('breaks the cost down into components that re-add to the yearly total', () => {
+    // Each part is rounded independently, so allow the one-dollar slack that creates.
+    defaults().yearlyBreakdown.forEach((year) => {
+      const parts = year.premium + year.deductible + year.outOfPocket
+      expect(Math.abs(parts - year.cost)).toBeLessThanOrEqual(1)
+    })
+  })
+
+  it('runs the breakdown from the retirement age for exactly gapYears entries', () => {
+    const result = defaults()
+    expect(result.yearlyBreakdown).toHaveLength(10)
+    result.yearlyBreakdown.forEach((year, index) => expect(year.age).toBe(55 + index))
+    expect(result.yearlyBreakdown[result.yearlyBreakdown.length - 1].age).toBe(64)
+  })
+
+  it('averages the total across the gap', () => {
+    const result = defaults()
+    expect(result.avgAnnualCost).toBeGreaterThan(result.annualCost)
+    expect(Math.abs(result.avgAnnualCost - result.totalCost / result.gapYears)).toBeLessThanOrEqual(1)
+  })
+
+  it('retiring earlier never costs less', () => {
+    const totals = [62, 60, 55, 50, 45].map(
+      (age) => calculateHealthcareGap(30, age, 600, 2_500, 2_000, 0.03).totalCost,
+    )
+    for (let i = 1; i < totals.length; i++) expect(totals[i]).toBeGreaterThan(totals[i - 1])
+  })
+
+  it('scales linearly with the annual cost', () => {
+    // The series is homogeneous in A, so doubling every component doubles the total.
+    const single = calculateHealthcareGap(30, 55, 600, 2_500, 2_000, 0.03).totalCost
+    const double = calculateHealthcareGap(30, 55, 1_200, 5_000, 4_000, 0.03).totalCost
+    expect(Math.abs(double - 2 * single)).toBeLessThanOrEqual(1)
+  })
+})

--- a/web/src/utils/__tests__/oracles.ts
+++ b/web/src/utils/__tests__/oracles.ts
@@ -1,0 +1,212 @@
+/**
+ * Independent analytic oracles.
+ *
+ * ============================ READ THIS BEFORE EDITING ============================
+ * Nothing in this file may import from `../calculations` or `../deferredCompensation`.
+ * Every function here is derived from the underlying financial algebra and is written to be
+ * read and checked against a textbook, not against the shipped implementation. That is the whole
+ * point: a test whose expectation came out of the code under test is a screenshot, not a test.
+ *
+ * Two of the bugs the cross-platform audit fixed (#45, #46) shipped precisely because the
+ * behaviour looked intentional — nothing independent contradicted it.
+ * =================================================================================
+ */
+
+/** Real (inflation-adjusted) return. Fisher relation: (1 + rho)(1 + i) = (1 + r). */
+export function realRate(nominalReturn: number, inflationRate: number): number {
+  return (1 + nominalReturn) / (1 + inflationRate) - 1
+}
+
+/**
+ * Balance after `n` years in TODAY'S dollars, closed form.
+ *
+ *   P_n / (1+i)^n = PV(1+rho)^n + C((1+rho)^n - 1)/rho,     rho = (1+r)/(1+i) - 1
+ *
+ * This is an identity, not an approximation, and it holds only under the app's convention that a
+ * contribution entered in today's dollars is actually paid as `C(1+i)^k` nominal at the end of
+ * year k. `nominalEscalatingSeries` below simulates that convention from scratch; the two agreeing
+ * to floating-point noise is the proof the identity applies.
+ *
+ * The `rho === 0` branch is the degenerate case r === i, where the annuity factor
+ * ((1+rho)^n - 1)/rho is 0/0 and the limit is simply n.
+ */
+export function realBalanceClosedForm(
+  presentValue: number,
+  annualContribution: number,
+  nominalReturn: number,
+  inflationRate: number,
+  years: number,
+): number {
+  const rho = realRate(nominalReturn, inflationRate)
+  if (rho === 0) return presentValue + annualContribution * years
+  const growth = Math.pow(1 + rho, years)
+  return presentValue * growth + annualContribution * ((growth - 1) / rho)
+}
+
+/**
+ * Nominal balances year by year under inflation-escalating contributions, simulated directly from
+ * the recurrence rather than from any closed form:
+ *
+ *   B_0 = PV,   B_k = B_{k-1}(1 + r) + C(1 + i)^k
+ *
+ * Returns `[B_0, B_1, ... B_years]`.
+ */
+export function nominalEscalatingSeries(
+  presentValue: number,
+  annualContribution: number,
+  nominalReturn: number,
+  inflationRate: number,
+  years: number,
+): number[] {
+  const series = [presentValue]
+  let balance = presentValue
+  for (let k = 1; k <= years; k++) {
+    balance = balance * (1 + nominalReturn) + annualContribution * Math.pow(1 + inflationRate, k)
+    series.push(balance)
+  }
+  return series
+}
+
+/**
+ * Nominal balances under FLAT contributions: the same nominal amount every year, so its purchasing
+ * power erodes.
+ *
+ *   B_0 = PV,   B_k = B_{k-1}(1 + r) + C
+ *
+ * No closed form in today's dollars exists for this model, which is why the shipped code solves it
+ * numerically. Simulating it here gives an oracle that owes the shipped solver nothing.
+ */
+export function nominalFlatSeries(
+  presentValue: number,
+  annualContribution: number,
+  nominalReturn: number,
+  years: number,
+): number[] {
+  const series = [presentValue]
+  let balance = presentValue
+  for (let k = 1; k <= years; k++) {
+    balance = balance * (1 + nominalReturn) + annualContribution
+    series.push(balance)
+  }
+  return series
+}
+
+/** Deflate a nominal amount observed at year `n` back into today's dollars. */
+export function deflate(nominal: number, inflationRate: number, years: number): number {
+  return nominal / Math.pow(1 + inflationRate, years)
+}
+
+/**
+ * Years to grow `presentValue` to `target` at rate `rate` with level payment `payment`, in closed
+ * form. Solve FV = PV(1+g)^n + C((1+g)^n - 1)/g for n:
+ *
+ *   (C + FV*g) / (C + PV*g) = (1+g)^n    =>    n = ln((C + FV*g)/(C + PV*g)) / ln(1+g)
+ *
+ * Returns a fractional year count. `null` when the target is unreachable (the ratio is <= 1, i.e.
+ * the balance converges below the target).
+ */
+export function yearsToTargetClosedForm(
+  presentValue: number,
+  payment: number,
+  rate: number,
+  target: number,
+): number | null {
+  if (presentValue >= target) return 0
+  if (rate === 0) return payment > 0 ? (target - presentValue) / payment : null
+  const numerator = payment + target * rate
+  const denominator = payment + presentValue * rate
+  if (denominator <= 0 || numerator <= denominator) return null
+  return Math.log(numerator / denominator) / Math.log(1 + rate)
+}
+
+/**
+ * The balance a declining-real-return plan converges to.
+ *
+ * When rho < 0 the recurrence B_{k+1} = B_k(1 + rho) + C has a stable fixed point at
+ * B* = -C/rho. Any target above B* is mathematically unreachable no matter how long you wait, so
+ * `Infinity` is the correct answer rather than a bug to be papered over.
+ */
+export function realFixedPoint(annualContribution: number, rho: number): number {
+  return -annualContribution / rho
+}
+
+/**
+ * Months to clear a single loan with level payment `payment`, standard amortization closed form.
+ *
+ *   n = -ln(1 - P*m/A) / ln(1 + m),    m = APR/12
+ *
+ * The lender charges interest once per period before the payment lands, so the real month count is
+ * ceil(n). Returns `null` when the payment never covers the first month's interest (P*m >= A), in
+ * which case the balance grows without bound.
+ */
+export function monthsToPayOffClosedForm(principal: number, apr: number, payment: number): number | null {
+  const monthlyRate = apr / 12
+  if (monthlyRate === 0) return Math.ceil(principal / payment)
+  if (principal * monthlyRate >= payment) return null
+  return -Math.log(1 - (principal * monthlyRate) / payment) / Math.log(1 + monthlyRate)
+}
+
+/**
+ * Total interest paid clearing a single loan, simulated from the recurrence:
+ * interest accrues once, then the payment is applied.
+ *
+ *   B <- B(1 + m);  pay min(A, B)
+ *
+ * Charging interest more than once per month is exactly the #45 defect, so this oracle is written
+ * to accrue it exactly once and nowhere else.
+ */
+export function amortize(principal: number, apr: number, payment: number, maxMonths = 600): {
+  months: number
+  totalInterest: number
+  firstMonthInterest: number
+} {
+  const monthlyRate = apr / 12
+  let balance = principal
+  let totalInterest = 0
+  let firstMonthInterest = 0
+  let months = 0
+  while (balance > 0 && months < maxMonths) {
+    months++
+    const interest = balance * monthlyRate
+    if (months === 1) firstMonthInterest = interest
+    balance += interest
+    totalInterest += interest
+    balance -= Math.min(payment, balance)
+  }
+  return { months, totalInterest, firstMonthInterest }
+}
+
+/**
+ * Sum of `n` payments starting at `amount` and inflating at `i`, closed form geometric series:
+ *
+ *   S = A * ((1+i)^n - 1) / i          (and A*n when i = 0)
+ */
+export function inflatingSum(amount: number, inflationRate: number, years: number): number {
+  if (years <= 0) return 0
+  if (inflationRate === 0) return amount * years
+  return (amount * (Math.pow(1 + inflationRate, years) - 1)) / inflationRate
+}
+
+/**
+ * Retirement drawdown balances, simulated from the recurrence:
+ *
+ *   B_0 = P,   B_k = B_{k-1}(1 + r) - W_0(1 + i)^{k-1}
+ *
+ * The withdrawal taken during year k is the one set at the START of that year, which is why the
+ * inflation exponent is k-1 and not k. Returns `[B_0, B_1, ...]` for `steps` steps.
+ */
+export function drawdownSeries(
+  portfolio: number,
+  initialWithdrawal: number,
+  nominalReturn: number,
+  inflationRate: number,
+  steps: number,
+): number[] {
+  const series = [portfolio]
+  let balance = portfolio
+  for (let k = 1; k <= steps; k++) {
+    balance = balance * (1 + nominalReturn) - initialWithdrawal * Math.pow(1 + inflationRate, k - 1)
+    series.push(balance)
+  }
+  return series
+}

--- a/web/src/utils/__tests__/parity.test.ts
+++ b/web/src/utils/__tests__/parity.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  calculateAvalanchePayoff,
+  calculateHealthcareGap,
+  calculateInvestmentGrowth,
+  calculateReverseFIRE,
+  calculateSnowballPayoff,
+  calculateStandardFIRE,
+  calculateWithdrawal,
+} from '../calculations'
+import {
+  debtCases,
+  decode,
+  fireCases,
+  healthcareCases,
+  investmentCases,
+  toFireInputs,
+  withdrawalCases,
+} from './parityFixtures'
+
+/**
+ * Shipped TypeScript === shared fixture.
+ *
+ * The same fixture is asserted against `FinancialCalculator.cs` by
+ * `app/MyFireNumber.Tests/Calculations/SharedParityFixtureTests.cs`. Neither platform can move a
+ * number without the other's suite failing, which is the drift issue #54 reports.
+ *
+ * `fixtureSelfCheck.test.ts` independently proves the fixture's own numbers are right, so a green
+ * run here means "web agrees with algebra", not merely "web agrees with itself".
+ */
+
+describe('standard FIRE parity', () => {
+  it.each(fireCases.map((c) => [c.id, c] as const))('%s', (_id, testCase) => {
+    const result = calculateStandardFIRE(toFireInputs(testCase))
+    const expected = testCase.expected
+
+    expect(result.fireNumber).toBe(expected.fireNumber)
+    expect(result.yearsToFIRE).toBe(decode(expected.yearsToFire))
+    expect(result.fireAge).toBe(decode(expected.fireAge))
+    expect(result.coastFireNumber).toBe(expected.coastFireNumber)
+    expect(result.savingsRate).toBeCloseTo(expected.savingsRate, 12)
+    expect(result.monthlyContribution).toBeCloseTo(expected.monthlyContribution, 12)
+    expect(result.projections).toHaveLength(expected.projectionCount)
+
+    for (const sample of expected.projectionSamples) {
+      const point = result.projections.find((p) => p.age === sample.age)
+      expect(point, `no projection point at age ${sample.age}`).toBeDefined()
+      expect(point!.portfolio).toBe(sample.portfolio)
+      expect(point!.inflationAdjusted).toBe(sample.inflationAdjusted)
+      expect(point!.totalContributions).toBe(sample.totalContributions)
+      expect(point!.contributions).toBe(sample.contributions)
+    }
+  })
+
+  it.each(fireCases.map((c) => [c.id, c] as const))('%s reverse FIRE', (_id, testCase) => {
+    const i = testCase.inputs
+    const result = calculateReverseFIRE(
+      i.currentAge,
+      i.retirementAge,
+      i.currentSavings,
+      i.annualExpenses,
+      i.expectedReturn,
+      i.inflationRate,
+      i.withdrawalRate,
+      i.contributionGrowth,
+    )
+    const expected = testCase.expected.reverse
+    expect(result.requiredAnnualSavings).toBeCloseTo(expected.requiredAnnualSavings, 6)
+    expect(result.requiredMonthlySavings).toBeCloseTo(expected.requiredMonthlySavings, 6)
+    expect(result.currentWillGrowTo).toBe(expected.currentWillGrowTo)
+    expect(result.alreadyAchievable).toBe(expected.alreadyAchievable)
+  })
+})
+
+describe('debt payoff parity', () => {
+  it.each(debtCases.map((c) => [c.id, c] as const))('%s', (_id, testCase) => {
+    const { debts, monthlyPayment, extraPayment, strategy } = testCase.inputs
+    const result =
+      strategy === 'snowball'
+        ? calculateSnowballPayoff(debts, monthlyPayment, extraPayment)
+        : calculateAvalanchePayoff(debts, monthlyPayment, extraPayment)
+
+    expect(result.totalMonths).toBe(testCase.expected.totalMonths)
+    expect(result.totalInterest).toBe(testCase.expected.totalInterest)
+    expect(result.totalPrincipal).toBe(testCase.expected.totalPrincipal)
+    expect(result.monthlyPayment).toBe(testCase.expected.monthlyPayment)
+    expect(result.payoffOrder).toEqual(testCase.expected.payoffOrder)
+    // Projection rows are rounded to whole dollars for display, so the exact accrual
+    // (sum of balance * rate / 12) is compared through the same rounding. This still separates
+    // correct from broken by a wide margin: the #45 defect double-charged interest, reporting
+    // 333 rather than 167 for the single-debt case. `debtPayoff.test.ts` pins an unrounded
+    // accrual exactly, using a balance whose monthly interest is a whole number.
+    expect(result.projections[0].interestPaid).toBe(Math.round(testCase.expected.firstMonthInterest))
+  })
+})
+
+describe('withdrawal parity', () => {
+  it.each(withdrawalCases.map((c) => [c.id, c] as const))('%s', (_id, testCase) => {
+    const i = testCase.inputs
+    const result = calculateWithdrawal(
+      i.portfolioValue,
+      i.withdrawalRate,
+      i.expectedReturn,
+      i.inflationRate,
+      i.retirementYears,
+    )
+    const expected = testCase.expected
+
+    expect(result.annualWithdrawal).toBe(expected.annualWithdrawal)
+    expect(result.monthlyWithdrawal).toBe(expected.monthlyWithdrawal)
+    expect(result.portfolioLongevity).toBe(expected.portfolioLongevity)
+    expect(result.horizonFundedRatio).toBeCloseTo(expected.horizonFundedRatio, 12)
+    expect(result.endingBalance).toBe(expected.endingBalance)
+    expect(result.rateAnalysis).toHaveLength(expected.rateAnalysis.length)
+    result.rateAnalysis.forEach((row, index) => {
+      expect(row.rate).toBeCloseTo(expected.rateAnalysis[index].rate, 12)
+      expect(row.years).toBe(expected.rateAnalysis[index].years)
+      expect(row.endBalance).toBe(expected.rateAnalysis[index].endBalance)
+    })
+  })
+})
+
+describe('investment growth parity', () => {
+  it.each(investmentCases.map((c) => [c.id, c] as const))('%s', (_id, testCase) => {
+    const i = testCase.inputs
+    const result = calculateInvestmentGrowth(
+      i.startingAmount,
+      i.contributionAmount,
+      i.contributionFrequency,
+      i.yearsInvesting,
+      i.expectedReturn,
+      i.inflationRate,
+      i.annualIncome,
+      i.currentAge,
+      i.contributionGrowth,
+    )
+    const expected = testCase.expected
+
+    expect(result.annualContribution).toBeCloseTo(expected.annualContribution, 9)
+    expect(result.monthlyContribution).toBeCloseTo(expected.monthlyContribution, 9)
+    expect(result.savingsRate).toBeCloseTo(expected.savingsRate, 12)
+    expect(result.finalNominalBalance).toBeCloseTo(expected.finalNominalBalance, 6)
+    expect(result.finalInflationAdjustedBalance).toBeCloseTo(expected.finalInflationAdjustedBalance, 6)
+    expect(result.totalInvested).toBeCloseTo(expected.totalInvested, 6)
+    expect(result.totalGrowth).toBeCloseTo(expected.totalGrowth, 6)
+    expect(result.inflationImpact).toBeCloseTo(expected.inflationImpact, 6)
+  })
+})
+
+describe('healthcare gap parity', () => {
+  it.each(healthcareCases.map((c) => [c.id, c] as const))('%s', (_id, testCase) => {
+    const i = testCase.inputs
+    const result = calculateHealthcareGap(
+      i.currentAge,
+      i.earlyRetirementAge,
+      i.monthlyPremium,
+      i.annualDeductible,
+      i.annualOutOfPocket,
+      i.inflationRate,
+    )
+    const expected = testCase.expected
+
+    expect(result.gapYears).toBe(expected.gapYears)
+    expect(result.annualCost).toBe(expected.annualCost)
+    expect(result.totalCost).toBe(expected.totalCost)
+    expect(result.avgAnnualCost).toBe(expected.avgAnnualCost)
+  })
+})

--- a/web/src/utils/__tests__/parityFixtures.ts
+++ b/web/src/utils/__tests__/parityFixtures.ts
@@ -1,0 +1,197 @@
+import rawFixture from '../../../../shared/parity/fire-parity-cases.json'
+
+import type { ContributionGrowth, DebtItem, FIREInputs } from '../calculations'
+
+/**
+ * Typed view over `shared/parity/fire-parity-cases.json`.
+ *
+ * The fixture is imported as a module rather than read with `fs` so TypeScript sees its literal
+ * shape. The `satisfies` assertion at the bottom of this file therefore makes a malformed case
+ * fail `npm run build` at compile time, instead of silently producing a plausible-looking wrong
+ * answer at runtime. That matters here: during the audit a malformed fixture produced a confident
+ * 22-row bug report that was entirely fictional.
+ */
+
+/** JSON has no infinity literal, so the fixture carries it as a string sentinel. */
+export type FixtureNumber = number | 'Infinity' | '-Infinity'
+
+export function decode(value: FixtureNumber): number {
+  if (value === 'Infinity') return Number.POSITIVE_INFINITY
+  if (value === '-Infinity') return Number.NEGATIVE_INFINITY
+  return value
+}
+
+export interface ProjectionSample {
+  year: number
+  age: number
+  portfolio: number
+  inflationAdjusted: number
+  totalContributions: number
+  contributions: number
+}
+
+export interface FireCase {
+  id: string
+  kind: 'fire'
+  description: string
+  derivation: string
+  inputs: {
+    currentAge: number
+    retirementAge: number
+    currentSavings: number
+    annualContribution: number
+    annualIncome: number
+    expectedReturn: number
+    inflationRate: number
+    withdrawalRate: number
+    annualExpenses: number
+    contributionGrowth: ContributionGrowth
+  }
+  expected: {
+    fireNumber: number
+    yearsToFire: FixtureNumber
+    fireAge: FixtureNumber
+    coastFireNumber: number
+    savingsRate: number
+    monthlyContribution: number
+    projectionCount: number
+    projectionSamples: ProjectionSample[]
+    reverse: {
+      requiredAnnualSavings: number
+      requiredMonthlySavings: number
+      currentWillGrowTo: number
+      alreadyAchievable: boolean
+    }
+  }
+}
+
+export interface DebtCase {
+  id: string
+  kind: 'debt'
+  description: string
+  derivation: string
+  inputs: {
+    debts: DebtItem[]
+    monthlyPayment: number
+    extraPayment: number
+    strategy: 'snowball' | 'avalanche'
+  }
+  expected: {
+    totalMonths: number
+    totalInterest: number
+    totalPrincipal: number
+    monthlyPayment: number
+    firstMonthInterest: number
+    payoffOrder: string[]
+  }
+}
+
+export interface WithdrawalCase {
+  id: string
+  kind: 'withdrawal'
+  description: string
+  derivation: string
+  inputs: {
+    portfolioValue: number
+    withdrawalRate: number
+    expectedReturn: number
+    inflationRate: number
+    retirementYears: number
+  }
+  expected: {
+    annualWithdrawal: number
+    monthlyWithdrawal: number
+    portfolioLongevity: number
+    horizonFundedRatio: number
+    endingBalance: number
+    rateAnalysis: { rate: number; years: number; endBalance: number }[]
+  }
+}
+
+export interface InvestmentCase {
+  id: string
+  kind: 'investment'
+  description: string
+  derivation: string
+  inputs: {
+    startingAmount: number
+    contributionAmount: number
+    contributionFrequency: 'monthly' | 'yearly'
+    yearsInvesting: number
+    expectedReturn: number
+    inflationRate: number
+    annualIncome: number
+    currentAge: number
+    contributionGrowth: ContributionGrowth
+  }
+  expected: {
+    annualContribution: number
+    monthlyContribution: number
+    savingsRate: number
+    finalNominalBalance: number
+    finalInflationAdjustedBalance: number
+    totalInvested: number
+    totalGrowth: number
+    inflationImpact: number
+  }
+}
+
+export interface HealthcareCase {
+  id: string
+  kind: 'healthcare'
+  description: string
+  derivation: string
+  inputs: {
+    currentAge: number
+    earlyRetirementAge: number
+    monthlyPremium: number
+    annualDeductible: number
+    annualOutOfPocket: number
+    inflationRate: number
+  }
+  expected: {
+    gapYears: number
+    annualCost: number
+    totalCost: number
+    avgAnnualCost: number
+  }
+}
+
+export type ParityCase = FireCase | DebtCase | WithdrawalCase | InvestmentCase | HealthcareCase
+
+/**
+ * The compile-time guard. If a case in the JSON gains a stray field, loses a required one, or uses
+ * a value outside a union (a `contributionGrowth` of `"indexed"`, say), this line fails `tsc` and
+ * therefore fails `npm run build`.
+ */
+const fixture = rawFixture as { cases: ParityCase[] }
+export const parityCases = fixture.cases satisfies ParityCase[]
+
+function casesOfKind<K extends ParityCase['kind']>(kind: K): Extract<ParityCase, { kind: K }>[] {
+  return parityCases.filter(
+    (testCase): testCase is Extract<ParityCase, { kind: K }> => testCase.kind === kind,
+  )
+}
+
+export const fireCases = casesOfKind('fire')
+export const debtCases = casesOfKind('debt')
+export const withdrawalCases = casesOfKind('withdrawal')
+export const investmentCases = casesOfKind('investment')
+export const healthcareCases = casesOfKind('healthcare')
+
+/** Maps a fixture case's named inputs onto the single-object shape the FIRE calculators take. */
+export function toFireInputs(testCase: FireCase): FIREInputs {
+  const { inputs } = testCase
+  return {
+    currentAge: inputs.currentAge,
+    retirementAge: inputs.retirementAge,
+    currentSavings: inputs.currentSavings,
+    annualContribution: inputs.annualContribution,
+    annualIncome: inputs.annualIncome,
+    expectedReturn: inputs.expectedReturn,
+    inflationRate: inputs.inflationRate,
+    withdrawalRate: inputs.withdrawalRate,
+    annualExpenses: inputs.annualExpenses,
+    contributionGrowth: inputs.contributionGrowth,
+  }
+}

--- a/web/src/utils/__tests__/projections.test.ts
+++ b/web/src/utils/__tests__/projections.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+
+import { generateProjections, realReturn } from '../calculations'
+import { deflate, nominalEscalatingSeries, nominalFlatSeries, realBalanceClosedForm, realRate } from './oracles'
+
+/**
+ * The inflation identity.
+ *
+ * Contributions are entered in today's dollars and are actually paid as C(1+i)^k nominal at the end
+ * of year k. Under that convention the deflated projection is *identical* to the closed form used
+ * for the headline FIRE age, not an approximation of it:
+ *
+ *   P_n/(1+i)^n = PV(1+rho)^n + C((1+rho)^n - 1)/rho,     rho = (1+r)/(1+i) - 1
+ *
+ * That equality is the strongest oracle available in this codebase, because it ties the chart the
+ * user sees to the number the headline reports. Issue #46 was precisely those two disagreeing.
+ */
+
+const SCENARIOS = [
+  { label: 'shipped defaults', pv: 100_000, c: 24_000, r: 0.07, i: 0.03 },
+  { label: 'high inflation', pv: 250_000, c: 30_000, r: 0.09, i: 0.06 },
+  { label: 'zero inflation', pv: 50_000, c: 12_000, r: 0.05, i: 0 },
+  { label: 'zero return', pv: 80_000, c: 10_000, r: 0, i: 0.02 },
+  { label: 'degenerate rho = 0', pv: 50_000, c: 20_000, r: 0.05, i: 0.05 },
+  { label: 'negative rho', pv: 100_000, c: 20_000, r: 0.02, i: 0.05 },
+  { label: 'no contribution', pv: 400_000, c: 0, r: 0.07, i: 0.03 },
+] as const
+
+describe('generateProjections structure', () => {
+  it('emits one point per year inclusive of both endpoints', () => {
+    expect(generateProjections(30, 100_000, 24_000, 0.07, 0.03, 25)).toHaveLength(26)
+    expect(generateProjections(30, 100_000, 24_000, 0.07, 0.03, 0)).toHaveLength(1)
+  })
+
+  it('advances age by exactly one year per point', () => {
+    const points = generateProjections(42, 100_000, 24_000, 0.07, 0.03, 20)
+    points.forEach((point, index) => expect(point.age).toBe(42 + index))
+  })
+
+  it('starts at the current savings with no growth or discounting applied', () => {
+    const [first] = generateProjections(30, 100_000, 24_000, 0.07, 0.03, 10)
+    expect(first.portfolio).toBe(100_000)
+    expect(first.inflationAdjusted).toBe(100_000)
+    expect(first.totalContributions).toBe(100_000)
+    expect(first.contributions).toBe(100_000)
+  })
+})
+
+describe.each(SCENARIOS.map((s) => [s.label, s] as const))('inflation identity: %s', (_label, s) => {
+  const YEARS = 30
+  const projections = generateProjections(30, s.pv, s.c, s.r, s.i, YEARS, 'inflation')
+
+  it('portfolio matches a from-scratch nominal recurrence B_k = B_{k-1}(1+r) + C(1+i)^k', () => {
+    const series = nominalEscalatingSeries(s.pv, s.c, s.r, s.i, YEARS)
+    projections.forEach((point, k) => expect(point.portfolio).toBe(Math.round(series[k])))
+  })
+
+  it('inflationAdjusted equals the deflated nominal series', () => {
+    const series = nominalEscalatingSeries(s.pv, s.c, s.r, s.i, YEARS)
+    projections.forEach((point, k) =>
+      expect(point.inflationAdjusted).toBe(Math.round(deflate(series[k], s.i, k))),
+    )
+  })
+
+  it('inflationAdjusted equals the closed form exactly, so the chart and headline cannot diverge', () => {
+    projections.forEach((point, k) =>
+      expect(point.inflationAdjusted).toBe(
+        Math.round(realBalanceClosedForm(s.pv, s.c, s.r, s.i, k)),
+      ),
+    )
+  })
+
+  it('recurrence and closed form agree to floating-point noise, confirming an identity', () => {
+    // If this were an approximation the gap would grow with n. Asserting a relative tolerance at
+    // year 30 rules that out.
+    const series = nominalEscalatingSeries(s.pv, s.c, s.r, s.i, YEARS)
+    const recurrence = deflate(series[YEARS], s.i, YEARS)
+    const closedForm = realBalanceClosedForm(s.pv, s.c, s.r, s.i, YEARS)
+    expect(Math.abs(recurrence - closedForm) / Math.max(1, Math.abs(closedForm))).toBeLessThan(1e-12)
+  })
+})
+
+describe.each(SCENARIOS.map((s) => [s.label, s] as const))('flat contributions: %s', (_label, s) => {
+  const YEARS = 30
+  const projections = generateProjections(30, s.pv, s.c, s.r, s.i, YEARS, 'flat')
+
+  it('portfolio matches B_k = B_{k-1}(1+r) + C with no escalation', () => {
+    const series = nominalFlatSeries(s.pv, s.c, s.r, YEARS)
+    projections.forEach((point, k) => expect(point.portfolio).toBe(Math.round(series[k])))
+  })
+
+  it('contributions stay nominally constant after the seed year', () => {
+    projections.slice(1).forEach((point) => expect(point.contributions).toBe(s.c))
+  })
+})
+
+describe('growth mode comparison', () => {
+  it('flat never outgrows inflation-matched contributions in real terms', () => {
+    // Same nominal contribution in year one, but flat loses purchasing power thereafter, so its
+    // deflated balance can never lead. Equality holds only when i = 0 or C = 0.
+    const inflation = generateProjections(30, 100_000, 24_000, 0.07, 0.03, 40, 'inflation')
+    const flat = generateProjections(30, 100_000, 24_000, 0.07, 0.03, 40, 'flat')
+    flat.forEach((point, k) => expect(point.inflationAdjusted).toBeLessThanOrEqual(inflation[k].inflationAdjusted))
+  })
+
+  it('the two modes coincide when inflation is zero', () => {
+    const inflation = generateProjections(30, 100_000, 24_000, 0.07, 0, 20, 'inflation')
+    const flat = generateProjections(30, 100_000, 24_000, 0.07, 0, 20, 'flat')
+    expect(flat.map((p) => p.portfolio)).toEqual(inflation.map((p) => p.portfolio))
+  })
+})
+
+describe('degenerate and unreachable real returns', () => {
+  it('rho = 0 grows linearly in today\u2019s dollars', () => {
+    // r = i = 5% means every year adds exactly the real contribution and nothing compounds:
+    // 50,000 + 20,000k. This is the divide-by-zero the annuity closed form must special-case.
+    expect(realReturn(0.05, 0.05)).toBe(0)
+    const projections = generateProjections(30, 50_000, 20_000, 0.05, 0.05, 60)
+    projections.forEach((point, k) => expect(point.inflationAdjusted).toBe(50_000 + 20_000 * k))
+    expect(projections[60].inflationAdjusted).toBe(1_250_000)
+  })
+
+  it('rho < 0 converges to the fixed point -C/rho and never exceeds it', () => {
+    // A 2% return against 5% inflation. The real balance rises but is bounded by 700,000 exactly,
+    // which is why a 1,250,000 target correctly reports Infinity rather than some large year count.
+    const rho = realRate(0.02, 0.05)
+    const ceiling = -20_000 / rho
+    expect(ceiling).toBeCloseTo(700_000, 6)
+
+    const projections = generateProjections(30, 100_000, 20_000, 0.02, 0.05, 100)
+    projections.forEach((point) => expect(point.inflationAdjusted).toBeLessThan(Math.ceil(ceiling)))
+
+    // Exact approach law: rewriting the recurrence about its fixed point gives
+    //   B_k = B* - (B* - B_0)(1+rho)^k
+    // so the gap to the ceiling shrinks geometrically. At k = 100, (1+rho)^100 is still ~0.055,
+    // hence ~666,900 rather than something arbitrarily close to 700,000 — convergence is slow,
+    // which is exactly why no finite year count reaches a 1,250,000 target.
+    projections.forEach((point, k) => {
+      const exact = ceiling - (ceiling - 100_000) * Math.pow(1 + rho, k)
+      expect(point.inflationAdjusted).toBe(Math.round(exact))
+    })
+
+    for (let k = 1; k < projections.length; k++) {
+      expect(projections[k].inflationAdjusted).toBeGreaterThanOrEqual(projections[k - 1].inflationAdjusted)
+    }
+  })
+})
+
+describe('totalContributions accounting', () => {
+  it('equals the seed plus every nominal contribution paid so far', () => {
+    const projections = generateProjections(30, 100_000, 24_000, 0.07, 0.03, 20, 'inflation')
+    let running = 100_000
+    projections.forEach((point, k) => {
+      if (k > 0) running += 24_000 * Math.pow(1.03, k)
+      expect(point.totalContributions).toBe(Math.round(running))
+    })
+  })
+
+  it('never exceeds the portfolio when returns are non-negative', () => {
+    const projections = generateProjections(30, 100_000, 24_000, 0.07, 0.03, 30)
+    projections.forEach((point) => expect(point.totalContributions).toBeLessThanOrEqual(point.portfolio))
+  })
+})

--- a/web/src/utils/__tests__/reverseFire.test.ts
+++ b/web/src/utils/__tests__/reverseFire.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateReverseFIRE, calculateStandardFIRE, realReturn } from '../calculations'
+import { realBalanceClosedForm, realRate } from './oracles'
+
+/**
+ * Reverse FIRE: "what must I save to retire at age X?"
+ *
+ * The strongest available oracle is the round trip. Feeding the required savings this function
+ * reports back into `calculateStandardFIRE` must return the target retirement age. The two
+ * functions solve the same equation for different unknowns, so agreement is a genuine constraint
+ * rather than a restatement of one implementation.
+ */
+
+describe('calculateReverseFIRE', () => {
+  // Signature: (currentAge, targetRetirementAge, currentSavings, annualExpenses, expectedReturn,
+  // inflationRate, withdrawalRate, contributionGrowth?)
+  const reverse = (overrides: Partial<{
+    currentAge: number
+    targetRetirementAge: number
+    currentSavings: number
+    annualExpenses: number
+    expectedReturn: number
+    inflationRate: number
+    withdrawalRate: number
+    contributionGrowth: 'inflation' | 'flat'
+  }> = {}) => {
+    const p = {
+      currentAge: 30,
+      targetRetirementAge: 55,
+      currentSavings: 100_000,
+      annualExpenses: 48_000,
+      expectedReturn: 0.07,
+      inflationRate: 0.03,
+      withdrawalRate: 0.04,
+      contributionGrowth: 'inflation' as const,
+      ...overrides,
+    }
+    return calculateReverseFIRE(
+      p.currentAge,
+      p.targetRetirementAge,
+      p.currentSavings,
+      p.annualExpenses,
+      p.expectedReturn,
+      p.inflationRate,
+      p.withdrawalRate,
+      p.contributionGrowth,
+    )
+  }
+
+  it('targets expenses divided by the withdrawal rate', () => {
+    expect(reverse().fireNumber).toBe(1_200_000)
+  })
+
+  it('lands exactly on the target in today\u2019s dollars', () => {
+    // The defining property: saving the reported amount for the reported horizon reaches the FIRE
+    // number precisely. Checked against an independently written closed form, not the projections.
+    const result = reverse()
+    const landed = realBalanceClosedForm(100_000, result.requiredAnnualSavings, 0.07, 0.03, 25)
+    expect(landed).toBeCloseTo(1_200_000, 6)
+  })
+
+  it('matches the annuity payment formula C = (T - PV(1+rho)^n) * rho / ((1+rho)^n - 1)', () => {
+    // Independent algebra: solve T = PV(1+rho)^n + C((1+rho)^n - 1)/rho for C.
+    const rho = realRate(0.07, 0.03)
+    const growth = Math.pow(1 + rho, 25)
+    const expected = ((1_200_000 - 100_000 * growth) * rho) / (growth - 1)
+    expect(reverse().requiredAnnualSavings).toBeCloseTo(expected, 6)
+    expect(expected).toBeCloseTo(22_946.80026660227, 6)
+  })
+
+  it('monthly savings is the annual figure over twelve', () => {
+    const result = reverse()
+    expect(result.requiredMonthlySavings).toBeCloseTo(result.requiredAnnualSavings / 12, 12)
+  })
+
+  it('round trips through calculateStandardFIRE back to the target age', () => {
+    // The key cross-check between the two solvers.
+    for (const targetRetirementAge of [45, 50, 55, 60, 65]) {
+      const result = reverse({ targetRetirementAge })
+      const forward = calculateStandardFIRE({
+        currentAge: 30,
+        retirementAge: targetRetirementAge,
+        currentSavings: 100_000,
+        annualContribution: result.requiredAnnualSavings,
+        annualIncome: 72_000,
+        expectedReturn: 0.07,
+        inflationRate: 0.03,
+        withdrawalRate: 0.04,
+        annualExpenses: 48_000,
+        contributionGrowth: 'inflation',
+      })
+      expect(forward.fireAge).toBeCloseTo(targetRetirementAge, 1)
+    }
+  })
+
+  it('round trips for flat nominal contributions too', () => {
+    for (const targetRetirementAge of [45, 55, 65]) {
+      const result = reverse({ targetRetirementAge, contributionGrowth: 'flat' })
+      const forward = calculateStandardFIRE({
+        currentAge: 30,
+        retirementAge: targetRetirementAge,
+        currentSavings: 100_000,
+        annualContribution: result.requiredAnnualSavings,
+        annualIncome: 72_000,
+        expectedReturn: 0.07,
+        inflationRate: 0.03,
+        withdrawalRate: 0.04,
+        annualExpenses: 48_000,
+        contributionGrowth: 'flat',
+      })
+      expect(forward.fireAge).toBeCloseTo(targetRetirementAge, 1)
+    }
+  })
+
+  it('reports what existing savings alone will grow to, in today\u2019s dollars', () => {
+    // PV(1+rho)^n with no contributions at all.
+    const expected = 100_000 * Math.pow(1 + realReturn(0.07, 0.03), 25)
+    expect(reverse().currentWillGrowTo).toBe(Math.round(expected))
+  })
+
+  it('requires nothing further when existing savings already reach the target', () => {
+    const result = reverse({ currentSavings: 600_000 })
+    expect(result.alreadyAchievable).toBe(true)
+    expect(result.requiredAnnualSavings).toBe(0)
+    expect(result.requiredMonthlySavings).toBe(0)
+  })
+
+  it('never reports a negative required contribution', () => {
+    for (const savings of [0, 100_000, 500_000, 900_000, 5_000_000]) {
+      expect(reverse({ currentSavings: savings }).requiredAnnualSavings).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('a longer horizon never requires saving more', () => {
+    const amounts = [40, 45, 50, 55, 60, 65].map(
+      (age) => reverse({ targetRetirementAge: age }).requiredAnnualSavings,
+    )
+    for (let i = 1; i < amounts.length; i++) expect(amounts[i]).toBeLessThanOrEqual(amounts[i - 1])
+  })
+
+  it('higher expenses never require saving less', () => {
+    const amounts = [24_000, 48_000, 72_000, 96_000].map(
+      (expenses) => reverse({ annualExpenses: expenses }).requiredAnnualSavings,
+    )
+    for (let i = 1; i < amounts.length; i++) expect(amounts[i]).toBeGreaterThanOrEqual(amounts[i - 1])
+  })
+
+  it('flat nominal contributions always demand more than inflation-matched ones', () => {
+    // A fixed nominal payment loses purchasing power, so more of it is needed to hit the same
+    // today's-dollars target.
+    const inflation = reverse({ contributionGrowth: 'inflation' }).requiredAnnualSavings
+    const flat = reverse({ contributionGrowth: 'flat' }).requiredAnnualSavings
+    expect(flat).toBeGreaterThan(inflation)
+  })
+
+  it('solves the zero-real-return case linearly', () => {
+    // rho = 0 makes the annuity factor 0/0; the limit is the straight-line split of the shortfall.
+    // (1,200,000 - 100,000)/25 = 44,000 exactly.
+    const result = reverse({ expectedReturn: 0.05, inflationRate: 0.05 })
+    expect(realReturn(0.05, 0.05)).toBe(0)
+    expect(result.requiredAnnualSavings).toBeCloseTo(44_000, 6)
+  })
+
+  it('treats a horizon of zero or less as a single year rather than dividing by zero', () => {
+    for (const targetRetirementAge of [30, 25]) {
+      const result = reverse({ targetRetirementAge })
+      expect(result.yearsToFIRE).toBe(1)
+      expect(Number.isFinite(result.requiredAnnualSavings)).toBe(true)
+    }
+  })
+})

--- a/web/src/utils/__tests__/withdrawal.test.ts
+++ b/web/src/utils/__tests__/withdrawal.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest'
+
+import { calculateWithdrawal } from '../calculations'
+import { drawdownSeries } from './oracles'
+
+/**
+ * Withdrawal / portfolio longevity.
+ *
+ * The oracle is an independently written drawdown recurrence:
+ *
+ *   B_0 = P,   B_k = B_{k-1}(1+r) - W_0(1+i)^{k-1}
+ *
+ * The withdrawal taken during year k is the one set at the start of that year, so the inflation
+ * exponent is k-1. Getting that off by one is exactly the class of error the audit was chasing.
+ */
+
+const RATE_ANALYSIS_RATES = [0.03, 0.035, 0.04, 0.045, 0.05]
+
+describe('calculateWithdrawal', () => {
+  // Signature: (portfolioValue, withdrawalRate, expectedReturn, inflationRate, retirementYears)
+  it('derives the withdrawal from portfolio and rate', () => {
+    const result = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30)
+    expect(result.annualWithdrawal).toBe(40_000)
+    expect(result.monthlyWithdrawal).toBe(Math.round(40_000 / 12))
+  })
+
+  it.each([
+    [1_000_000, 0.04, 0.07, 0.03, 30],
+    [1_000_000, 0.05, 0.03, 0.03, 40],
+    [500_000, 0.05, 0.02, 0.04, 45],
+    [1_000_000, 0.04, 0.04, 0.05, 45],
+    [2_500_000, 0.03, 0.06, 0.02, 35],
+  ] as const)(
+    'balances follow B_k = B_{k-1}(1+r) - W(1+i)^{k-1} for (%s, %s, %s, %s, %s)',
+    (portfolio, rate, ret, inflation, years) => {
+      const result = calculateWithdrawal(portfolio, rate, ret, inflation, years)
+      const oracle = drawdownSeries(portfolio, portfolio * rate, ret, inflation, years + 1)
+      result.withdrawalProjections.forEach((point) => {
+        expect(point.balance).toBe(Math.round(oracle[point.year]))
+      })
+    },
+  )
+
+  it('inflates each successive withdrawal by exactly one year', () => {
+    const result = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30)
+    result.withdrawalProjections.forEach((point) => {
+      expect(point.withdrawal).toBe(Math.round(40_000 * Math.pow(1.03, point.year)))
+    })
+  })
+
+  it('numbers projection years consecutively from zero', () => {
+    const result = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30)
+    result.withdrawalProjections.forEach((point, index) => expect(point.year).toBe(index))
+  })
+
+  it('every reported funded year really did end with a positive balance', () => {
+    // The definition of portfolioLongevity, checked against the independent series rather than
+    // against the loop that produced it.
+    for (const [portfolio, rate, ret, inflation, years] of [
+      [1_000_000, 0.05, 0.03, 0.03, 40],
+      [500_000, 0.05, 0.02, 0.04, 45],
+      [1_000_000, 0.04, 0.04, 0.05, 45],
+    ] as const) {
+      const result = calculateWithdrawal(portfolio, rate, ret, inflation, years)
+      const oracle = drawdownSeries(portfolio, portfolio * rate, ret, inflation, years + 1)
+      expect(oracle[result.portfolioLongevity]).toBeGreaterThan(0)
+      if (result.portfolioLongevity < years) {
+        expect(oracle[result.portfolioLongevity + 1]).toBeLessThanOrEqual(0)
+      }
+    }
+  })
+
+  it('caps longevity at the requested horizon when the portfolio survives', () => {
+    const result = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30)
+    expect(result.portfolioLongevity).toBe(30)
+    expect(result.horizonFundedRatio).toBe(1)
+  })
+
+  it('reports a fractional funded ratio when the portfolio runs out early', () => {
+    const result = calculateWithdrawal(1_000_000, 0.05, 0.03, 0.03, 40)
+    expect(result.portfolioLongevity).toBeLessThan(40)
+    expect(result.horizonFundedRatio).toBeCloseTo(result.portfolioLongevity / 40, 12)
+    expect(result.horizonFundedRatio).toBeLessThan(1)
+  })
+
+  it('never reports a funded ratio above 1 or below 0', () => {
+    for (const rate of [0.02, 0.03, 0.04, 0.06, 0.10]) {
+      const { horizonFundedRatio } = calculateWithdrawal(1_000_000, rate, 0.05, 0.03, 30)
+      expect(horizonFundedRatio).toBeGreaterThanOrEqual(0)
+      expect(horizonFundedRatio).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('treats a zero-length horizon as fully funded rather than dividing by zero', () => {
+    const result = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 0)
+    expect(result.horizonFundedRatio).toBe(1)
+    expect(Number.isNaN(result.horizonFundedRatio)).toBe(false)
+  })
+
+  it('never reports a negative ending balance', () => {
+    for (const rate of [0.03, 0.05, 0.08, 0.15]) {
+      expect(calculateWithdrawal(500_000, rate, 0.02, 0.04, 45).endingBalance).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  describe('rate analysis table', () => {
+    it('covers the five documented rates in ascending order', () => {
+      const rows = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30).rateAnalysis
+      expect(rows.map((r) => r.rate)).toEqual(RATE_ANALYSIS_RATES)
+    })
+
+    it('years are non-increasing as the withdrawal rate rises', () => {
+      // Spending more can never make a portfolio last longer.
+      for (const [ret, inflation] of [
+        [0.07, 0.03],
+        [0.03, 0.03],
+        [0.02, 0.04],
+      ] as const) {
+        const rows = calculateWithdrawal(1_000_000, 0.04, ret, inflation, 30).rateAnalysis
+        for (let i = 1; i < rows.length; i++) {
+          expect(rows[i].years).toBeLessThanOrEqual(rows[i - 1].years)
+        }
+      }
+    })
+
+    it('ending balances are non-increasing as the withdrawal rate rises', () => {
+      const rows = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30).rateAnalysis
+      for (let i = 1; i < rows.length; i++) {
+        expect(rows[i].endBalance).toBeLessThanOrEqual(rows[i - 1].endBalance)
+      }
+    })
+
+    it('each row matches an independent drawdown at that rate', () => {
+      const rows = calculateWithdrawal(1_000_000, 0.04, 0.03, 0.03, 40).rateAnalysis
+      for (const row of rows) {
+        const oracle = drawdownSeries(1_000_000, 1_000_000 * row.rate, 0.03, 0.03, 50)
+        if (row.years < 50) {
+          expect(oracle[row.years]).toBeGreaterThan(0)
+          expect(oracle[row.years + 1]).toBeLessThanOrEqual(0)
+        }
+      }
+    })
+
+    it('agrees with the headline longevity when depletion beats both horizon caps', () => {
+      // The headline stops at `retirementYears`; the table stops at a fixed 50-year horizon. When
+      // the portfolio runs dry before either cap binds, both must report the same year. These three
+      // cases all deplete early, so any disagreement here is a real inconsistency.
+      for (const [portfolio, rate, ret, inflation, years] of [
+        [1_000_000, 0.05, 0.03, 0.03, 40],
+        [500_000, 0.05, 0.02, 0.04, 45],
+        [1_000_000, 0.04, 0.04, 0.05, 45],
+      ] as const) {
+        const result = calculateWithdrawal(portfolio, rate, ret, inflation, years)
+        const row = result.rateAnalysis.find((r) => Math.abs(r.rate - rate) < 1e-12)
+        expect(row, `no rate analysis row for ${rate}`).toBeDefined()
+        expect(result.portfolioLongevity).toBeLessThan(years)
+        expect(row!.years).toBeLessThan(50)
+        expect(result.portfolioLongevity).toBe(row!.years)
+      }
+    })
+
+    it('the two horizons bind independently when the portfolio survives', () => {
+      // Characterization, not a defect: a portfolio that outlives both windows reports the
+      // headline capped at `retirementYears` (30) and the table capped at its own 50-year horizon.
+      // They describe different questions, so they are allowed to differ here — but only here.
+      const result = calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30)
+      expect(result.portfolioLongevity).toBe(30)
+      expect(result.rateAnalysis.find((r) => r.rate === 0.04)!.years).toBe(50)
+    })
+  })
+
+  describe('economic sanity', () => {
+    it('a portfolio earning more than it pays out never depletes', () => {
+      // Withdrawals grow at 3% while the portfolio earns 7%: the balance rises without bound.
+      const result = calculateWithdrawal(1_000_000, 0.03, 0.07, 0.03, 50)
+      expect(result.portfolioLongevity).toBe(50)
+      expect(result.endingBalance).toBeGreaterThan(1_000_000)
+    })
+
+    it('a portfolio paying out far more than it earns depletes quickly', () => {
+      const result = calculateWithdrawal(1_000_000, 0.20, 0.02, 0.03, 40)
+      expect(result.portfolioLongevity).toBeLessThan(10)
+    })
+
+    it('a larger portfolio at the same rate lasts exactly as long', () => {
+      // The drawdown recurrence is homogeneous of degree one, so scaling the portfolio scales every
+      // balance and leaves the depletion year unchanged.
+      const small = calculateWithdrawal(500_000, 0.05, 0.03, 0.03, 40)
+      const large = calculateWithdrawal(5_000_000, 0.05, 0.03, 0.03, 40)
+      expect(large.portfolioLongevity).toBe(small.portfolioLongevity)
+    })
+  })
+})

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -10,6 +10,9 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    /* The shared parity fixture is imported as a typed module so a malformed case
+       fails `npm run build` instead of producing garbage at runtime. */
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Standalone from `vite.config.ts` on purpose.
+ *
+ * The app config instantiates the React and PWA plugins, neither of which the calculation suite
+ * needs — these tests are pure functions plus `react-dom/server` string rendering, so they run in
+ * the `node` environment with no DOM and no service-worker generation.
+ *
+ * Test files live under `src/` so the existing `tsconfig.json` (`include: ["src"]`) type-checks
+ * them during `npm run build`. That is deliberate: several calculator entry points take long
+ * positional argument lists, so a miswired call is caught by `tsc` before it can produce a
+ * confidently wrong number.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+})


### PR DESCRIPTION
Closes #54.

`web/` had no test runner, so `calculations.ts` (1,208 lines) and `deferredCompensation.ts` (313 lines) had zero automated coverage. This adds Vitest, covers both modules, and introduces a shared fixture that pins the web and MAUI engines to the same numbers.

**Test-only. No calculation source file is modified.** Verified: the diff touches no file under `web/src/utils/calculations.ts`, `deferredCompensation.ts`, `excelExport.ts`, or `app/MyFireNumber.Core/`.

## Why Vitest

Shares the existing Vite 7 transform pipeline, so strict-mode TypeScript runs with no extra build config and one new devDependency. Jest would need a parallel transform stack for an ESM/TS/Vite project; `node --test` can't resolve the project's TS path aliases.

Tests live under `src/`, inside the existing `tsconfig` `include`. That is deliberate: `npm run build` runs `tsc` first, so **a wrong call signature is a build failure**, not a confidently wrong assertion. Verified by planting a 7-argument `calculateCoastFIRE` call — `error TS2554: Expected 8-9 arguments, but got 7`.

## Expectations are derived, not captured

The central hazard is a test that asserts current output — a screenshot, not a test. The defence here is structural.

`web/src/utils/__tests__/oracles.ts` **imports nothing at all**. It is independently written closed forms and recurrence simulators. `fixtureSelfCheck.test.ts` imports only those oracles and the fixture — never the shipped code.

The strongest oracle is the inflation identity. With contributions in today's dollars escalating with inflation, the deflated projection *equals* the closed form rather than approximating it:

```
P_n/(1+i)^n = PV*(1+rho)^n + C*((1+rho)^n - 1)/rho,   rho = (1+r)/(1+i) - 1
```

The projection series is asserted against that directly, over a parameter table including `rho = 0` and `rho < 0`. The **crossing invariant** from #46 — the age where the projection crosses the target must equal the headline FIRE age — is asserted across Standard/Lean/Fat/Coast/Barista in both growth modes, on both platforms.

## Parity is three-way, not two-way

Previously each platform asserted against constants copied from the other at some point, so either could drift and its own tests would drift with it.

```
independent algebraic oracle === shared JSON fixture === web (Vitest)
                                                     === MAUI (xUnit)
```

`shared/parity/fire-parity-cases.json` holds 16 cases read by both suites. Every case carries a **required `derivation` field** stating the closed form it came from; a case cannot be added without it, and a `[Fact]` enforces the field is non-empty. A fixture value silently regenerated from an implementation fails the oracle self-check.

Inputs are named **semantically, never positionally**, because the platforms disagree on argument order — web takes 8 positional args for Coast FIRE, the MAUI mirror takes a single record. Each side adapts locally, so an argument-order mistake cannot be shared between the suites.

`Infinity` is stored as the string `"Infinity"`: JSON has no infinity literal, and emitting a bare `Infinity` token produces a file `JSON.parse` rejects. Both adapters decode the sentinel.

## Anchors

All eight verified anchors were **independently re-derived from algebra before writing any assertion**, then reproduced by the fixture, then by the shipped TypeScript, then by the C# mirror. **None contradicted.** FIRE age 54.4; crossing 1,173,603 to 1,243,180; savings and investment 643,649.74 / 1,562,306.86; reverse FIRE landing exactly on 1,200,000; degenerate `rho=0` giving age 90 exactly; debt 25 months / $2,266 / $166.67 month-one; avalanche never costing more interest than snowball; and `Infinity` correct where the fixed point `-C/rho` = $700,000 sits below a $1.25M target.

## Coverage

**541 web tests** across 12 files; **155 C# tests** (120 existing, all still passing, plus 35 new).

`prepareResultsForExport` gets direct coverage via **key-set guards** per result type — any new scalar on a result type fails the test and forces a conscious decision rather than silently appearing in a user's `.xlsx`. `ResultCard` unreachable-value guards are covered with `react-dom/server`, zero new dependencies.

## CI

New `.github/workflows/tests.yml` runs both suites on pull requests. `dotnet test` previously ran **only on push to `main`**, inside the Android packaging workflow, filtered to `app/**` — nothing verified either engine on a PR. Both jobs also trigger on `shared/parity/**`, so a fixture edit re-runs both sides rather than one.

## Findings — reported, deliberately not fixed

Per the test-only constraint. Each needs its own issue and PR.

1. **`totalMonths` exports as currency.** New, live, user-visible. `'totalmonths'` contains `'total'`, which is in `currencyKeys`, and `currencyKeys` is tested *before* `timeKeys` — so the `'months'` match is never reached. `'currency'` maps to numFmt `'$#,##0'`, so a 25-month debt payoff is written into the user's spreadsheet as **`$25`**. `DebtPayoff.tsx:74` forwards the derived formats with no override. Same substring-collision class as the `'rate'`/`'ratio'` bug the audit already hit. Pinned as a characterization test asserting the *wrong* value on purpose — when it is fixed, that test should fail, and that is the signal.
2. **`calculateCoastFIRE` JSDoc is inverted** relative to the actual signature: it lists `@param withdrawalRate` before `@param annualExpenses`, and its `@example` passes `0.04` as `annualExpenses` and `48000` as `withdrawalRate`. Almost certainly the source of the audit's trap #1.
3. **Booleans still leak into exports.** `typeof true` is neither array nor object, so `isLean` / `isFat` / `alreadyCoasting` reach the workbook with no format hint.
4. **`null` still emits a row.** The guard is `typeof value === 'object' && value !== null`. `DeferredCompensation.tsx:94` works around it at the call site with `?? 0` rather than in the helper.
5. **`calculateWithdrawal` JSDoc overstates agreement** — it claims the headline and `rateAnalysis` "always agree for the same rate", but the headline caps at `retirementYears` while the table caps at `RATE_ANALYSIS_MAX_YEARS = 50`. Behaviour is by design; only the comment is wrong.
6. **The degenerate case's crossing is unobservable.** `fire-degenerate-zero-real-return` reaches FIRE in year 60, but projections cap at 50 points, so the chart stops 10 years short of the crossing. Documented in that case's `derivation`; the invariant test returns early rather than silently passing.

## Deliberately not covered

React pages, hooks, URL/localStorage round-tripping (needs jsdom, different concern); `exportToExcel` workbook bytes (MAUI already has 10 workbook tests — the hazard is `prepareResultsForExport`, not ExcelJS); `quizRecommendations.ts`, `savedCalculationStorage.ts`, `currencyPeriod.ts` (outside #54); chart rendering.

## Validation

- `npm test` — 541 passing
- `npm run build` — clean
- `dotnet test` — 155 passing, Debug and Release
- `npm ci` verified against the hand-edited lockfile from a clean `node_modules`; the lockfile does not re-churn
- Zero spurious `"peer": true` entries in the lockfile diff
- No calculation source file changed
