### PR TITLE
Fix inert and mismatched Excel export formulas (#66)

### DIFF
--- a/web/src/pages/BaristaFIRE.tsx
+++ b/web/src/pages/BaristaFIRE.tsx
@@ -31,7 +31,7 @@ export default function BaristaFIRE() {
       calculatorName: 'Barista FIRE', inputs, results: resultValues, projections: results.projections, inputFormats, resultFormats,
       resultFormulas: {
         fullFireNumber: '{annualExpenses}/{withdrawalRate}',
-        baristaNumber: '({annualExpenses}-{partTimeIncome})/{withdrawalRate}',
+        baristaNumber: 'MAX(0,{annualExpenses}-{partTimeIncome})/{withdrawalRate}',
       },
     })
   }

--- a/web/src/pages/FatFIRE.tsx
+++ b/web/src/pages/FatFIRE.tsx
@@ -31,7 +31,7 @@ export default function FatFIRE() {
     const { values: resultValues, formats: resultFormats } = prepareResultsForExport(results)
     exportToExcel({
       calculatorName: 'Fat FIRE', inputs, results: resultValues, projections: results.projections, inputFormats, resultFormats,
-      resultFormulas: { fireNumber: '{annualExpenses}/{withdrawalRate}', savingsRate: '{annualContribution}/{annualIncome}' },
+      resultFormulas: { fireNumber: '{annualExpenses}/{withdrawalRate}', savingsRate: 'IF({annualIncome}>0,{annualContribution}/{annualIncome},0)' },
     })
   }
 

--- a/web/src/pages/HealthcareGap.tsx
+++ b/web/src/pages/HealthcareGap.tsx
@@ -28,8 +28,8 @@ export default function HealthcareGap() {
       calculatorName: 'Healthcare Gap', inputs, results: resultValues, projections: results.yearlyBreakdown,
       inputFormats, resultFormats,
       resultFormulas: {
-        yearsInGap: '{medicareAge}-{earlyRetirementAge}',
-        annualBaseCost: '({monthlyPremium}*12)+{annualDeductible}+{annualOutOfPocket}',
+        gapYears: 'MAX(0,{medicareAge}-{earlyRetirementAge})',
+        annualCost: '({monthlyPremium}*12)+{annualDeductible}+{annualOutOfPocket}',
       },
     })
   }

--- a/web/src/pages/LeanFIRE.tsx
+++ b/web/src/pages/LeanFIRE.tsx
@@ -37,7 +37,7 @@ export default function LeanFIRE() {
     const { values: resultValues, formats: resultFormats } = prepareResultsForExport(results)
     exportToExcel({
       calculatorName: 'Lean FIRE', inputs, results: resultValues, projections: results.projections, inputFormats, resultFormats,
-      resultFormulas: { fireNumber: '{annualExpenses}/{withdrawalRate}', savingsRate: '{annualContribution}/{annualIncome}' },
+      resultFormulas: { fireNumber: '{annualExpenses}/{withdrawalRate}', savingsRate: 'IF({annualIncome}>0,{annualContribution}/{annualIncome},0)' },
     })
   }
 

--- a/web/src/pages/SavingsRate.tsx
+++ b/web/src/pages/SavingsRate.tsx
@@ -36,8 +36,8 @@ export default function SavingsRate() {
       inputFormats, resultFormats,
       resultFormulas: {
         savingsRate: params.savingsFrequency === 'monthly'
-          ? '({contributionAmount}*12)/{annualIncome}'
-          : '{contributionAmount}/{annualIncome}',
+          ? 'IF({annualIncome}>0,({contributionAmount}*12)/{annualIncome},0)'
+          : 'IF({annualIncome}>0,{contributionAmount}/{annualIncome},0)',
       },
     })
   }

--- a/web/src/pages/StandardFIRE.tsx
+++ b/web/src/pages/StandardFIRE.tsx
@@ -66,7 +66,7 @@ export default function StandardFIRE() {
       resultFormats,
       resultFormulas: {
         fireNumber: '{annualExpenses}/{withdrawalRate}',
-        savingsRate: '{annualContribution}/{annualIncome}',
+        savingsRate: 'IF({annualIncome}>0,{annualContribution}/{annualIncome},0)',
         monthlyContribution: '{annualContribution}/12',
       },
     })

--- a/web/src/utils/__tests__/excelExport.test.ts
+++ b/web/src/utils/__tests__/excelExport.test.ts
@@ -196,6 +196,41 @@ function topLevelKeys(body: string): string[] {
   return keys
 }
 
