### PR TITLE
test: pin cross-platform surplus rounding divergence and input-export hazards

### DIFF
--- a/app/MyFireNumber.Tests/Calculations/SurplusRoundingDivergenceTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/SurplusRoundingDivergenceTests.cs
@@ -1,0 +1,106 @@
+using MyFireNumber.Core.Calculations;
+
+namespace MyFireNumber.Tests.Calculations;
+
+/// <summary>
+/// KNOWN CROSS-PLATFORM DIVERGENCE — tracked in issue #63. Not fixed here; this PR is test-only.
+///
+/// <para>The web engine rounds the deferred-compensation <c>surplus</c> with bare
+/// <c>Math.round</c> (deferredCompensation.ts:284), while this side uses
+/// <c>Math.Round(value, MidpointRounding.AwayFromZero)</c>. <c>surplus</c> is the only signed field —
+/// every other field goes through a helper that clamps at zero first, so no other value is
+/// exposed.</para>
+///
+/// <para>The two modes agree on positives and away from midpoints, and disagree at an exact negative
+/// half-integer:</para>
+/// <code>
+/// JS  Math.round(-2.5)                              === -2
+/// C#  Math.Round(-2.5, MidpointRounding.AwayFromZero) == -3
+/// </code>
+///
+/// <para>The inputs below drive the raw surplus to exactly -2.50 and exactly -0.50. Both operands
+/// are exactly representable in binary64, so these are deterministic midpoints rather than
+/// floating-point noise.</para>
+///
+/// <para>These assert the CURRENT C# VALUES, and the matching web pins live in
+/// <c>web/src/utils/__tests__/deferredCompensation.test.ts</c>. They are deliberately NOT in
+/// <c>shared/parity/fire-parity-cases.json</c>: that fixture asserts agreement between the two
+/// platforms, and there is none to assert here. Adding a case would have forced a choice of which
+/// platform is correct, which is a behaviour change and belongs in the fix for #63. When that fix
+/// lands, these tests SHOULD fail — that is the signal.</para>
+/// </summary>
+public class SurplusRoundingDivergenceTests
+{
+    /// <summary>
+    /// A flat, after-tax $10,000 pension with zero inflation and no accounts, so the surplus is
+    /// exactly <c>10,000 - annualExpenses</c> with no compounding in the way.
+    /// </summary>
+    private static DeferredCompensationResult FlatShortfall(double annualExpenses) =>
+        DeferredCompensationCalculator.Calculate(new DeferredCompensationInputs(
+            CurrentAge: 60,
+            SemiRetirementAge: 60,
+            PlanThroughAge: 62,
+            AnnualExpenses: annualExpenses,
+            InflationRate: 0,
+            Accounts: [],
+            IncomeSources: [new RetirementIncomeSource("pension", "Pension", 10_000, 0, 200, 0, true, 0)],
+            AdditionalExpenses: [],
+            WithdrawOnlyAfterRetirement: false,
+            ReinvestSurplus: false,
+            CurrentYear: 2025));
+
+    [Fact]
+    public void NegativeMidpoint_RoundsAwayFromZero_WhereWebRoundsTowardIt()
+    {
+        // 10,000 - 10,002.50 = -2.50 exactly. The web engine reports -2 for this same input.
+        var result = FlatShortfall(10_002.5);
+
+        Assert.Equal(-3, result.Projections[0].Surplus);
+        Assert.Equal(-3, result.FirstYearSurplus);
+    }
+
+    [Fact]
+    public void HalfDollarShortfall_ReportsAShortfall_WhereWebReportsAFullyFundedPlan()
+    {
+        /*
+         * This is the consequential half. The shortfall predicate reads the ROUNDED surplus
+         * (DeferredCompensationCalculator.cs:155), so the rounding mode decides a categorical
+         * outcome rather than a display cent.
+         *
+         * This side rounds -0.50 to -1, which is < 0, so the year counts as a shortfall. The web
+         * engine gets Math.round(-0.5) === -0, and -0 < 0 is false, so it counts the same year as
+         * fully funded. Same inputs, opposite answers to "does my plan work":
+         *
+         *                        web       MAUI
+         *   surplus               -0         -1
+         *   fundedYears            3          0
+         *   firstShortfallAge   null         60
+         *   yearsFullyCovered      3          0
+         */
+        var result = FlatShortfall(10_000.5);
+
+        Assert.Equal(-1, result.Projections[0].Surplus);
+        Assert.Equal(0, result.FundedYears);
+        Assert.Equal(60, result.FirstShortfallAge);
+        Assert.Equal(0, result.YearsFullyCovered);
+    }
+
+    [Fact]
+    public void PositiveMidpoint_AgreesWithWeb_WhichIsWhyThisWentUnnoticed()
+    {
+        // Math.round(2.5) === 3 and MidpointRounding.AwayFromZero also gives 3. The modes differ
+        // only on negatives.
+        var result = FlatShortfall(9_997.5);
+
+        Assert.Equal(3, result.Projections[0].Surplus);
+    }
+
+    [Fact]
+    public void AwayFromMidpoint_AgreesWithWeb()
+    {
+        // -2.4 rounds to -2 under both modes; the divergence needs an exact half.
+        var result = FlatShortfall(10_002.4);
+
+        Assert.Equal(-2, result.Projections[0].Surplus);
+    }
+}

