### PR TITLE
Replace Excel export name-inference with a declared field registry

### DIFF
--- a/web/src/pages/DeferredCompensation.tsx
+++ b/web/src/pages/DeferredCompensation.tsx
@@ -91,8 +91,9 @@ export default function DeferredCompensation() {
       accountCount: params.accounts.length,
       additionalExpenseCount: params.additionalExpenses.length,
     })
-    // prepareResultsForExport enumerates every scalar key, so a null firstShortfallAge would emit
-    // a blank row. Pass a curated shape instead of the raw result.
+    // prepareResultsForExport omits null rather than emitting a blank row, so a plan with no
+    // shortfall simply has no "First Shortfall Age" row. This used to pass `?? 0`, which wrote a 0
+    // that reads as a shortfall at age 0.
     const { values: resultValues, formats: resultFormats } = prepareResultsForExport({
       currentBalance: results.currentBalance,
       balanceAtSemiRetirement: results.balanceAtSemiRetirement,
@@ -102,7 +103,7 @@ export default function DeferredCompensation() {
       consecutiveFundedYears: results.fundedYears,
       retirementYears: results.retirementYears,
       yearsFullyCovered: results.yearsFullyCovered,
-      firstShortfallAge: results.firstShortfallAge ?? 0,
+      firstShortfallAge: results.firstShortfallAge,
     })
 
     exportToExcel({

--- a/web/src/utils/__tests__/excelExport.test.ts
+++ b/web/src/utils/__tests__/excelExport.test.ts
@@ -89,13 +89,13 @@ const PAGE_SOURCES = import.meta.glob('../../pages/*.tsx', {
 function readCallSiteKeys(fnName: string): Map<string, string[]> {
   const byFile = new Map<string, string[]>()
 
-  for (const [path, source] of Object.entries(PAGE_SOURCES)) {
+  for (const [path, raw] of Object.entries(PAGE_SOURCES)) {
+    const source = blankOutCommentsAndStrings(raw)
     const keys: string[] = []
-    const needle = `${fnName}({`
+    const call = new RegExp(`\\b${fnName}\\s*\\(\\s*\\{`, 'g')
 
-    let cursor = source.indexOf(needle)
-    while (cursor !== -1) {
-      const open = cursor + needle.length - 1
+    for (const match of source.matchAll(call)) {
+      const open = match.index + match[0].length - 1
       let depth = 0
       let close = -1
 
@@ -110,10 +110,11 @@ function readCallSiteKeys(fnName: string): Map<string, string[]> {
           }
         }
       }
-      if (close === -1) break
+      // An unbalanced literal means the scan lost track, and a scan that quietly returns fewer
+      // keys is worse than no scan at all: it reports success over fields nobody checked.
+      if (close === -1) throw new Error(`Could not find the end of the ${fnName} call in ${path}`)
 
       keys.push(...topLevelKeys(source.slice(open + 1, close)))
-      cursor = source.indexOf(needle, close)
     }
 
     if (keys.length > 0) byFile.set(path.split('/').pop() ?? path, keys)
@@ -122,10 +123,53 @@ function readCallSiteKeys(fnName: string): Map<string, string[]> {
   return byFile
 }
 
+/**
+ * Replace the contents of comments and string literals with spaces, preserving length and so every
+ * offset, before anything counts a brace.
+ *
+ * A `//` comment or a string holding an unbalanced `)` would otherwise end a scan early and drop
+ * every key after it, silently. That is the one failure mode this whole file cannot afford: the
+ * coverage suites would still pass, over a shorter list, which is indistinguishable from success.
+ */
+function blankOutCommentsAndStrings(source: string): string {
+  const out = source.split('')
+  let i = 0
+
+  const blankUntil = (isEnd: (index: number) => boolean, escapes: boolean) => {
+    i += 1
+    while (i < source.length && !isEnd(i)) {
+      if (escapes && source[i] === '\\') out[i++] = ' '
+      out[i] = source[i] === '\n' ? '\n' : ' '
+      i += 1
+    }
+  }
+
+  while (i < source.length) {
+    const char = source[i]
+    const next = source[i + 1]
+
+    if (char === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') out[i++] = ' '
+    } else if (char === '/' && next === '*') {
+      out[i] = ' '
+      blankUntil(index => source[index] === '*' && source[index + 1] === '/', false)
+      out[i] = ' '
+      out[i + 1] = ' '
+      i += 2
+    } else if (char === '"' || char === "'" || char === '`') {
+      blankUntil(index => source[index] === char, true)
+      i += 1
+    } else {
+      i += 1
+    }
+  }
+
+  return out.join('')
+}
+
 /** Property names declared directly on an object literal body, ignoring anything nested. */
 function topLevelKeys(body: string): string[] {
   const keys: string[] = []
-  const withoutComments = body.replace(/\/\/[^\n]*/g, '')
   let depth = 0
   let start = 0
 
@@ -138,16 +182,16 @@ function topLevelKeys(body: string): string[] {
     if (/^[A-Za-z_$][\w$]*$/.test(name)) keys.push(name)
   }
 
-  for (let i = 0; i < withoutComments.length; i += 1) {
-    const char = withoutComments[i]
+  for (let i = 0; i < body.length; i += 1) {
+    const char = body[i]
     if (char === '{' || char === '[' || char === '(') depth += 1
     else if (char === '}' || char === ']' || char === ')') depth -= 1
     else if (char === ',' && depth === 0) {
-      take(withoutComments.slice(start, i))
+      take(body.slice(start, i))
       start = i + 1
     }
   }
-  take(withoutComments.slice(start))
+  take(body.slice(start))
 
   return keys
 }
@@ -198,13 +242,65 @@ describe('exported fields are declared', () => {
 
   it('actually finds the page call sites it claims to check', () => {
     // Without this, renaming a helper would make the scan match nothing and the two suites above
-    // would pass by checking zero fields.
-    const inputs = readCallSiteKeys('prepareInputsForExport')
-    expect(inputs.size).toBe(11)
-    expect(inputs.get('DebtPayoff.tsx')).toContain('totalDebt')
+    // would pass by checking zero fields. Rather than hard-code a page count — which passes when a
+    // twelfth page is missed, i.e. fails in the permissive direction — this locates every call
+    // independently and asserts that each one passing an object literal was actually read.
+    for (const fnName of ['prepareInputsForExport', 'prepareResultsForExport'] as const) {
+      const parsed = readCallSiteKeys(fnName)
+      let literalCallSites = 0
 
-    const results = readCallSiteKeys('prepareResultsForExport')
-    expect(results.get('DeferredCompensation.tsx')).toContain('firstShortfallAge')
+      for (const [path, raw] of Object.entries(PAGE_SOURCES)) {
+        const file = path.split('/').pop() ?? path
+        const source = blankOutCommentsAndStrings(raw)
+
+        for (const call of source.matchAll(new RegExp(`\\b${fnName}\\s*\\(`, 'g'))) {
+          // Pages either build the shape inline or hand over a result object wholesale. Only the
+          // inline ones are this scanner's job; the rest are covered by RESULT_BUILDERS above.
+          if (!/^\s*\{/.test(source.slice(call.index + call[0].length))) continue
+          literalCallSites += 1
+          expect(
+            parsed.get(file),
+            `${file} passes an object literal to ${fnName}, but the call-site scanner in this ` +
+              'file read no fields out of it, so those exports are unchecked. Fix the scanner — ' +
+              'do not delete this assertion, and do not relax it to make the build go green.',
+          ).toBeDefined()
+        }
+      }
+
+      expect(literalCallSites).toBeGreaterThan(0)
+    }
+
+    expect(readCallSiteKeys('prepareInputsForExport').get('DebtPayoff.tsx')).toContain('totalDebt')
+    expect(readCallSiteKeys('prepareResultsForExport').get('DeferredCompensation.tsx')).toContain(
+      'firstShortfallAge',
+    )
+  })
+
+  it('reads keys past a comment or a string holding an unbalanced brace', () => {
+    // The three ways the scanner used to give up early and silently report a shorter list.
+    const hostile = [
+      'const handleExport = () => {',
+      '  prepareInputsForExport(',
+      '    {',
+      '      currentAge,',
+      "      label: 'plan {A',  // capped at 64 (see #62) :)",
+      '      mortgageBalance,',
+      '    },',
+      '  )',
+      '}',
+    ].join('\n')
+
+    const original = PAGE_SOURCES['../../pages/StandardFIRE.tsx']
+    try {
+      PAGE_SOURCES['../../pages/StandardFIRE.tsx'] = hostile
+      expect(readCallSiteKeys('prepareInputsForExport').get('StandardFIRE.tsx')).toEqual([
+        'currentAge',
+        'label',
+        'mortgageBalance',
+      ])
+    } finally {
+      PAGE_SOURCES['../../pages/StandardFIRE.tsx'] = original
+    }
   })
 })
 
@@ -469,7 +565,12 @@ describe('substring collisions that used to mis-format live exports', () => {
     // payoff was written into the user's spreadsheet as "$25". Exact lookup makes that impossible.
     //
     // Declared 'number' (#,##0 -> "25") rather than 'years' (0.0 -> "25.0"): these are whole
-    // months. MAUI already writes the same field with its decimal style, so the platforms agree.
+    // months, and "25.0 months" is a smaller version of the same defect.
+    //
+    // This deliberately diverges from MAUI, which writes TotalMonths with DecimalStyleIndex
+    // (DebtPayoffWorkbook.cs:61 -> format code "0.0") and so renders "25.0". MAUI is immune to the
+    // name-inference class — it declares a style per cell at the call site — but it picked a
+    // decimal style for a whole-number field. Web is correct here; the C# side is worth a look.
     const debt = calculateSnowballPayoff(DEBTS, 500)
     expect(debt.totalMonths).toBe(25)
 

--- a/web/src/utils/__tests__/excelExport.test.ts
+++ b/web/src/utils/__tests__/excelExport.test.ts
@@ -4,6 +4,7 @@ import {
   calculateBaristaFIRE,
   calculateCoastFIRE,
   calculateFatFIRE,
+  calculateHealthcareGap,
   calculateInvestmentGrowth,
   calculateLeanFIRE,
   calculateReverseFIRE,
@@ -12,21 +13,25 @@ import {
   calculateWithdrawal,
 } from '../calculations'
 import type { FIREInputs } from '../calculations'
-import { prepareInputsForExport, prepareResultsForExport } from '../excelExport'
+import { isExportFieldDeclared, prepareInputsForExport, prepareResultsForExport } from '../excelExport'
 
 /**
- * `prepareResultsForExport` enumerates every scalar on a result object and picks percent/currency
- * formatting by substring match on the key name. That design means **any new scalar field on a
- * result type silently appears in the user's spreadsheet**, formatted by whatever its name happens
- * to contain.
+ * Both export helpers used to infer a cell format by substring-matching the key name against
+ * hand-maintained lists whose order decided precedence. That produced seven shipped defects —
+ * `$25` for a 25-month payoff, `$3` for a count of three income sources, the string `"snowball"`
+ * in a percent cell — because a name like `totalMonths` or `incomeSourceCount` contains a word
+ * belonging to the wrong list.
  *
- * It bit the cross-platform audit three separate times: a new boolean leaked a row into the export,
- * `'rate'` matched while `'ratio'` did not so percent formatting was silently dropped, and a null
- * field emitted a blank row.
+ * Lookup is now exact, against a single declared map. This file guards the two properties that
+ * keep it that way:
  *
- * The key-set guards below are the point of this file. They fail when a result type gains or loses
- * an exported field, forcing a conscious decision about the workbook rather than letting it change
- * by accident.
+ *   - `exported fields are declared` walks the real calculator results and the real page call
+ *     sites, so a field that reaches a workbook without a declared format fails here first.
+ *   - `exported key sets` pins which fields reach the workbook at all, so a new scalar becomes a
+ *     decision rather than an accident.
+ *
+ * Both derive what they check from real code rather than a hand-kept list. A hand-kept list would
+ * be the same maintenance failure one level up.
  */
 
 const DEFAULTS: FIREInputs = {
@@ -42,60 +47,240 @@ const DEFAULTS: FIREInputs = {
   contributionGrowth: 'inflation',
 }
 
+const DEBTS = [{ id: '1', name: 'Card', balance: 10_000, rate: 0.2, minPayment: 200 }]
+
+/** Every result type a page hands to `prepareResultsForExport`, built by the real calculator. */
+const RESULT_BUILDERS = {
+  StandardFIRE: () => calculateStandardFIRE(DEFAULTS),
+  LeanFIRE: () => calculateLeanFIRE(DEFAULTS),
+  FatFIRE: () => calculateFatFIRE(DEFAULTS),
+  CoastFIRE: () => calculateCoastFIRE(30, 55, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04),
+  BaristaFIRE: () => calculateBaristaFIRE(30, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04, 20_000),
+  Withdrawal: () => calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30),
+  ReverseFIRE: () => calculateReverseFIRE(30, 55, 100_000, 48_000, 0.07, 0.03, 0.04),
+  InvestmentGrowth: () => calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30),
+  HealthcareGap: () => calculateHealthcareGap(30, 55, 600, 3_000, 2_000, 0.03),
+  DebtPayoff: () => calculateSnowballPayoff(DEBTS, 500),
+} as const
+
+// ================================================================================================
+// Coverage: nothing reaches a workbook without a declared format
+// ================================================================================================
+
+/**
+ * The source of every calculator page, read through Vite rather than `node:fs` so the suite keeps
+ * type-checking under `npm run build` without pulling in Node type definitions.
+ */
+const PAGE_SOURCES = import.meta.glob('../../pages/*.tsx', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>
+
+/**
+ * Read the object literals the pages actually pass to the export helpers.
+ *
+ * The input shapes are built inline inside each page's export handler, so there is nothing to
+ * import. Listing them here by hand would reintroduce exactly the drift this file exists to catch:
+ * the list would be correct the day it was written and quietly wrong afterwards. Reading the call
+ * sites keeps the check tied to shipping code, so adding `mortgageBalance: …` to a page fails this
+ * test rather than surfacing in someone's spreadsheet.
+ */
+function readCallSiteKeys(fnName: string): Map<string, string[]> {
+  const byFile = new Map<string, string[]>()
+
+  for (const [path, source] of Object.entries(PAGE_SOURCES)) {
+    const keys: string[] = []
+    const needle = `${fnName}({`
+
+    let cursor = source.indexOf(needle)
+    while (cursor !== -1) {
+      const open = cursor + needle.length - 1
+      let depth = 0
+      let close = -1
+
+      for (let i = open; i < source.length; i += 1) {
+        const char = source[i]
+        if (char === '{' || char === '[' || char === '(') depth += 1
+        else if (char === '}' || char === ']' || char === ')') {
+          depth -= 1
+          if (depth === 0) {
+            close = i
+            break
+          }
+        }
+      }
+      if (close === -1) break
+
+      keys.push(...topLevelKeys(source.slice(open + 1, close)))
+      cursor = source.indexOf(needle, close)
+    }
+
+    if (keys.length > 0) byFile.set(path.split('/').pop() ?? path, keys)
+  }
+
+  return byFile
+}
+
+/** Property names declared directly on an object literal body, ignoring anything nested. */
+function topLevelKeys(body: string): string[] {
+  const keys: string[] = []
+  const withoutComments = body.replace(/\/\/[^\n]*/g, '')
+  let depth = 0
+  let start = 0
+
+  const take = (segment: string) => {
+    const text = segment.trim()
+    if (!text) return
+    const colon = text.indexOf(':')
+    // A colon-less segment is shorthand (`totalDebt,`), which is a property name on its own.
+    const name = (colon === -1 ? text : text.slice(0, colon)).trim()
+    if (/^[A-Za-z_$][\w$]*$/.test(name)) keys.push(name)
+  }
+
+  for (let i = 0; i < withoutComments.length; i += 1) {
+    const char = withoutComments[i]
+    if (char === '{' || char === '[' || char === '(') depth += 1
+    else if (char === '}' || char === ']' || char === ')') depth -= 1
+    else if (char === ',' && depth === 0) {
+      take(withoutComments.slice(start, i))
+      start = i + 1
+    }
+  }
+  take(withoutComments.slice(start))
+
+  return keys
+}
+
+function undeclared(keys: Iterable<string>): string[] {
+  return [...new Set(keys)].filter(key => !isExportFieldDeclared(key)).sort()
+}
+
+function coverageFailure(source: string, missing: string[]): string {
+  return [
+    `${source} reaches an exported workbook with no declared format: ${missing.join(', ')}.`,
+    '',
+    'Undeclared fields still export, they just render unstyled — that is deliberate, so a missing',
+    'declaration never costs a user their data. It does mean nobody has decided how these should',
+    'look. Add each one to EXPORT_FIELD_FORMATS in web/src/utils/excelExport.ts:',
+    '',
+    "  'currency' / 'percent' / 'age'   dollars, rates, whole ages",
+    "  'years'                          a duration carrying one decimal (25.4 years)",
+    "  'number'                         a whole count (25 months, 3 accounts)",
+    "  'text'                           deliberately non-numeric: a string or a boolean",
+    '',
+    'Guessing the format from the name is what this map replaced. Pick one explicitly.',
+  ].join('\n')
+}
+
+describe('exported fields are declared', () => {
+  it.each(Object.entries(RESULT_BUILDERS))('%s results are fully declared', (label, build) => {
+    const { values } = prepareResultsForExport(build())
+    const missing = undeclared(Object.keys(values))
+    expect(missing, coverageFailure(`${label} results`, missing)).toEqual([])
+  })
+
+  it.each([...readCallSiteKeys('prepareInputsForExport')])(
+    '%s passes only declared input fields',
+    (file, keys) => {
+      const missing = undeclared(keys)
+      expect(missing, coverageFailure(`${file} inputs`, missing)).toEqual([])
+    },
+  )
+
+  it.each([...readCallSiteKeys('prepareResultsForExport')])(
+    '%s passes only declared result fields',
+    (file, keys) => {
+      const missing = undeclared(keys)
+      expect(missing, coverageFailure(`${file} results`, missing)).toEqual([])
+    },
+  )
+
+  it('actually finds the page call sites it claims to check', () => {
+    // Without this, renaming a helper would make the scan match nothing and the two suites above
+    // would pass by checking zero fields.
+    const inputs = readCallSiteKeys('prepareInputsForExport')
+    expect(inputs.size).toBe(11)
+    expect(inputs.get('DebtPayoff.tsx')).toContain('totalDebt')
+
+    const results = readCallSiteKeys('prepareResultsForExport')
+    expect(results.get('DeferredCompensation.tsx')).toContain('firstShortfallAge')
+  })
+})
+
+// ================================================================================================
+// Which fields reach the workbook at all
+// ================================================================================================
+
+function keySetFailure(label: string, actual: string[], expected: readonly string[]): string {
+  const added = actual.filter(key => !expected.includes(key))
+  const removed = expected.filter(key => !actual.includes(key))
+
+  return [
+    `${label} no longer exports the fields this test expects.`,
+    added.length > 0 ? `  now also exported: ${added.join(', ')}` : null,
+    removed.length > 0 ? `  no longer exported: ${removed.join(', ')}` : null,
+    '',
+    'This test is not asking you to paste the new list in. Everything in it lands in a spreadsheet',
+    'a user downloads and forwards to other people, so for each ADDED field pick one:',
+    '',
+    '  1. It belongs in the workbook — declare it in EXPORT_FIELD_FORMATS (web/src/utils/',
+    '     excelExport.ts) with the format it should render as, then add it to the list below.',
+    '  2. It does not belong — it is internal, or configuration rather than an outcome. Stop',
+    '     passing the raw result and pass a curated object instead, the way',
+    '     DeferredCompensation.tsx does.',
+    "  3. It belongs but is not a number — declare it as 'text' and add it below.",
+    '',
+    'A REMOVED field means a row existing users currently see has disappeared from their download.',
+    'Confirm that was intended before deleting it from the list.',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n')
+}
+
 describe('exported key sets', () => {
-  // If one of these fails, a result type gained or lost a scalar. Decide whether it belongs in the
-  // user's workbook and update the list deliberately — do not just paste the new set in.
   it.each([
     [
       'StandardFIRE',
-      () => calculateStandardFIRE(DEFAULTS),
       ['fireNumber', 'yearsToFIRE', 'fireAge', 'savingsRate', 'monthlyContribution', 'coastFireNumber'],
     ],
     [
       'LeanFIRE',
-      () => calculateLeanFIRE(DEFAULTS),
       ['fireNumber', 'yearsToFIRE', 'fireAge', 'savingsRate', 'monthlyContribution', 'coastFireNumber', 'isLean', 'leanThreshold'],
     ],
     [
       'FatFIRE',
-      () => calculateFatFIRE(DEFAULTS),
       ['fireNumber', 'yearsToFIRE', 'fireAge', 'savingsRate', 'monthlyContribution', 'coastFireNumber', 'isFat', 'fatThreshold'],
     ],
-    [
-      'CoastFIRE',
-      () => calculateCoastFIRE(30, 55, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04),
-      ['coastNumber', 'yearsToCoast', 'alreadyCoasting', 'fireNumber'],
-    ],
+    ['CoastFIRE', ['coastNumber', 'yearsToCoast', 'alreadyCoasting', 'fireNumber']],
     [
       'BaristaFIRE',
-      () => calculateBaristaFIRE(30, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04, 20_000),
       ['baristaNumber', 'fullFireNumber', 'yearsToBaristaFIRE', 'partTimeIncomeNeeded', 'savingsFromPartTime'],
     ],
     [
       'Withdrawal',
-      () => calculateWithdrawal(1_000_000, 0.04, 0.07, 0.03, 30),
       ['portfolioLongevity', 'horizonFundedRatio', 'annualWithdrawal', 'monthlyWithdrawal', 'endingBalance'],
     ],
     [
       'ReverseFIRE',
-      () => calculateReverseFIRE(30, 55, 100_000, 48_000, 0.07, 0.03, 0.04),
       ['fireNumber', 'yearsToFIRE', 'requiredAnnualSavings', 'requiredMonthlySavings', 'alreadyAchievable', 'currentWillGrowTo'],
     ],
     [
       'InvestmentGrowth',
-      () => calculateInvestmentGrowth(100_000, 500, 'monthly', 30, 0.07, 0.03, 72_000, 30),
       ['savingsRate', 'annualContribution', 'monthlyContribution', 'finalNominalBalance', 'finalInflationAdjustedBalance', 'totalInvested', 'totalGrowth', 'inflationImpact'],
     ],
-    [
-      'DebtPayoff',
-      () => calculateSnowballPayoff([{ id: '1', name: 'Card', balance: 10_000, rate: 0.2, minPayment: 200 }], 500),
-      ['totalMonths', 'totalInterest', 'totalPrincipal', 'monthlyPayment'],
-    ],
-  ] as const)('%s exports exactly its known scalar fields', (_label, build, expected) => {
-    const { values } = prepareResultsForExport(build())
-    expect(Object.keys(values).sort()).toEqual([...expected].sort())
+    ['HealthcareGap', ['gapYears', 'annualCost', 'totalCost', 'avgAnnualCost']],
+    ['DebtPayoff', ['totalMonths', 'totalInterest', 'totalPrincipal', 'monthlyPayment']],
+  ] as const)('%s exports exactly its known scalar fields', (label, expected) => {
+    const { values } = prepareResultsForExport(RESULT_BUILDERS[label]())
+    const actual = Object.keys(values).sort()
+    expect(actual, keySetFailure(label, actual, expected)).toEqual([...expected].sort())
   })
 })
+
+// ================================================================================================
+// Structural filtering
+// ================================================================================================
 
 describe('structural filtering', () => {
   it('omits arrays, which belong on their own sheets', () => {
@@ -110,10 +295,23 @@ describe('structural filtering', () => {
   })
 
   it('omits an empty array as readily as a populated one', () => {
-    const { values } = prepareResultsForExport({ rows: [], total: 5 })
-    expect(Object.keys(values)).toEqual(['total'])
+    const { values } = prepareResultsForExport({ rows: [], totalDebt: 5 })
+    expect(Object.keys(values)).toEqual(['totalDebt'])
+  })
+
+  it('applies the same rules to inputs as to results', () => {
+    // These were two near-copies that had already drifted: only one had a non-finite guard, only
+    // one type-gated formatting, and their key lists disagreed about whether 'total' meant money.
+    // They share one implementation now, so the two calls cannot disagree.
+    const shape = { debts: [{ balance: 1 }], nested: {}, monthlyBudget: 500, mode: null }
+    expect(prepareInputsForExport(shape)).toEqual(prepareResultsForExport(shape))
+    expect(Object.keys(prepareInputsForExport(shape).values)).toEqual(['monthlyBudget'])
   })
 })
+
+// ================================================================================================
+// Values that are not plain finite numbers
+// ================================================================================================
 
 describe('non-finite values', () => {
   it('replaces Infinity with wording rather than writing "$∞" into a cell', () => {
@@ -135,35 +333,66 @@ describe('non-finite values', () => {
   })
 
   it('handles -Infinity and NaN the same way', () => {
-    const { values } = prepareResultsForExport({ a: -Infinity, b: NaN, c: 42 })
-    expect(values.a).toBe('Not reachable')
-    expect(values.b).toBe('Not reachable')
-    expect(values.c).toBe(42)
+    const { values } = prepareResultsForExport({ fireNumber: -Infinity, totalCost: NaN, gapYears: 42 })
+    expect(values.fireNumber).toBe('Not reachable')
+    expect(values.totalCost).toBe('Not reachable')
+    expect(values.gapYears).toBe(42)
+  })
+
+  it('guards non-finite inputs too, which it previously did not', () => {
+    // Pinned under #64: only the results helper had this guard, so an infinite input was written
+    // straight into a cell. Sharing one implementation removed the asymmetry.
+    const { values, formats } = prepareInputsForExport({ annualIncome: Infinity })
+    expect(values.annualIncome).toBe('Not reachable')
+    expect(formats).not.toHaveProperty('annualIncome')
   })
 
   it('leaves finite values, including zero and negatives, as numbers', () => {
-    const { values } = prepareResultsForExport({ zero: 0, negative: -1_500 })
-    expect(values.zero).toBe(0)
-    expect(values.negative).toBe(-1_500)
+    const { values } = prepareResultsForExport({ totalGrowth: 0, firstYearSurplus: -1_500 })
+    expect(values.totalGrowth).toBe(0)
+    expect(values.firstYearSurplus).toBe(-1_500)
   })
 })
 
-describe('format inference by key name', () => {
+describe('null and undefined', () => {
+  it('omits null instead of emitting a blank labelled row', () => {
+    // #64 item 2. `typeof null === 'object'`, but the old guard also required `value !== null`, so
+    // null fell through to a blank row. DeferredCompensation.tsx worked around it with `?? 0`,
+    // which wrote a 0 that reads as a shortfall at age 0.
+    const { values, formats } = prepareResultsForExport({ firstShortfallAge: null, fireNumber: 1_200_000 })
+    expect(values).not.toHaveProperty('firstShortfallAge')
+    expect(formats).not.toHaveProperty('firstShortfallAge')
+    expect(values.fireNumber).toBe(1_200_000)
+  })
+
+  it('omits undefined the same way, so the two are no longer asymmetric', () => {
+    const { values } = prepareResultsForExport({ fireAge: undefined, fireNumber: 1 })
+    expect(values).not.toHaveProperty('fireAge')
+    expect(values.fireNumber).toBe(1)
+  })
+
+  it('still exports a real zero, which says something different from null', () => {
+    const { values } = prepareResultsForExport({ firstShortfallAge: 0 })
+    expect(values.firstShortfallAge).toBe(0)
+  })
+})
+
+// ================================================================================================
+// Declared formats
+// ================================================================================================
+
+describe('declared formats', () => {
+  const format = (key: string, value: unknown) =>
+    prepareResultsForExport({ [key]: value }).formats[key]
+
   it.each([
     ['withdrawalRate', 'percent'],
     ['savingsRate', 'percent'],
     ['horizonFundedRatio', 'percent'],
-    ['percentComplete', 'percent'],
-    ['progress', 'percent'],
-  ] as const)('%s is formatted as a percentage', (key, expected) => {
-    expect(prepareResultsForExport({ [key]: 0.04 }).formats[key]).toBe(expected)
-  })
-
-  it('formats horizonFundedRatio as a percentage', () => {
-    // The audit's second bite: 'rate' matched but 'ratio' did not, so this ratio silently exported
-    // as a bare number. 'ratio' is now in the percent list and must stay there.
-    const { formats } = prepareResultsForExport(calculateWithdrawal(1_000_000, 0.05, 0.03, 0.03, 40))
-    expect(formats.horizonFundedRatio).toBe('percent')
+    ['expectedReturn', 'percent'],
+    ['inflationRate', 'percent'],
+  ] as const)('%s renders as a percentage', (key, expected) => {
+    expect(format(key, 0.04)).toBe(expected)
   })
 
   it.each([
@@ -171,126 +400,163 @@ describe('format inference by key name', () => {
     ['endingBalance', 'currency'],
     ['annualWithdrawal', 'currency'],
     ['totalInterest', 'currency'],
+    ['totalPrincipal', 'currency'],
     ['monthlyPayment', 'currency'],
     ['requiredAnnualSavings', 'currency'],
     ['totalCost', 'currency'],
-    ['totalPrincipal', 'currency'],
     ['portfolioValue', 'currency'],
-  ] as const)('%s is formatted as currency', (key, expected) => {
-    expect(prepareResultsForExport({ [key]: 1_000 }).formats[key]).toBe(expected)
+    // Both are dollar thresholds and used to render as bare numbers.
+    ['leanThreshold', 'currency'],
+    ['fatThreshold', 'currency'],
+  ] as const)('%s renders as currency', (key, expected) => {
+    expect(format(key, 1_000)).toBe(expected)
   })
 
   it.each([
     ['yearsToFIRE', 'years'],
-    ['fireAge', 'years'],
+    ['yearsToCoast', 'years'],
     ['portfolioLongevity', 'years'],
-    ['monthsRemaining', 'years'],
-  ] as const)('%s is formatted as a duration', (key, expected) => {
-    expect(prepareResultsForExport({ [key]: 25 }).formats[key]).toBe(expected)
+    ['gapYears', 'years'],
+    // An age, but the calculators round it to one decimal, so the integer 'age' format would show
+    // 51.5 as 52 — a silent change to the number rather than to its styling.
+    ['fireAge', 'years'],
+  ] as const)('%s renders with a decimal', (key, expected) => {
+    expect(format(key, 25.4)).toBe(expected)
   })
 
-  it('falls back to plain number for an unrecognised key', () => {
-    expect(prepareResultsForExport({ mysteryField: 7 }).formats.mysteryField).toBe('number')
+  it.each([
+    ['currentAge', 'age'],
+    ['retirementAge', 'age'],
+    ['medicareAge', 'age'],
+    ['firstShortfallAge', 'age'],
+  ] as const)('%s renders as a whole age', (key, expected) => {
+    expect(format(key, 55)).toBe(expected)
   })
 
-  it('checks percent before currency, so a key matching both is a percentage', () => {
-    // 'savingsRate' contains both 'savings' (currency) and 'rate' (percent). Percent wins because
-    // it is tested first, which is the behaviour the result cards depend on.
-    expect(prepareResultsForExport({ savingsRate: 0.33 }).formats.savingsRate).toBe('percent')
+  it.each([
+    ['totalMonths', 'number'],
+    ['targetMonths', 'number'],
+    ['totalDebts', 'number'],
+    ['incomeSourceCount', 'number'],
+    ['accountCount', 'number'],
+    ['retirementYears', 'number'],
+  ] as const)('%s renders as a whole count', (key, expected) => {
+    expect(format(key, 25)).toBe(expected)
   })
 
-  it('matches key names case-insensitively', () => {
-    expect(prepareResultsForExport({ TotalInterest: 500 }).formats.TotalInterest).toBe('currency')
-    expect(prepareResultsForExport({ WITHDRAWALRATE: 0.04 }).formats.WITHDRAWALRATE).toBe('percent')
+  it('leaves an undeclared key unformatted rather than guessing', () => {
+    const { values, formats } = prepareResultsForExport({ mysteryField: 7 })
+    // Still exported: an unstyled number is never wrong, whereas a guessed one can be.
+    expect(values.mysteryField).toBe(7)
+    expect(formats).not.toHaveProperty('mysteryField')
   })
 
-  it('attaches no format to non-numeric values', () => {
-    const { values, formats } = prepareResultsForExport({ label: 'Standard', flag: true })
-    expect(values.label).toBe('Standard')
-    expect(values.flag).toBe(true)
-    expect(formats).not.toHaveProperty('label')
-    expect(formats).not.toHaveProperty('flag')
+  it('matches key names exactly, so a differently-cased key is not a match', () => {
+    // The old lookup lowercased both sides and used `.includes()`, which is how 'strategy' matched
+    // 'rate'. Exact matching is what makes that class of collision unrepresentable.
+    expect(prepareResultsForExport({ TotalInterest: 500 }).formats).not.toHaveProperty('TotalInterest')
+    expect(prepareResultsForExport({ totalInterest: 500 }).formats.totalInterest).toBe('currency')
   })
 })
 
-describe('known hazards, pinned as characterization', () => {
-  /*
-   * The behaviours below are pre-existing and are NOT changed by this test-only work. They are
-   * pinned so the next person sees them stated rather than rediscovering them from a user's
-   * spreadsheet. Booleans and null are tracked in issue #64; totalMonths has its own issue, #62.
-   */
+// ================================================================================================
+// The specific defects in #62 and #64
+// ================================================================================================
 
-  it('booleans still reach the workbook as untyped rows', () => {
-    // `typeof true` is neither array nor object, so a boolean passes the filter and lands in the
-    // export with no format hint. LeanFIRE, FatFIRE and CoastFIRE all pass raw results containing
-    // isLean / isFat / alreadyCoasting straight through.
+describe('substring collisions that used to mis-format live exports', () => {
+  it('#62: totalMonths is a count of months, not an amount of money', () => {
+    // 'totalmonths'.includes('total'), and currencyKeys was tested before timeKeys, so a 25-month
+    // payoff was written into the user's spreadsheet as "$25". Exact lookup makes that impossible.
+    //
+    // Declared 'number' (#,##0 -> "25") rather than 'years' (0.0 -> "25.0"): these are whole
+    // months. MAUI already writes the same field with its decimal style, so the platforms agree.
+    const debt = calculateSnowballPayoff(DEBTS, 500)
+    expect(debt.totalMonths).toBe(25)
+
+    const { formats } = prepareResultsForExport(debt)
+    expect(formats.totalMonths).toBe('number')
+
+    // The genuinely-currency siblings are unchanged.
+    expect(formats.totalInterest).toBe('currency')
+    expect(formats.totalPrincipal).toBe('currency')
+    expect(formats.monthlyPayment).toBe('currency')
+  })
+
+  it('#64: strategy is a word, not a percentage', () => {
+    // 'strategy' contains 'rate' — st-RATE-gy — and percentKeys was tested first, so the string
+    // "snowball" was written into a cell carrying numFmt '0.0%'.
+    const { values, formats } = prepareInputsForExport({ strategy: 'snowball', mode: 'budget' })
+    expect(values.strategy).toBe('snowball')
+    expect(formats.strategy).toBe('text')
+    expect(formats.mode).toBe('text')
+  })
+
+  it('#64: totalDebt is money, the inverse of the totalMonths defect', () => {
+    // The inputs list had no 'total' entry at all, so a real dollar amount exported unformatted
+    // while the results list treated 'total' as currency. One shared map ends that disagreement.
+    const { formats } = prepareInputsForExport({ totalDebt: 21_500, monthlyBudget: 500 })
+    expect(formats.totalDebt).toBe('currency')
+    expect(formats.monthlyBudget).toBe('currency')
+  })
+
+  it('a count of income sources is a count, not an amount of money', () => {
+    // Not filed: 'incomeSourceCount' contains 'income', so three income sources exported as "$3".
+    // The same defect as #62 on a different field, found by enumerating every live call site.
+    expect(prepareInputsForExport({ incomeSourceCount: 3 }).formats.incomeSourceCount).toBe('number')
+  })
+
+  it('a contribution frequency is a word, not an amount of money', () => {
+    // Not filed: 'contributionFrequency' contains 'contribution', so "monthly" landed in a $ cell.
+    const { values, formats } = prepareInputsForExport({ contributionFrequency: 'monthly' })
+    expect(values.contributionFrequency).toBe('monthly')
+    expect(formats.contributionFrequency).toBe('text')
+  })
+
+  it('input booleans are declared non-numeric instead of receiving a number format', () => {
+    // Not filed: neither list matched 'withdrawOnlyAfterRetirement' or 'reinvestSurplus', and the
+    // inputs helper never type-gated, so both booleans received numFmt '#,##0'.
+    const { values, formats } = prepareInputsForExport({
+      withdrawOnlyAfterRetirement: true,
+      reinvestSurplus: false,
+    })
+    expect(values.withdrawOnlyAfterRetirement).toBe(true)
+    expect(values.reinvestSurplus).toBe(false)
+    expect(formats.withdrawOnlyAfterRetirement).toBe('text')
+    expect(formats.reinvestSurplus).toBe('text')
+  })
+
+  it('result booleans stay in the workbook, now declared rather than accidental', () => {
+    // #64 item 1. These carry real meaning — "you are already coasting" — so they are exported,
+    // with no number format. Previously they were exported because nothing happened to filter them
+    // out, which is not the same thing.
     const lean = prepareResultsForExport(calculateLeanFIRE(DEFAULTS))
     expect(lean.values.isLean).toBe(false)
-    expect(lean.formats).not.toHaveProperty('isLean')
+    expect(lean.formats.isLean).toBe('text')
 
     const coast = prepareResultsForExport(
       calculateCoastFIRE(30, 55, 100_000, 24_000, 0.07, 0.03, 48_000, 0.04),
     )
     expect(coast.values.alreadyCoasting).toBe(false)
-    expect(coast.formats).not.toHaveProperty('alreadyCoasting')
+    expect(coast.formats.alreadyCoasting).toBe('text')
   })
 
-  it('null still emits a row', () => {
-    // The guard is `typeof value === 'object' && value !== null`, so null falls through to
-    // `values[key] = null` and produces a blank row. Callers work around this at the call site
-    // (DeferredCompensation.tsx uses `?? 0`) rather than in this helper.
-    const { values, formats } = prepareResultsForExport({ firstShortfallAge: null, fireNumber: 1_200_000 })
-    expect(values).toHaveProperty('firstShortfallAge')
-    expect(values.firstShortfallAge).toBeNull()
-    expect(formats).not.toHaveProperty('firstShortfallAge')
-  })
+  it('a name that merely contains "age" is no longer formatted as an age', () => {
+    // Latent when filed under #64: ageKeys was checked first and 'age' is the shortest, most
+    // collision-prone token in any of the lists, so a future 'mortgageBalance' or 'averageReturn'
+    // would have exported with the age format ahead of the currency and percent rules. There is no
+    // precedence to get wrong now, and neither name matches anything.
+    const { formats } = prepareInputsForExport({ mortgageBalance: 300_000, averageReturn: 0.07 })
+    expect(formats).not.toHaveProperty('mortgageBalance')
+    expect(formats).not.toHaveProperty('averageReturn')
 
-  it('undefined is dropped, unlike null', () => {
-    // Object.entries skips nothing, but `typeof undefined` is 'undefined', so it is stored as a
-    // value with no format. Pinned to document the asymmetry with null above.
-    const { values } = prepareResultsForExport({ maybe: undefined, sure: 1 })
-    expect(values.maybe).toBeUndefined()
-    expect(values.sure).toBe(1)
-  })
-
-  it('a threshold constant is exported as if it were a result', () => {
-    // leanThreshold / fatThreshold are configuration, not outcomes, but they are scalars on the
-    // result type so they reach the user's workbook. Documented, not changed.
-    const { values, formats } = prepareResultsForExport(calculateLeanFIRE(DEFAULTS))
-    expect(values.leanThreshold).toBe(40_000)
-    expect(formats.leanThreshold).toBe('number')
-  })
-
-  it('totalMonths is exported as CURRENCY, not a duration', () => {
-    /*
-     * FINDING (live, user-visible, pre-existing). Tracked in issue #62, deliberately not fixed here.
-     *
-     * This is the same substring-collision class as the 'rate' / 'ratio' bug the audit already hit,
-     * and it is currently shipping.
-     *
-     * 'totalmonths' contains 'total', which is in currencyKeys. currencyKeys is tested BEFORE
-     * timeKeys, so the intended 'months' match in timeKeys is never reached. The 'currency' hint
-     * maps to numFmt '$#,##0' (getExcelFormat), so a debt payoff that takes 25 months is written
-     * into the user's spreadsheet as "$25".
-     *
-     * DebtPayoff.tsx passes the raw result to prepareResultsForExport and forwards the derived
-     * formats to the workbook without overriding them, so nothing downstream corrects this.
-     *
-     * Asserted as the WRONG value on purpose. When this is fixed, this test SHOULD fail — that is
-     * the signal, and the expectation below should flip to 'years'.
-     */
-    const debt = calculateSnowballPayoff([{ id: '1', name: 'Card', balance: 10_000, rate: 0.2, minPayment: 200 }], 500)
-    expect(debt.totalMonths).toBe(25)
-
-    const { formats } = prepareResultsForExport(debt)
-    expect(formats.totalMonths).toBe('currency')
-
-    // The genuinely-currency siblings are unaffected and correct.
-    expect(formats.totalInterest).toBe('currency')
-    expect(formats.totalPrincipal).toBe('currency')
-    expect(formats.monthlyPayment).toBe('currency')
+    // A real age is still correct, which is why the collision was easy to miss.
+    expect(prepareInputsForExport({ currentAge: 30 }).formats.currentAge).toBe('age')
   })
 })
+
+// ================================================================================================
+// Degenerate input
+// ================================================================================================
 
 describe('empty and degenerate input', () => {
   it('returns empty maps for an empty result object', () => {
@@ -303,81 +569,9 @@ describe('empty and degenerate input', () => {
     const { values } = prepareResultsForExport({ rows: [1, 2], nested: { a: 1 } })
     expect(values).toEqual({})
   })
-})
 
-/**
- * `prepareInputsForExport` is the sibling of `prepareResultsForExport` and has the same
- * substring-matching design, with two differences that both produce wrong formatting. Tracked in
- * issue #64. Not fixed here; this PR is test-only.
- *
- * All of these assert the CURRENT, WRONG behaviour on purpose. When #64 is fixed they SHOULD fail.
- */
-describe('prepareInputsForExport hazards, pinned as characterization (issue #64)', () => {
-  // The exact input DebtPayoff.tsx:71 passes, so these are the formats a real user's workbook gets.
-  const debtInputs = () =>
-    prepareInputsForExport({
-      strategy: 'snowball',
-      mode: 'budget',
-      monthlyBudget: 500,
-      targetMonths: 24,
-      extraPayment: 0,
-      totalDebts: 2,
-      totalDebt: 21_500,
-    })
-
-  it('exports totalDebt without currency formatting', () => {
-    // The exact inverse of the totalMonths bug in #62. There, a month count is formatted as money
-    // because 'total' is in the results currencyKeys. Here, the inputs currencyKeys list
-    // ('savings', 'contribution', 'expenses', 'income', 'value', 'budget', 'payment', 'premium',
-    // 'deductible', 'pocket') has no 'total' entry at all, so totalDebt — a genuine dollar amount —
-    // matches nothing and falls through to 'number'. Same root cause, opposite direction.
-    expect(debtInputs().formats.totalDebt).toBe('number')
-
-    // monthlyBudget is formatted correctly, via 'budget'. The list is not broken, just incomplete.
-    expect(debtInputs().formats.monthlyBudget).toBe('currency')
-  })
-
-  it('assigns a numeric format to non-numeric values', () => {
-    // Unlike prepareResultsForExport, the format branch here is not gated on
-    // `typeof value === 'number'`, so text values receive a numeric format too.
-    //
-    // CORRECTION to issue #64, which records `strategy` as getting 'number': it actually gets
-    // 'percent', because 'strategy' contains the substring 'rate' (st-RATE-gy) and percentKeys is
-    // tested before currencyKeys. So the string "snowball" is written into a cell carrying numFmt
-    // '0.0%'. 'mode' does get 'number' as filed.
-    const { values, formats } = debtInputs()
-
-    expect(values.strategy).toBe('snowball')
-    expect(formats.strategy).toBe('percent')
-
-    expect(values.mode).toBe('budget')
-    expect(formats.mode).toBe('number')
-  })
-
-  it('has no non-finite guard, unlike its results sibling', () => {
-    // prepareResultsForExport substitutes 'Not reachable' for Infinity and NaN. This one has no such
-    // guard, so a non-finite input value is written straight through. Inputs are user-entered so
-    // this is harder to reach than the results path, but the asymmetry is worth stating.
-    const { values } = prepareInputsForExport({ annualIncome: Infinity })
-    expect(values.annualIncome).toBe(Infinity)
-  })
-
-  it('checks ageKeys first, so any key containing "age" is formatted as an age', () => {
-    // Latent rather than live: every current parameter containing 'age' is a genuine age
-    // (currentAge, retirementAge, targetRetirementAge, earlyRetirementAge, medicareAge,
-    // planThroughAge), so nothing is mis-formatted today. But 'age' is checked before percent and
-    // currency, so a future 'mortgageBalance' or 'averageReturn' would silently export with the
-    // age format. Pinned to document the ordering trap before it bites.
-    const { formats } = prepareInputsForExport({ mortgageBalance: 300_000, averageReturn: 0.07 })
-    expect(formats.mortgageBalance).toBe('age')
-    expect(formats.averageReturn).toBe('age')
-
-    // A real age is still correct, which is why the collision is easy to miss.
-    expect(prepareInputsForExport({ currentAge: 30 }).formats.currentAge).toBe('age')
-  })
-
-  it('skips arrays and objects, matching its results sibling', () => {
-    const { values } = prepareInputsForExport({ debts: [{ balance: 1 }], nested: {}, budget: 500 })
-    expect(Object.keys(values)).toEqual(['budget'])
+  it('tolerates a missing object rather than throwing mid-download', () => {
+    expect(prepareResultsForExport(undefined).values).toEqual({})
+    expect(prepareInputsForExport(null).values).toEqual({})
   })
 })

--- a/web/src/utils/__tests__/excelWorkbook.test.ts
+++ b/web/src/utils/__tests__/excelWorkbook.test.ts
@@ -1,0 +1,157 @@
+import ExcelJS from 'exceljs'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { calculateSnowballPayoff } from '../calculations'
+import { exportToExcel, prepareInputsForExport, prepareResultsForExport } from '../excelExport'
+
+/**
+ * The rest of the export suite checks the format *token* a field is assigned. This file checks that
+ * the token survives the trip into a real `.xlsx` and lands on the cell as a number format.
+ *
+ * That last hop is where #62 was visible: `prepareResultsForExport` said `'currency'`, and
+ * `getExcelFormat` faithfully turned that into numFmt `'$#,##0'`, so a 25-month debt payoff opened
+ * as `$25` in the spreadsheet a user downloaded and forwarded to someone else. Asserting the token
+ * alone would not have caught the impact, and asserting it now would not prove the impact is gone.
+ */
+
+/** `exportToExcel` triggers a browser download, so the suite stands in for the DOM to catch it. */
+async function buildWorkbook(run: () => Promise<void>): Promise<ExcelJS.Workbook> {
+  const globals = globalThis as Record<string, unknown>
+  const saved = { Blob: globals.Blob, window: globals.window, document: globals.document }
+  let captured: ArrayBuffer | undefined
+
+  globals.Blob = class {
+    constructor(parts: ArrayBuffer[]) {
+      captured = parts[0]
+    }
+  }
+  globals.window = { URL: { createObjectURL: () => 'blob:test', revokeObjectURL: () => {} } }
+  globals.document = { createElement: () => ({ click: () => {} }) }
+
+  try {
+    await run()
+  } finally {
+    Object.assign(globals, saved)
+  }
+
+  const workbook = new ExcelJS.Workbook()
+  await workbook.xlsx.load(captured!)
+  return workbook
+}
+
+/** The label/value pairs of a two-column sheet, keyed by the label a user reads. */
+function readSheet(workbook: ExcelJS.Workbook, name: string) {
+  const rows: Record<string, { value: unknown; numFmt?: string }> = {}
+  workbook.getWorksheet(name)?.eachRow((row, index) => {
+    if (index === 1) return // header
+    rows[String(row.getCell(1).value)] = {
+      value: row.getCell(2).value,
+      numFmt: row.getCell(2).numFmt,
+    }
+  })
+  return rows
+}
+
+const DEBT_INPUTS = {
+  strategy: 'snowball',
+  mode: 'budget',
+  monthlyBudget: 500,
+  targetMonths: 24,
+  extraPayment: 0,
+  totalDebts: 2,
+  totalDebt: 21_500,
+}
+
+async function debtPayoffWorkbook() {
+  const results = calculateSnowballPayoff(
+    [{ id: '1', name: 'Card', balance: 10_000, rate: 0.2, minPayment: 200 }],
+    500,
+  )
+  const { values: inputs, formats: inputFormats } = prepareInputsForExport(DEBT_INPUTS)
+  const { values: resultValues, formats: resultFormats } = prepareResultsForExport(results)
+
+  return buildWorkbook(() =>
+    exportToExcel({
+      calculatorName: 'Debt Payoff',
+      inputs,
+      results: resultValues,
+      inputFormats,
+      resultFormats,
+    }),
+  )
+}
+
+afterEach(() => {
+  // `buildWorkbook` restores the globals it replaces; this is the backstop if a test throws first.
+  const globals = globalThis as Record<string, unknown>
+  if (typeof globals.window === 'object' && globals.window !== null && !('addEventListener' in globals.window)) {
+    delete globals.window
+    delete globals.document
+  }
+})
+
+describe('formats that reach the spreadsheet', () => {
+  it('#62: a 25-month payoff opens as 25, not $25', async () => {
+    const results = readSheet(await debtPayoffWorkbook(), 'Results')
+
+    expect(results['Total Months']).toEqual({ value: 25, numFmt: '#,##0' })
+
+    // The genuinely-currency siblings on the same sheet are untouched, which is what made the
+    // defect easy to miss: three of the four rows were right.
+    expect(results['Total Interest'].numFmt).toBe('$#,##0')
+    expect(results['Total Principal'].numFmt).toBe('$#,##0')
+    expect(results['Monthly Payment'].numFmt).toBe('$#,##0')
+  })
+
+  it('#64: text inputs carry no number format, and totalDebt carries currency', async () => {
+    const inputs = readSheet(await debtPayoffWorkbook(), 'Inputs')
+
+    // 'strategy' contains 'rate', so this cell used to carry numFmt '0.0%' around the word
+    // "snowball". 'mode' matched nothing and fell through to '#,##0'.
+    expect(inputs.Strategy).toEqual({ value: 'snowball', numFmt: undefined })
+    expect(inputs.Mode).toEqual({ value: 'budget', numFmt: undefined })
+
+    // A real dollar amount that the inputs list had no entry for, so it exported bare.
+    expect(inputs['Total Debt']).toEqual({ value: 21_500, numFmt: '$#,##0' })
+
+    // A count of debts is not money, and the budget is.
+    expect(inputs['Total Debts'].numFmt).toBe('#,##0')
+    expect(inputs['Monthly Budget'].numFmt).toBe('$#,##0')
+  })
+
+  it('omits a null result rather than writing a labelled blank row', async () => {
+    const { values, formats } = prepareResultsForExport({
+      endingBalance: 250_000,
+      firstShortfallAge: null,
+    })
+    const workbook = await buildWorkbook(() =>
+      exportToExcel({
+        calculatorName: 'Retirement Cash Flow',
+        inputs: {},
+        results: values,
+        resultFormats: formats,
+      }),
+    )
+
+    const results = readSheet(workbook, 'Results')
+    expect(results).not.toHaveProperty('First Shortfall Age')
+    expect(results['Ending Balance']).toEqual({ value: 250_000, numFmt: '$#,##0' })
+  })
+
+  it('writes unreachable results as words rather than "$∞"', async () => {
+    const { values, formats } = prepareResultsForExport({ fireNumber: Infinity })
+    const workbook = await buildWorkbook(() =>
+      exportToExcel({
+        calculatorName: 'Standard FIRE',
+        inputs: {},
+        results: values,
+        resultFormats: formats,
+      }),
+    )
+
+    expect(readSheet(workbook, 'Results')['Fire Number']).toEqual({
+      value: 'Not reachable',
+      numFmt: undefined,
+    })
+  })
+})

--- a/web/src/utils/calculations.ts
+++ b/web/src/utils/calculations.ts
@@ -677,9 +677,13 @@ const RATE_ANALYSIS_MAX_YEARS = 50
  * This function projects a single deterministic path at a fixed return. It does not run
  * historical or Monte Carlo simulations, so it cannot produce a probability of success.
  *
- * Year convention: both `portfolioLongevity` and each `rateAnalysis[].years` count the
- * full years funded while a positive balance remained, so the headline and the comparison
- * table always agree for the same rate.
+ * Year convention: `portfolioLongevity` and each `rateAnalysis[].years` count years the same way —
+ * full years funded while a positive balance remained — but they stop at different horizons, so for
+ * the same rate they can report different numbers. `portfolioLongevity` stops at `retirementYears`,
+ * because the headline answers "does this last my retirement?". `rateAnalysis` stops at
+ * `RATE_ANALYSIS_MAX_YEARS`, because the table answers "how long would each rate last?". A portfolio
+ * that outlives a 30-year plan shows 30 in the headline and up to 50 in the table. That divergence
+ * is the intended design, not a disagreement, and only appears when one of the two caps binds.
  * 
  * @param portfolioValue - Starting portfolio balance
  * @param withdrawalRate - Initial withdrawal rate (decimal, e.g., 0.04 for 4%)
@@ -734,8 +738,10 @@ export function calculateWithdrawal(
     ? 1
     : portfolioLongevity / retirementYears
 
-  // Analyze different withdrawal rates using the same "years fully funded" convention
-  // as portfolioLongevity so the headline and this table cannot disagree.
+  // Analyze different withdrawal rates using the same "years fully funded" convention as
+  // portfolioLongevity. The horizon differs: this table runs to RATE_ANALYSIS_MAX_YEARS so it can
+  // show how far a lower rate stretches, while portfolioLongevity stops at the user's
+  // retirementYears. Equal counting, different caps — see the note on this function.
   const rates = [0.03, 0.035, 0.04, 0.045, 0.05]
   const rateAnalysis = rates.map(rate => {
     let bal = portfolioValue

--- a/web/src/utils/excelExport.ts
+++ b/web/src/utils/excelExport.ts
@@ -1,10 +1,18 @@
 import ExcelJS from 'exceljs'
-import { formatCurrency, formatPercent } from './calculations'
 
 /**
  * Export calculator data to Excel spreadsheet
  * Creates a workbook with multiple sheets for inputs, results, and projections
  */
+
+/**
+ * How a value is rendered in its cell.
+ *
+ * `'text'` is a positive declaration that a field is deliberately non-numeric — a string or a
+ * boolean — and must carry no number format. It is not the same as a field having no entry here,
+ * which means nobody has declared it yet.
+ */
+export type ExportFormat = 'currency' | 'percent' | 'number' | 'age' | 'years' | 'text'
 
 interface ExportData {
   calculatorName: string
@@ -18,8 +26,8 @@ interface ExportData {
   // New: Support for formulas in results
   resultFormulas?: Record<string, string>
   // New: Support for formatting hints
-  inputFormats?: Record<string, 'currency' | 'percent' | 'number' | 'age'>
-  resultFormats?: Record<string, 'currency' | 'percent' | 'number' | 'years'>
+  inputFormats?: Record<string, ExportFormat>
+  resultFormats?: Record<string, ExportFormat>
 }
 
 /** Written in place of Infinity/NaN scalars so an exported workbook never contains "$∞". */
@@ -65,7 +73,7 @@ function formatValue(value: any): any {
 /**
  * Get Excel format string for a given format type
  */
-function getExcelFormat(format?: 'currency' | 'percent' | 'number' | 'age' | 'years'): string | undefined {
+function getExcelFormat(format?: ExportFormat): string | undefined {
   switch (format) {
     case 'currency':
       return '$#,##0'
@@ -77,6 +85,7 @@ function getExcelFormat(format?: 'currency' | 'percent' | 'number' | 'age' | 'ye
       return '0'
     case 'number':
       return '#,##0'
+    // 'text' is a declared non-numeric field: exported, but deliberately unformatted.
     default:
       return undefined
   }
@@ -327,172 +336,216 @@ export async function exportToExcel(data: ExportData): Promise<void> {
 }
 
 /**
- * Helper to prepare input values for Excel export
- * Returns raw numeric values (not formatted strings) and format hints
+ * The single declaration site for how every exported field is formatted.
+ *
+ * Lookup is by **exact** field name. That is the whole point. This map replaces two independently
+ * maintained lists of substrings, matched with `.includes()` in an order that decided precedence,
+ * which produced seven distinct formatting defects:
+ *
+ *   - `'rate'` matched but `'ratio'` did not, so percent formatting was silently dropped (#53).
+ *   - `'totalmonths'` contains `'total'`, so a 25-month payoff exported as `$25` (#62).
+ *   - `'strategy'` contains `'rate'` — st-RATE-gy — so the string `"snowball"` got numFmt `0.0%` (#64).
+ *   - `'totalDebt'` matched nothing in the *inputs* list, so real dollars exported unformatted (#64).
+ *   - `'incomeSourceCount'` contains `'income'`, so a count of 3 income sources exported as `$3`.
+ *   - `'contributionFrequency'` contains `'contribution'`, so `"monthly"` landed in a `$#,##0` cell.
+ *   - `'withdrawOnlyAfterRetirement'` matched nothing, so a boolean received numFmt `#,##0`.
+ *
+ * Exact matching makes every one of those unrepresentable rather than merely reordered. There is no
+ * precedence to get wrong, and a name like `mortgageBalance` can no longer resolve to `age`.
+ *
+ * Inputs and results share this map deliberately. The `totalDebt` defect existed *because* the two
+ * helpers kept separate lists; one map makes that divergence impossible. Adding a field here is the
+ * conscious decision — `exportedFieldsAreDeclared` in the test suite fails until you make it.
  */
-export function prepareInputsForExport(params: any): { 
-  values: Record<string, any>
-  formats: Record<string, 'currency' | 'percent' | 'number' | 'age'>
-} {
-  const values: Record<string, any> = {}
-  const formats: Record<string, 'currency' | 'percent' | 'number' | 'age'> = {}
-  
-  // Define patterns for different value types
-  const currencyKeys = ['savings', 'contribution', 'expenses', 'income', 'value', 'budget', 'payment', 'premium', 'deductible', 'pocket']
-  const percentKeys = ['rate', 'return', 'inflation', 'withdrawal', 'swr']
-  const ageKeys = ['age']
-  
-  for (const [key, value] of Object.entries(params)) {
-    // Skip complex objects like debts array
-    if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
-      continue
-    }
-    
-    // Store raw numeric value
-    values[key] = value
-    
-    const lowerKey = key.toLowerCase()
-    
-    // Determine format type
-    if (ageKeys.some(pattern => lowerKey.includes(pattern))) {
-      formats[key] = 'age'
-    } else if (percentKeys.some(pattern => lowerKey.includes(pattern))) {
-      formats[key] = 'percent'
-    } else if (currencyKeys.some(pattern => lowerKey.includes(pattern))) {
-      formats[key] = 'currency'
-    } else {
-      formats[key] = 'number'
-    }
-  }
-  
-  return { values, formats }
+const EXPORT_FIELD_FORMATS: Record<string, ExportFormat> = {
+  // --- Ages -------------------------------------------------------------------------------------
+  currentAge: 'age',
+  retirementAge: 'age',
+  targetRetirementAge: 'age',
+  earlyRetirementAge: 'age',
+  medicareAge: 'age',
+  planThroughAge: 'age',
+  firstShortfallAge: 'age',
+
+  // --- Rates ------------------------------------------------------------------------------------
+  expectedReturn: 'percent',
+  inflationRate: 'percent',
+  withdrawalRate: 'percent',
+  savingsRate: 'percent',
+  horizonFundedRatio: 'percent',
+
+  // --- Dollar inputs ----------------------------------------------------------------------------
+  currentSavings: 'currency',
+  annualContribution: 'currency',
+  annualIncome: 'currency',
+  annualExpenses: 'currency',
+  partTimeIncome: 'currency',
+  portfolioValue: 'currency',
+  contributionAmount: 'currency',
+  monthlyPremium: 'currency',
+  annualDeductible: 'currency',
+  annualOutOfPocket: 'currency',
+  monthlyBudget: 'currency',
+  extraPayment: 'currency',
+  // A real dollar amount that the old inputs list had no entry for at all (#64).
+  totalDebt: 'currency',
+
+  // --- Dollar results ---------------------------------------------------------------------------
+  fireNumber: 'currency',
+  coastFireNumber: 'currency',
+  coastNumber: 'currency',
+  baristaNumber: 'currency',
+  fullFireNumber: 'currency',
+  partTimeIncomeNeeded: 'currency',
+  savingsFromPartTime: 'currency',
+  monthlyContribution: 'currency',
+  annualWithdrawal: 'currency',
+  monthlyWithdrawal: 'currency',
+  endingBalance: 'currency',
+  requiredAnnualSavings: 'currency',
+  requiredMonthlySavings: 'currency',
+  currentWillGrowTo: 'currency',
+  finalNominalBalance: 'currency',
+  finalInflationAdjustedBalance: 'currency',
+  totalInvested: 'currency',
+  totalGrowth: 'currency',
+  inflationImpact: 'currency',
+  totalInterest: 'currency',
+  totalPrincipal: 'currency',
+  monthlyPayment: 'currency',
+  currentBalance: 'currency',
+  balanceAtSemiRetirement: 'currency',
+  firstYearIncomeAfterTax: 'currency',
+  firstYearSurplus: 'currency',
+  annualCost: 'currency',
+  totalCost: 'currency',
+  avgAnnualCost: 'currency',
+  // Configuration rather than an outcome, but it reaches the workbook and it is measured in dollars.
+  leanThreshold: 'currency',
+  fatThreshold: 'currency',
+
+  // --- Durations --------------------------------------------------------------------------------
+  // These carry a fractional part (rounded to one decimal by the calculators), so '0.0' is correct.
+  yearsToFIRE: 'years',
+  yearsToCoast: 'years',
+  yearsToBaristaFIRE: 'years',
+  // An age rather than a duration, but rounded to one decimal, so '0.0' preserves it where the
+  // integer 'age' format would silently show 51.5 as 52.
+  fireAge: 'years',
+  portfolioLongevity: 'years',
+  gapYears: 'years',
+
+  // --- Whole counts -----------------------------------------------------------------------------
+  // Integers, so '#,##0' rather than the '0.0' of the duration formats above. `totalMonths` is the
+  // #62 defect: it used to render as '$25' for a 25-month payoff.
+  totalMonths: 'number',
+  targetMonths: 'number',
+  retirementYears: 'number',
+  yearsInvesting: 'number',
+  consecutiveFundedYears: 'number',
+  yearsFullyCovered: 'number',
+  totalDebts: 'number',
+  incomeSourceCount: 'number',
+  accountCount: 'number',
+  additionalExpenseCount: 'number',
+
+  // --- Declared non-numeric ---------------------------------------------------------------------
+  // Strings and booleans. Declaring them keeps a number format off a text cell without needing a
+  // type guard to rescue them from a name-based guess.
+  strategy: 'text',
+  mode: 'text',
+  contributionFrequency: 'text',
+  withdrawOnlyAfterRetirement: 'text',
+  reinvestSurplus: 'text',
+  isLean: 'text',
+  isFat: 'text',
+  alreadyCoasting: 'text',
+  alreadyAchievable: 'text',
+}
+
+/** True when a field has a declared format. Used by the test suite's coverage guard. */
+export function isExportFieldDeclared(key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(EXPORT_FIELD_FORMATS, key)
 }
 
 /**
- * Helper to prepare result values for Excel export
- * Returns raw numeric values (not formatted strings) and format hints
+ * Flatten an inputs or results object into cell values plus their declared formats.
+ *
+ * Inputs and results share one implementation on purpose. They used to be two near-copies whose
+ * behaviour had already diverged — only one had a non-finite guard, only one type-gated formatting,
+ * and their key lists disagreed about whether `total*` meant money. Sharing the code means they
+ * cannot drift apart again.
+ *
+ * An **undeclared** field is still exported, just without a number format. Losing a value from a
+ * user's workbook is worse than showing it unstyled, and an unstyled number is never *wrong* — the
+ * whole point of the defects above is that a guessed format is. `EXPORT_FIELD_FORMATS` is enforced
+ * in CI instead, so an undeclared field fails a test long before it reaches anyone.
  */
-export function prepareResultsForExport(results: any): {
+function prepareForExport(source: any): {
   values: Record<string, any>
-  formats: Record<string, 'currency' | 'percent' | 'number' | 'years'>
+  formats: Record<string, ExportFormat>
 } {
   const values: Record<string, any> = {}
-  const formats: Record<string, 'currency' | 'percent' | 'number' | 'years'> = {}
-  
-  // Define patterns for different value types
-  const currencyKeys = ['number', 'value', 'balance', 'withdrawal', 'income', 'interest', 'payment', 'savings', 'cost', 'total', 'principal']
-  const percentKeys = ['rate', 'savingsrate', 'ratio', 'percent', 'progress']
-  const timeKeys = ['years', 'months', 'age', 'longevity']
-  
-  for (const [key, value] of Object.entries(results)) {
-    // Skip arrays and complex objects (they go in separate sheets)
+  const formats: Record<string, ExportFormat> = {}
+
+  for (const [key, value] of Object.entries(source ?? {})) {
+    // Arrays and nested objects belong on their own sheets, not as a JSON blob in a labelled row.
     if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
+      continue
+    }
+
+    // A null means "this did not happen" — no shortfall age, no payoff date. A blank labelled row
+    // cannot be told apart from a missing one, and substituting 0 at the call site reads as a
+    // shortfall at age 0. Omitting the row is the only option that generalises.
+    if (value === null || value === undefined) {
       continue
     }
 
     // Non-finite results are legitimate ("the target is never reached"), but writing Infinity or
-    // NaN into a currency-formatted cell produces a spreadsheet that outlives the session and
-    // cannot be reasoned about. Substitute the same wording the result cards use.
+    // NaN into a numeric cell produces a spreadsheet that outlives the session and cannot be
+    // reasoned about. Substitute the same wording the result cards use, with no numeric format.
     if (typeof value === 'number' && !Number.isFinite(value)) {
       values[key] = UNREACHABLE_EXPORT_VALUE
       continue
     }
 
-    // Store raw value
     values[key] = value
-    
-    // Determine format type
-    if (typeof value === 'number') {
-      const lowerKey = key.toLowerCase()
-      
-      if (percentKeys.some(pattern => lowerKey.includes(pattern))) {
-        formats[key] = 'percent'
-      } else if (currencyKeys.some(pattern => lowerKey.includes(pattern))) {
-        formats[key] = 'currency'
-      } else if (timeKeys.some(pattern => lowerKey.includes(pattern))) {
-        formats[key] = 'years'
-      } else {
-        formats[key] = 'number'
-      }
+
+    const format = EXPORT_FIELD_FORMATS[key]
+    if (format) {
+      formats[key] = format
+    } else if (import.meta.env?.DEV && import.meta.env?.MODE !== 'test') {
+      // The suite deliberately exercises undeclared keys, so it opts out of the noise. In the dev
+      // server this is the first signal that a newly added field is heading for the workbook
+      // unstyled; the `exported fields are declared` suite is what actually blocks it.
+      console.warn(
+        `[excelExport] "${key}" has no entry in EXPORT_FIELD_FORMATS, so it is exported unformatted. ` +
+          'Add it there to choose how it renders.',
+      )
     }
   }
-  
+
   return { values, formats }
 }
 
 /**
- * Helper to format input values for display (DEPRECATED - kept for backward compatibility)
- * Use prepareInputsForExport instead for Excel exports with formulas
+ * Helper to prepare input values for Excel export
+ * Returns raw values (not formatted strings) and their declared format hints
  */
-export function formatInputsForExport(params: any): Record<string, any> {
-  const formatted: Record<string, any> = {}
-  
-  // Define patterns for different value types
-  const currencyKeys = ['savings', 'contribution', 'expenses', 'income', 'value', 'budget', 'payment', 'premium', 'deductible', 'pocket']
-  const percentKeys = ['rate', 'return', 'inflation', 'withdrawal', 'swr']
-  const ageKeys = ['age']
-  const timeKeys = ['years', 'months']
-  
-  for (const [key, value] of Object.entries(params)) {
-    // Skip complex objects like debts array
-    if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
-      continue
-    }
-    
-    const lowerKey = key.toLowerCase()
-    
-    // Format based on the key name patterns
-    if (ageKeys.some(pattern => lowerKey.includes(pattern))) {
-      formatted[key] = value
-    } else if (percentKeys.some(pattern => lowerKey.includes(pattern))) {
-      formatted[key] = formatPercent(value as number)
-    } else if (currencyKeys.some(pattern => lowerKey.includes(pattern))) {
-      formatted[key] = formatCurrency(value as number)
-    } else if (timeKeys.some(pattern => lowerKey.includes(pattern))) {
-      formatted[key] = value
-    } else {
-      formatted[key] = value
-    }
-  }
-  
-  return formatted
+export function prepareInputsForExport(params: any): {
+  values: Record<string, any>
+  formats: Record<string, ExportFormat>
+} {
+  return prepareForExport(params)
 }
 
 /**
- * Helper to format result values for display (DEPRECATED - kept for backward compatibility)
- * Use prepareResultsForExport instead for Excel exports with formulas
+ * Helper to prepare result values for Excel export
+ * Returns raw values (not formatted strings) and their declared format hints
  */
-export function formatResultsForExport(results: any): Record<string, any> {
-  const formatted: Record<string, any> = {}
-  
-  // Define patterns for different value types
-  const currencyKeys = ['number', 'value', 'balance', 'withdrawal', 'income', 'interest', 'payment', 'savings', 'cost', 'total', 'principal']
-  const percentKeys = ['rate', 'savingsrate', 'ratio', 'percent', 'progress']
-  const timeKeys = ['years', 'months', 'age', 'longevity']
-  
-  for (const [key, value] of Object.entries(results)) {
-    // Skip arrays and complex objects (they go in separate sheets)
-    if (Array.isArray(value) || (typeof value === 'object' && value !== null)) {
-      continue
-    }
-    
-    // Format based on the key name and value type
-    if (typeof value === 'number') {
-      const lowerKey = key.toLowerCase()
-      
-      if (percentKeys.some(pattern => lowerKey.includes(pattern))) {
-        formatted[key] = formatPercent(value)
-      } else if (currencyKeys.some(pattern => lowerKey.includes(pattern))) {
-        formatted[key] = formatCurrency(value)
-      } else if (timeKeys.some(pattern => lowerKey.includes(pattern))) {
-        formatted[key] = Math.round(value * 10) / 10 // Round to 1 decimal
-      } else {
-        formatted[key] = value
-      }
-    } else {
-      formatted[key] = value
-    }
-  }
-  
-  return formatted
+export function prepareResultsForExport(results: any): {
+  values: Record<string, any>
+  formats: Record<string, ExportFormat>
+} {
+  return prepareForExport(results)
 }


### PR DESCRIPTION
Fixes #62
Fixes #64

Both issues are symptoms of one mechanism, so this replaces the mechanism rather than correcting its output.

## The mechanism

`web/src/utils/excelExport.ts` chose a cell's Excel number format by lowercasing an arbitrary object's key and substring-matching it against hand-maintained lists, where **list order was precedence**:

```
prepareInputsForExport   ageKeys → percentKeys → currencyKeys → number
prepareResultsForExport  percentKeys → currencyKeys → timeKeys → number
```

Two helpers, two independently-maintained lists, wrong in different directions on the same page.

## Seven live defects, not four

Four were filed. Three more turned up while enumerating every key that flows through the helpers across all 11 call sites:

| Field | Page | Exported as | Should be | Why |
|---|---|---|---|---|
| `totalMonths` | DebtPayoff | **`$25`** | `25` | `'totalmonths'` contains `'total'`, and currency is tested before durations, so the `'months'` match is unreachable (#62) |
| `strategy` | DebtPayoff | `"snowball"` in a **`0.0%`** cell | no format | `'strategy'` contains `'rate'` — st-**rate**-gy (#64) |
| `totalDebt` | DebtPayoff | **unformatted** | `$21,500` | the *inputs* list has no `'total'` entry, so real money fell through — the exact inverse of #62, on the same page (#64) |
| `incomeSourceCount` | DeferredCompensation | **`$3`** | `3` | contains `'income'`; three income sources export as three dollars |
| `contributionFrequency` | SavingsRate | `"monthly"` in a **`$#,##0`** cell | no format | contains `'contribution'` |
| `withdrawOnlyAfterRetirement`, `reinvestSurplus` | DeferredCompensation | booleans with numFmt **`#,##0`** | no format | the inputs helper never gated on `typeof value === 'number'` at all |
| `null` results | any | a labelled blank row | omitted | `typeof null === 'object'` but the guard also required `value !== null` |

`incomeSourceCount` → `$3` is user-visible and would have justified its own issue.

## The fix

A single `EXPORT_FIELD_FORMATS` registry keyed by **exact** field name, shared by both helpers, which now delegate to one implementation.

**Central, not per-page.** The issue suggested a per-export map. `totalDebt` exporting unformatted while results treat every `total*` field as currency is caused *by* two independent lists — per-page maps multiply that failure mode across 11 pages, and force `currentAge`, `expectedReturn` and `inflationRate` to be redeclared 9–11 times. Verified no field name means two different things across the input/result union, so one map suffices.

**How this stops the eighth instance rather than fixing seven:**

1. **Exact match** — `strategy` cannot match `rate`; `mortgageBalance` and `averageReturn` cannot match `age`. #64's note that `ageKeys` is the shortest, most collision-prone token in any list is addressed structurally, not by re-ordering.
2. **No precedence** — "which list is checked first" stops being a concept.
3. **One implementation** — the non-finite guard, the null rule and object-skipping are shared by construction, so inputs and results cannot drift apart again.
4. **CI forces the declaration** — see below.

**Runtime is fail-safe, not fail-closed.** An undeclared field still exports, just without a format. An unstyled number is never *wrong*; `$25` for 25 months is. Throwing at export time would turn a cosmetic defect into a broken download for a user who did nothing wrong. Strictness lives in CI, where it costs a build instead of a download.

## Deleting the dead helpers removes a trap

`formatInputsForExport` and `formatResultsForExport` had zero call sites — and carried **verbatim copies** of the same buggy lists. The file maintained **four** substring lists, two of which did nothing. Anyone grepping `currencyKeys` to fix a format bug had even odds of editing the pair with no effect, confirming the fix locally and shipping nothing.

## Guards

- **Coverage guard** walks the real calculator result objects and reads the real input literals out of `pages/*.tsx` (via `import.meta.glob`, since `@types/node` is deliberately absent). Adding an exported field now fails CI until it is declared. It is derived from code, not a hand-listed key array — a hand-listed array would be the same maintenance failure one level up.
- **Key-set guards** (one per calculator, plus HealthcareGap which was missing) are preserved. Failure text now names the added and removed keys and states the three choices — declare a format, curate it out at the call site, or accept it unformatted — so the next person reasons instead of pasting in the new value.
- **`excelWorkbook.test.ts`** is new: it generates the real `.xlsx`, loads it back, and asserts the number format on the cell. Every other test checks the format *token*; this checks the thing the user actually opens, which is where #62 was visible.

The second commit hardens the call-site scanner after review found it could fail in the **permissive** direction — the one way this file must not break, since a scan that silently reads fewer keys still reports success over fields nobody checked. Comments and string contents are now blanked out (length-preserving) before any bracket is counted, an unbalanced literal throws rather than returning a short list, and the vacuity check no longer hard-codes "11 pages" — which would have passed when a twelfth page was missed. Every guard here was verified to fail when deliberately undermined.

## Deliberate divergences from the issues

- **`totalMonths` → `'number'`, not `'years'`.** `'years'` maps to numFmt `'0.0'` and would write **`25.0`** — a smaller version of the same bug.
- **`fireAge` stays `'years'`.** It is rounded to one decimal, so `'age'` (`'0'`) would render 51.5 as 52 — a silent data change, not a format change.
- **`leanThreshold` / `fatThreshold` → `'currency'`** (were `'number'`). Both are dollar amounts.
- **`null` is omitted, not zeroed.** This removes the `?? 0` workaround at `DeferredCompensation.tsx:94`, which wrote a `0` that reads as a shortfall at age 0.
- **Booleans are exported, not dropped.** `alreadyCoasting: true` is genuine information; what was wrong was giving it `#,##0`.

## Tests that flip — expected, not regressions

The characterization tests in `excelExport.test.ts` pinned the wrong values on purpose, with headers saying the failure is the signal. All of them are updated: the `describe('format inference by key name')` block describes a mechanism that no longer exists and is rewritten as declared formats; the case-insensitivity and precedence tests go away because lookup is exact; the five `prepareInputsForExport hazards` and the #62 currency assertion flip to correct behavior.

Rebased onto `main` after #63 merged. Full suite green: **615 web** and **164 .NET** (this PR adds the export tests and changes no C#; the pre-audit baselines were 550 and 159). `npm run build` clean, `package-lock.json` untouched.

## Out of scope, reported not fixed

- **`HealthcareGap.tsx` declares two dead formulas.** It sets `resultFormulas: { yearsInGap, annualBaseCost }`, but the result carries `gapYears` and `annualCost`. Neither key matches, so that workbook ships with **zero** formulas while declaring two. A correct `gapYears` formula also needs `MAX(0, …)` to match the clamp in `calculations.ts`. Being filed separately.
- **MAUI writes whole month counts with a decimal format.** `DebtPayoffWorkbook.cs` writes `TotalMonths`, `TargetMonths` and each `point.Month` with `DecimalStyleIndex`, which resolves to format code `"0.0"` — so MAUI renders **`25.0`** where web now renders `25`. This is *not* the name-inference defect class: MAUI declares a style per cell at the call site and is structurally immune to that. It just picked a decimal style for whole-number fields. Reporting only; C# is out of scope here.

  **Correction:** the first commit message and an earlier version of this description claimed MAUI already wrote `totalMonths` this way and that the platforms therefore agreed. That was wrong — I had not checked what `DecimalStyleIndex` resolves to. The `'number'` decision stands on its own merits (these are whole months), but the parity justification was backwards, and the second commit corrects it in the code comment.

No calculation values changed. The only `calculations.ts` edit is comments: the `calculateWithdrawal` JSDoc claimed the headline figure and the rate-analysis table share a horizon (they cap at `retirementYears` and `RATE_ANALYSIS_MAX_YEARS = 50` respectively, deliberately), and an inline comment further down overstated it the same way — the issue only named the JSDoc.