+/**
+ * Like `topLevelKeys`, but pairs each top-level property name with the RAW text of its value.
+ *
+ * Comma and colon positions are found in the length-preserved blanked body (so a brace or colon
+ * inside a string never splits a segment), then the same offsets index into the raw body to recover
+ * the untouched formula string that blanking would otherwise have emptied.
+ */
+function topLevelEntries(blanked: string, raw: string): Array<[string, string]> {
+  const entries: Array<[string, string]> = []
+  let depth = 0
+  let start = 0
+
+  const take = (from: number, to: number) => {
+    const blankedSegment = blanked.slice(from, to)
+    const colon = blankedSegment.indexOf(':')
+    if (colon === -1) return
+    const name = blankedSegment.slice(0, colon).trim()
+    if (!/^[A-Za-z_$][\w$]*$/.test(name)) return
+    entries.push([name, raw.slice(from + colon + 1, to)])
+  }
+
+  for (let i = 0; i < blanked.length; i += 1) {
+    const char = blanked[i]
+    if (char === '{' || char === '[' || char === '(') depth += 1
+    else if (char === '}' || char === ']' || char === ')') depth -= 1
+    else if (char === ',' && depth === 0) {
+      take(start, i)
+      start = i + 1
+    }
+  }
+  take(start, blanked.length)
+
+  return entries
+}
+
 function undeclared(keys: Iterable<string>): string[] {
   return [...new Set(keys)].filter(key => !isExportFieldDeclared(key)).sort()
 }