--- a/web/src/utils/__tests__/deferredCompensation.test.ts
+++ b/web/src/utils/__tests__/deferredCompensation.test.ts
@@ -572,3 +572,89 @@ describe('degenerate inputs', () => {
     })
   })
 })
+
+/**
+ * KNOWN CROSS-PLATFORM DIVERGENCE — tracked in issue #63. Not fixed here; this PR is test-only.
+ *
+ * `surplus` is the one field that uses bare `Math.round` (line 284) rather than the `round` helper,
+ * because it is legitimately allowed to be negative — the helper clamps at zero. The MAUI mirror
+ * rounds the same field with `MidpointRounding.AwayFromZero`.
+ *
+ * Those two agree everywhere except at an exact negative half-integer:
+ *
+ *     JS  Math.round(-2.5)                             === -2
+ *     C#  Math.Round(-2.5, MidpointRounding.AwayFromZero) == -3
+ *
+ * The inputs below make the raw surplus exactly -2.50 and exactly -0.50. Both operands are exactly
+ * representable in binary64, so these are deterministic midpoints, not floating-point noise.
+ *
+ * These tests assert the CURRENT WEB VALUES so the divergence is visible and cannot drift further
+ * unnoticed. They are deliberately NOT in shared/parity/fire-parity-cases.json: that fixture asserts
+ * agreement between the platforms, and adding a case would have forced a choice of which platform is
+ * right, which is a behaviour change. When #63 unifies the rounding, these tests SHOULD fail — that
+ * is the signal. The matching pins live in SharedParityFixtureTests.cs.
+ */
+describe('negative-midpoint surplus rounding (issue #63)', () => {
+  // A flat, after-tax $10,000 pension with zero inflation and no accounts, so surplus is exactly
+  // `pension - annualExpenses` with no compounding in the way.
+  const flatShortfall = (annualExpenses: number) =>
+    calculateDeferredCompensation(
+      plan({
+        currentAge: 60,
+        semiRetirementAge: 60,
+        planThroughAge: 62,
+        annualExpenses,
+        inflationRate: 0,
+        accounts: [],
+        incomeSources: [income({ id: 'pension', name: 'Pension', annualAmount: 10_000 })],
+        withdrawOnlyAfterRetirement: false,
+      }),
+    )
+
+  it('rounds a -2.50 surplus toward zero, where the MAUI mirror rounds away from it', () => {
+    // 10,000 - 10,002.50 = -2.50 exactly. MAUI reports -3 for this same input.
+    const result = flatShortfall(10_002.5)
+
+    expect(result.projections[0].surplus).toBe(-2)
+    expect(result.firstYearSurplus).toBe(-2)
+  })
+
+  it('rounds a -0.50 surplus to negative zero, which flips the funded/shortfall verdict', () => {
+    /*
+     * This is the consequential half. The shortfall predicates below (`point.surplus < 0`, lines
+     * 296-299) read the ROUNDED surplus, so the rounding mode decides a categorical outcome rather
+     * than a display cent.
+     *
+     * `Math.round(-0.5)` is `-0`, and `-0 < 0` is false, so web classifies a fifty-cent shortfall as
+     * a fully funded year. The MAUI mirror gets -1, which IS < 0, and reports a shortfall at the
+     * first retirement age. Same inputs, opposite answers to "does my plan work":
+     *
+     *              web        MAUI
+     *   surplus     -0          -1
+     *   fundedYears  3           0
+     *   firstShortfallAge null   60
+     *   yearsFullyCovered 3      0
+     */
+    const result = flatShortfall(10_000.5)
+
+    expect(Object.is(result.projections[0].surplus, -0)).toBe(true)
+    expect(result.fundedYears).toBe(3)
+    expect(result.firstShortfallAge).toBeNull()
+    expect(result.yearsFullyCovered).toBe(3)
+  })
+
+  it('agrees with the mirror at a positive midpoint, which is why this went unnoticed', () => {
+    // Math.round(2.5) === 3 and MidpointRounding.AwayFromZero also gives 3. The two modes differ
+    // only on negatives, and surplus is the only signed field, so nothing else is exposed.
+    const result = flatShortfall(9_997.5)
+
+    expect(result.projections[0].surplus).toBe(3)
+  })
+
+  it('agrees with the mirror away from midpoints', () => {
+    // -2.4 rounds to -2 under both modes; the divergence needs an exact half.
+    const result = flatShortfall(10_002.4)
+
+    expect(result.projections[0].surplus).toBe(-2)
+  })
+})