@@ -652,6 +687,153 @@ describe('substring collisions that used to mis-format live exports', () => {
 
     // A real age is still correct, which is why the collision was easy to miss.
     expect(prepareInputsForExport({ currentAge: 30 }).formats.currentAge).toBe('age')
+  })
+})
+
+// ================================================================================================
+// Coverage: every declared result formula attaches to a real cell
+// ================================================================================================
+
+/**
+ * `resultFormulas` turns a Results cell into a live Excel formula instead of a frozen value, but
+ * only when two things line up, and nothing warns when they don't:
+ *
+ *   - the formula's KEY must match a field in the `results:` object (the output of
+ *     `prepareResultsForExport(...)`). A key that matches nothing is silently inert — no error, no
+ *     console warning, no visual difference — so the cell just keeps its plain value. That is how
+ *     HealthcareGap shipped `yearsInGap`/`annualBaseCost` against a result exposing
+ *     `gapYears`/`annualCost` (#66), and why it went unnoticed until someone opened the formula bar.
+ *   - every `{inputKey}` INSIDE the formula must match a field passed to `prepareInputsForExport`,
+ *     or the `{inputKey}`→cell-reference substitution leaves the literal `{inputKey}` in the cell.
+ *
+ * This suite derives both truth sets from real invocation — the calculator output and the page's
+ * own input call site — rather than a hand-kept list, and refuses to pass while checking nothing.
+ * It deliberately does not try to prove the formula's arithmetic equals `calculations.ts`; a clamp
+ * or guard dropped from an otherwise valid formula (BaristaFIRE's `MAX`, savingsRate's divide-by-
+ * zero guard) is a human read, not a mechanical one.
+ */
+
+/** Page file (as it appears in PAGE_SOURCES) → the RESULT_BUILDERS entry whose fields it exports. */
+const PAGE_RESULT_BUILDER: Record<string, keyof typeof RESULT_BUILDERS> = {
+  'BaristaFIRE.tsx': 'BaristaFIRE',
+  'CoastFIRE.tsx': 'CoastFIRE',
+  'FatFIRE.tsx': 'FatFIRE',
+  'HealthcareGap.tsx': 'HealthcareGap',
+  'LeanFIRE.tsx': 'LeanFIRE',
+  'ReverseFIRE.tsx': 'ReverseFIRE',
+  'SavingsRate.tsx': 'InvestmentGrowth',
+  'StandardFIRE.tsx': 'StandardFIRE',
+  'WithdrawalRate.tsx': 'Withdrawal',
+}
+
+/**
+ * Read each page's `resultFormulas` object literal as key → formula string.
+ *
+ * Built on the same hardened scan as `readCallSiteKeys`: comments and strings are blanked
+ * length-preservingly before any brace is counted, and an unbalanced literal throws rather than
+ * returning a short list, so this can never quietly report fewer formulas than a page declares.
+ */
+function readResultFormulas(): Map<string, Map<string, string>> {
+  const byFile = new Map<string, Map<string, string>>()
+
+  for (const [path, raw] of Object.entries(PAGE_SOURCES)) {
+    const source = blankOutCommentsAndStrings(raw)
+    const marker = /\bresultFormulas\s*:\s*\{/g
+    const formulas = new Map<string, string>()
+
+    for (const match of source.matchAll(marker)) {
+      const open = match.index + match[0].length - 1
+      let depth = 0
+      let close = -1
+
+      for (let i = open; i < source.length; i += 1) {
+        const char = source[i]
+        if (char === '{' || char === '[' || char === '(') depth += 1
+        else if (char === '}' || char === ']' || char === ')') {
+          depth -= 1
+          if (depth === 0) {
+            close = i
+            break
+          }
+        }
+      }
+      if (close === -1) throw new Error(`Could not find the end of resultFormulas in ${path}`)
+
+      // Keys are read from blanked source so nesting counts correctly; each key's formula refs are
+      // read from the RAW slice (blanking emptied every string literal). Attribute refs per key by
+      // walking the same top-level segments the key extraction used.
+      const blankedBody = source.slice(open + 1, close)
+      const rawBody = raw.slice(open + 1, close)
+      for (const [key, rawSegment] of topLevelEntries(blankedBody, rawBody)) {
+        const formulaRefs = [...rawSegment.matchAll(/\{([A-Za-z_$][\w$]*)\}/g)].map(m => m[1])
+        formulas.set(key, formulaRefs.join(' '))
+      }
+    }
+
+    if (formulas.size > 0) byFile.set(path.split('/').pop() ?? path, formulas)
+  }
+
+  return byFile
+}
+
+describe('declared result formulas attach to real cells', () => {
+  const formulasByFile = readResultFormulas()
+  const inputKeysByFile = readCallSiteKeys('prepareInputsForExport')
+
+  it.each([...formulasByFile])('%s keys all name a real result field', (file, formulas) => {
+    const builder = PAGE_RESULT_BUILDER[file]
+    expect(
+      builder,
+      `${file} declares resultFormulas but has no PAGE_RESULT_BUILDER entry, so this test cannot ` +
+        'check its keys against real calculator output. Add the mapping — do not skip the page.',
+    ).toBeDefined()
+
+    const fields = new Set(Object.keys(prepareResultsForExport(RESULT_BUILDERS[builder]()).values))
+    const dead = [...formulas.keys()].filter(key => !fields.has(key)).sort()
+    expect(
+      dead,
+      `${file} declares resultFormulas key(s) that no field in its exported results provides: ` +
+        `${dead.join(', ')}. A formula keyed to a nonexistent field never attaches — the cell ` +
+        `silently keeps a plain value. Real fields are: ${[...fields].sort().join(', ')}.`,
+    ).toEqual([])
+  })
+
+  it.each([...formulasByFile])('%s formulas reference only declared input fields', (file, formulas) => {
+    const inputs = new Set(inputKeysByFile.get(file) ?? [])
+    const unresolved = [...new Set([...formulas.values()].flatMap(refs => refs.split(' ').filter(Boolean)))]
+      .filter(ref => !inputs.has(ref))
+      .sort()
+    expect(
+      unresolved,
+      `${file} has resultFormulas referencing {input} key(s) not passed to prepareInputsForExport: ` +
+        `${unresolved.join(', ')}. The {key}->cell substitution would leave the literal text in the ` +
+        `cell. Declared inputs are: ${[...inputs].sort().join(', ')}.`,
+    ).toEqual([])
+  })
+
+  it('actually reads the resultFormulas it claims to check', () => {
+    // The vacuity guard, in the spirit of #68: if the marker or the scan silently matched nothing,
+    // the two suites above would pass over zero formulas. Rather than hard-code a page count (which
+    // passes when a tenth page is missed), locate every `resultFormulas:` literal independently and
+    // require that each one was read into a non-empty map.
+    let literalSites = 0
+    for (const [path, raw] of Object.entries(PAGE_SOURCES)) {
+      const file = path.split('/').pop() ?? path
+      const source = blankOutCommentsAndStrings(raw)
+      for (const _ of source.matchAll(/\bresultFormulas\s*:\s*\{/g)) {
+        literalSites += 1
+        expect(
+          formulasByFile.get(file)?.size,
+          `${file} declares a resultFormulas literal, but readResultFormulas read no keys from it. ` +
+            'Fix the scanner — do not delete this assertion or relax it to go green.',
+        ).toBeGreaterThan(0)
+      }
+    }
+    expect(literalSites).toBeGreaterThan(0)
+
+    // A known-good pair, so the scan cannot pass by reading keys but losing their formula refs.
+    expect(formulasByFile.get('HealthcareGap.tsx')?.get('gapYears')).toContain('medicareAge')
+    expect(formulasByFile.get('HealthcareGap.tsx')?.has('annualCost')).toBe(true)
   })
 })
 


### PR DESCRIPTION
Fixes #66.

## What was dead

`web/src/pages/HealthcareGap.tsx` passed `resultFormulas` keyed to `yearsInGap` and `annualBaseCost`, but `calculateHealthcareGap` returns `gapYears` and `annualCost`. `exceljs` attaches a formula only when its key exactly matches a field in the `results:` object, so **both formulas were silently inert** — no error, no console warning, no visual difference. The exported workbook shipped plain values where every other calculator shows its work. Re-keyed to `gapYears` / `annualCost`.

## What the clamp bug would have caused

The shipped code is `gapYears = Math.max(0, MEDICARE_AGE - earlyRetirementAge)`, but the formula string was `{medicareAge}-{earlyRetirementAge}` — **no clamp**. Had it merely been re-keyed as-is, a user retiring at or after 65 would have seen a **negative** gap in the spreadsheet while the app UI correctly shows 0 and the message "Retiring at or after Medicare eligibility leaves no coverage gap in this estimate." The formula is now `MAX(0,{medicareAge}-{earlyRetirementAge})`. `annualCost` already matched (`monthlyPremium` is stored monthly via `storedPeriod="monthly"`, so the `*12` lands on the right operand).

## What the audit of the other eight pages found

Auditing all nine pages that declare `resultFormulas` surfaced **five more formula strings** — correct keys, but arithmetic that dropped a clamp/guard present in `calculations.ts`:

| Page | Formula | Shipped code | Was |
| --- | --- | --- | --- |
| BaristaFIRE | `baristaNumber` | `Math.max(0, annualExpenses - partTimeIncome)/withdrawalRate` | omitted `MAX(0,…)` |
| FatFIRE | `savingsRate` | `annualIncome > 0 ? annualContribution/annualIncome : 0` | omitted guard → `#DIV/0!` |
| LeanFIRE | `savingsRate` | same | omitted guard |
| SavingsRate | `savingsRate` (both branches) | same guard | omitted guard |
| StandardFIRE | `savingsRate` | same | omitted guard |

All are rewritten to mirror the shipped arithmetic (`MAX(0,…)` / `IF({annualIncome}>0,…,0)`). **OK, unchanged:** CoastFIRE, ReverseFIRE, WithdrawalRate, and StandardFIRE's `fireNumber`/`monthlyContribution`. Every `{input}` reference resolves on every page.

These are **export-metadata changes only** — no `calculations.ts` value changes, no `app/` changes.

## The guard, and how I proved it fires

Added a suite in `web/src/utils/__tests__/excelExport.test.ts` (reusing #68's hardened scanner — comments/strings blanked length-preservingly before any brace is counted, unbalanced literals throw rather than returning short) that:

1. reads every page's `resultFormulas` literal (key → formula refs),
2. fails if any key is not a **real result field**, derived from a real `RESULT_BUILDERS` invocation via `prepareResultsForExport` — not a source scrape,
3. fails if any `{input}` reference is not a declared input for that page,
4. **vacuity guards**: locates every `resultFormulas:` literal independently (no hard-coded page count) and requires each was read into a non-empty map, plus pins a known key/formula pair.

I verified the guard by breaking things on purpose and confirming the matching test fails, then reverting each:
- misspelled a result key (`gapYears`→`yearsInGap`) → **key-existence test failed**;
- referenced a bogus `{notAnInput}` → **input-resolution test failed**;
- neutered the scanner's marker regex → **vacuity test failed**.

## Validation

- `npm ci` → `npm test`: **634 passing** (was 615; +19 new cases).
- `npm run build`: clean (type-checks tests too).

## Note to reviewer

The brief framed this as HealthcareGap-plus-audit; it turned out **six** formula strings were wrong across six pages, not one. The mechanical guard catches the two *silent* failure modes (dead keys, unresolved input refs). The five arithmetic-only mismatches can't be caught mechanically without re-deriving each calculation, so they were fixed by hand and rely on the audit + review.