--- a/web/src/utils/__tests__/excelExport.test.ts
+++ b/web/src/utils/__tests__/excelExport.test.ts
@@ -12,7 +12,7 @@ import {
   calculateWithdrawal,
 } from '../calculations'
 import type { FIREInputs } from '../calculations'
-import { prepareResultsForExport } from '../excelExport'
+import { prepareInputsForExport, prepareResultsForExport } from '../excelExport'
 
 /**
  * `prepareResultsForExport` enumerates every scalar on a result object and picks percent/currency
@@ -215,9 +215,9 @@ describe('format inference by key name', () => {
 
 describe('known hazards, pinned as characterization', () => {
   /*
-   * The two behaviours below are pre-existing and are NOT changed by this test-only work. They are
+   * The behaviours below are pre-existing and are NOT changed by this test-only work. They are
    * pinned so the next person sees them stated rather than rediscovering them from a user's
-   * spreadsheet. Both deserve their own issue and their own fix.
+   * spreadsheet. Booleans and null are tracked in issue #64; totalMonths has its own issue, #62.
    */
 
   it('booleans still reach the workbook as untyped rows', () => {
@@ -263,7 +263,7 @@ describe('known hazards, pinned as characterization', () => {
 
   it('totalMonths is exported as CURRENCY, not a duration', () => {
     /*
-     * FINDING (live, user-visible, pre-existing — reported, deliberately not fixed here).
+     * FINDING (live, user-visible, pre-existing). Tracked in issue #62, deliberately not fixed here.
      *
      * This is the same substring-collision class as the 'rate' / 'ratio' bug the audit already hit,
      * and it is currently shipping.
@@ -302,5 +302,82 @@ describe('empty and degenerate input', () => {
   it('does not invent rows for a result made only of arrays and objects', () => {
     const { values } = prepareResultsForExport({ rows: [1, 2], nested: { a: 1 } })
     expect(values).toEqual({})
+  })
+})
+
+/**
+ * `prepareInputsForExport` is the sibling of `prepareResultsForExport` and has the same
+ * substring-matching design, with two differences that both produce wrong formatting. Tracked in
+ * issue #64. Not fixed here; this PR is test-only.
+ *
+ * All of these assert the CURRENT, WRONG behaviour on purpose. When #64 is fixed they SHOULD fail.
+ */
+describe('prepareInputsForExport hazards, pinned as characterization (issue #64)', () => {
+  // The exact input DebtPayoff.tsx:71 passes, so these are the formats a real user's workbook gets.
+  const debtInputs = () =>
+    prepareInputsForExport({
+      strategy: 'snowball',
+      mode: 'budget',
+      monthlyBudget: 500,
+      targetMonths: 24,
+      extraPayment: 0,
+      totalDebts: 2,
+      totalDebt: 21_500,
+    })
+
+  it('exports totalDebt without currency formatting', () => {
+    // The exact inverse of the totalMonths bug in #62. There, a month count is formatted as money
+    // because 'total' is in the results currencyKeys. Here, the inputs currencyKeys list
+    // ('savings', 'contribution', 'expenses', 'income', 'value', 'budget', 'payment', 'premium',
+    // 'deductible', 'pocket') has no 'total' entry at all, so totalDebt — a genuine dollar amount —
+    // matches nothing and falls through to 'number'. Same root cause, opposite direction.
+    expect(debtInputs().formats.totalDebt).toBe('number')
+
+    // monthlyBudget is formatted correctly, via 'budget'. The list is not broken, just incomplete.
+    expect(debtInputs().formats.monthlyBudget).toBe('currency')
+  })
+
+  it('assigns a numeric format to non-numeric values', () => {
+    // Unlike prepareResultsForExport, the format branch here is not gated on
+    // `typeof value === 'number'`, so text values receive a numeric format too.
+    //
+    // CORRECTION to issue #64, which records `strategy` as getting 'number': it actually gets
+    // 'percent', because 'strategy' contains the substring 'rate' (st-RATE-gy) and percentKeys is
+    // tested before currencyKeys. So the string "snowball" is written into a cell carrying numFmt
+    // '0.0%'. 'mode' does get 'number' as filed.
+    const { values, formats } = debtInputs()
+
+    expect(values.strategy).toBe('snowball')
+    expect(formats.strategy).toBe('percent')
+
+    expect(values.mode).toBe('budget')
+    expect(formats.mode).toBe('number')
+  })
+
+  it('has no non-finite guard, unlike its results sibling', () => {
+    // prepareResultsForExport substitutes 'Not reachable' for Infinity and NaN. This one has no such
+    // guard, so a non-finite input value is written straight through. Inputs are user-entered so
+    // this is harder to reach than the results path, but the asymmetry is worth stating.
+    const { values } = prepareInputsForExport({ annualIncome: Infinity })
+    expect(values.annualIncome).toBe(Infinity)
+  })
+
+  it('checks ageKeys first, so any key containing "age" is formatted as an age', () => {
+    // Latent rather than live: every current parameter containing 'age' is a genuine age
+    // (currentAge, retirementAge, targetRetirementAge, earlyRetirementAge, medicareAge,
+    // planThroughAge), so nothing is mis-formatted today. But 'age' is checked before percent and
+    // currency, so a future 'mortgageBalance' or 'averageReturn' would silently export with the
+    // age format. Pinned to document the ordering trap before it bites.
+    const { formats } = prepareInputsForExport({ mortgageBalance: 300_000, averageReturn: 0.07 })
+    expect(formats.mortgageBalance).toBe('age')
+    expect(formats.averageReturn).toBe('age')
+
+    // A real age is still correct, which is why the collision is easy to miss.
+    expect(prepareInputsForExport({ currentAge: 30 }).formats.currentAge).toBe('age')
+  })
+
+  it('skips arrays and objects, matching its results sibling', () => {
+    const { values } = prepareInputsForExport({ debts: [{ balance: 1 }], nested: {}, budget: 500 })
+    expect(Object.keys(values)).toEqual(['budget'])
   })
 })

--- a/web/src/utils/calculations.ts
+++ b/web/src/utils/calculations.ts
@@ -472,12 +472,15 @@ export function calculateStandardFIRE(inputs: FIREInputs): StandardFIREResult {
  * @param annualContribution - Annual savings amount (used for accelerated scenario)
  * @param expectedReturn - Expected annual return (decimal, e.g., 0.07 for 7%)
  * @param inflationRate - Expected inflation rate (decimal)
- * @param withdrawalRate - Safe withdrawal rate (typically 0.04)
  * @param annualExpenses - Annual living expenses in retirement
+ * @param withdrawalRate - Safe withdrawal rate (typically 0.04)
+ * @param contributionGrowth - Whether contributions escalate with inflation or stay flat
  * @returns Coast FIRE metrics including coast number, years to reach it, and projections
- * 
+ *
  * @example
- * calculateCoastFIRE(30, 55, 100000, 24000, 0.07, 0.03, 0.04, 48000)
+ * // annualExpenses comes BEFORE withdrawalRate. Passing them the other way round is silent —
+ * // both are numbers — and yields a plausible-looking but entirely wrong result.
+ * calculateCoastFIRE(30, 55, 100000, 24000, 0.07, 0.03, 48000, 0.04)
  * // If you have $100k at 30, you need ~$466k to "coast" to $1.2M by 55
  */
 export function calculateCoastFIRE(


### PR DESCRIPTION
Follow-up to #61. Test-only, plus one comment-only JSDoc correction. Targets `calculator-audit-fixes`.

Three items from review of #61: pin the rounding divergence, pin the two `prepareInputsForExport` hazards, and land the authorized `calculateCoastFIRE` JSDoc fix.

## 1. Surplus rounding divergence (#63) — pinned on both platforms

The web engine rounds `surplus` with bare `Math.round`; MAUI uses `MidpointRounding.AwayFromZero`. `surplus` is the only signed field either side exposes — every other field goes through a helper that clamps at zero first — so this is the sole point of contact.

They agree everywhere except exact negative half-integers:

```
JS  Math.round(-2.5)                               === -2
C#  Math.Round(-2.5, MidpointRounding.AwayFromZero) == -3
```

The consequential half: the shortfall predicate reads the **rounded** value, so rounding mode decides a categorical outcome, not a display cent. At a 50-cent shortfall `Math.round(-0.5)` is `-0`, and `-0 < 0` is `false`:

| | web | MAUI |
|---|---|---|
| `surplus` | `-0` | `-1` |
| `fundedYears` | **3** | **0** |
| `firstShortfallAge` | **null** | **60** |
| `yearsFullyCovered` | **3** | **0** |

Same inputs, opposite answers to "does my retirement plan work". The repro uses a flat $10,000 pension against `annualExpenses` of `10002.50` / `10000.50` — both operands exactly representable in binary64, so these are deterministic midpoints, not float noise.

**Pinned as platform-local characterization, deliberately NOT as a shared fixture case.** `shared/parity/fire-parity-cases.json` asserts agreement between the two engines, and there is none to assert here. A shared case would have forced choosing which platform is correct — a behaviour change, out of scope for a test-only PR, and properly part of the fix for #63. Each side asserts its own current value with a header citing #63. **When #63 is fixed these tests should fail. That is the signal.**

Each side also pins the two cases where the platforms *agree* — positive midpoint, and away from any midpoint — which is why this survived review.

## 2. `prepareInputsForExport` hazards (#64)

- **`totalDebt` exports without currency formatting.** The exact inverse of #62. There a month count is formatted as money because `'total'` is in the *results* `currencyKeys`; here a genuine dollar amount matches nothing in the *inputs* `currencyKeys` and falls through to `'number'`. Live via `DebtPayoff.tsx:71`.
- **Non-numeric values receive numeric formats.** Unlike `prepareResultsForExport`, this branch is not gated on `typeof value === 'number'`, so text cells carry number formats.

### One correction to #64

The issue records `strategy: 'snowball'` as getting `'number'`. It actually gets **`'percent'`** — `'strategy'` contains the substring `'rate'` (st-**rate**-gy), and `percentKeys` is tested before `currencyKeys`. So the string `"snowball"` is written into a cell with numFmt `'0.0%'`. `mode` does get `'number'` as filed. Pinned as observed.

### One new latent finding

`ageKeys = ['age']` is checked **first**, before percent and currency. No current parameter collides — every real param containing `age` is a genuine age — so this is latent, not live. Pinned to document the ordering trap before a future `mortgageBalance` or `averageReturn` hits it.

Also pins that `prepareInputsForExport` has **no non-finite guard**, unlike its results sibling which substitutes `'Not reachable'`.

## 3. `calculateCoastFIRE` JSDoc (authorized in review of #61)

The `@example` passed `withdrawalRate` and `annualExpenses` in the wrong order, and the `@param` list was ordered to match the wrong example rather than the signature. This is very likely the origin of trap #1 in the audit — two people got confidently wrong results from it. Comment-only; the signature is untouched. Every changed line in `calculations.ts` begins with ` *`.

Also adds #62 / #64 citations to the characterization tests landed in #61, so whoever fixes those issues knows which tests will flip.

## Validation

- `npm test` — **550 passing** (was 541)
- `npm run build` — clean
- `dotnet test` — **159 passing** (was 155)
- No calculation behaviour changed. The only non-test edit is the JSDoc comment above.

## CI topology — note for whoever comes next

The `tests.yml` jobs added in #61 run on this PR. **Android and iOS do not**, because they are `pull_request: branches: ['main']` and this targets `calculator-audit-fixes`. That is correct behaviour, not a gap — a PR into the integration branch gets the fast suites, and the full platform builds run at the integration PR into `main`. Noting it so the short check list is not misread as something being skipped.

Refs #62, #63, #64
