### PR TITLE
Fix #69: give MAUI workbook exporters an integer number format

### DIFF
--- a/app/MyFireNumber.Core/Exports/BaristaFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/BaristaFireWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -46,23 +47,24 @@ public static class BaristaFireWorkbook
             new(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new(CreateTextCell("A4", "Input"), CreateTextCell("B4", "Value"))
         };
-        var inputs = new (string Label, double Value, uint Style)[]
+        var inputs = new (string Label, Cell Value)[]
         {
-            ("Current age", draft.CurrentAge, DecimalStyleIndex),
-            ("Current savings", draft.CurrentSavings, CurrencyStyleIndex),
-            ("Annual contribution", draft.AnnualContribution, CurrencyStyleIndex),
-            ("Annual retirement spending (today's dollars)", draft.AnnualExpenses, CurrencyStyleIndex),
-            ("Part-time take-home income (after tax)", draft.PartTimeAnnualIncome, CurrencyStyleIndex),
-            ("Expected return", draft.ExpectedReturn, PercentageStyleIndex),
-            ("Inflation rate", draft.InflationRate, PercentageStyleIndex),
-            ("Safe withdrawal rate", draft.WithdrawalRate, PercentageStyleIndex)
+            ("Current age", CreateNumberCell("", draft.CurrentAge, IntegerFormat.Plain)),
+            ("Current savings", CreateNumberCell("", draft.CurrentSavings, CurrencyStyleIndex)),
+            ("Annual contribution", CreateNumberCell("", draft.AnnualContribution, CurrencyStyleIndex)),
+            ("Annual retirement spending (today's dollars)", CreateNumberCell("", draft.AnnualExpenses, CurrencyStyleIndex)),
+            ("Part-time take-home income (after tax)", CreateNumberCell("", draft.PartTimeAnnualIncome, CurrencyStyleIndex)),
+            ("Expected return", CreateNumberCell("", draft.ExpectedReturn, PercentageStyleIndex)),
+            ("Inflation rate", CreateNumberCell("", draft.InflationRate, PercentageStyleIndex)),
+            ("Safe withdrawal rate", CreateNumberCell("", draft.WithdrawalRate, PercentageStyleIndex))
         };
 
         for (var index = 0; index < inputs.Length; index++)
         {
             var rowNumber = index + 5;
             var input = inputs[index];
-            rows.Add(new Row(CreateTextCell($"A{rowNumber}", input.Label), CreateNumberCell($"B{rowNumber}", input.Value, input.Style)));
+            input.Value.CellReference = $"B{rowNumber}";
+            rows.Add(new Row(CreateTextCell($"A{rowNumber}", input.Label), input.Value));
         }
 
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
@@ -105,9 +107,9 @@ public static class BaristaFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
-                    CreateNumberCell($"D{rowNumber}", 0, CurrencyStyleIndex),
+                    CreateNumberCell($"D{rowNumber}", 0d, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.TotalContributions, CurrencyStyleIndex),
                     CreateNumberCell($"F{rowNumber}", point.InflationAdjusted, CurrencyStyleIndex)));
                 continue;
@@ -116,7 +118,7 @@ public static class BaristaFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$10)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -154,6 +156,21 @@ public static class BaristaFireWorkbook
 
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new()
         {

--- a/app/MyFireNumber.Core/Exports/BaristaFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/BaristaFireWorkbook.cs
@@ -154,8 +154,6 @@ public static class BaristaFireWorkbook
         InlineString = new InlineString(new Text(value))
     };
 
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
     // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
     // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
@@ -171,6 +169,8 @@ public static class BaristaFireWorkbook
     private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
         CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new()
         {

--- a/app/MyFireNumber.Core/Exports/BaristaFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/BaristaFireWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class BaristaFireWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, BaristaFireDraft draft, BaristaFireResult result, DateTimeOffset generatedAt)
     {
@@ -103,7 +105,7 @@ public static class BaristaFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
                     CreateNumberCell($"D{rowNumber}", 0, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.TotalContributions, CurrencyStyleIndex),
@@ -114,7 +116,7 @@ public static class BaristaFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$10)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -168,22 +170,5 @@ public static class BaristaFireWorkbook
         CellFormula = new CellFormula(formula)
     };
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(
-            new NumberingFormats(
-                new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" },
-                new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" },
-                new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }),
-            new Fonts(new Font()),
-            new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
-            new Borders(new Border()),
-            new CellStyleFormats(new CellFormat()),
-            new CellFormats(
-                new CellFormat(),
-                new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true },
-                new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true },
-                new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/CoastFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/CoastFireWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class CoastFireWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, CoastFireDraft draft, CoastFireResult result, DateTimeOffset generatedAt)
     {
@@ -106,7 +108,7 @@ public static class CoastFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
                     CreateNumberCell($"D{rowNumber}", contribution, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", 0, CurrencyStyleIndex),
@@ -117,7 +119,7 @@ public static class CoastFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$10)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", contribution, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -171,22 +173,5 @@ public static class CoastFireWorkbook
         CellFormula = new CellFormula(formula)
     };
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(
-            new NumberingFormats(
-                new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" },
-                new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" },
-                new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }),
-            new Fonts(new Font()),
-            new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
-            new Borders(new Border()),
-            new CellStyleFormats(new CellFormat()),
-            new CellFormats(
-                new CellFormat(),
-                new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true },
-                new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true },
-                new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/CoastFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/CoastFireWorkbook.cs
@@ -157,8 +157,6 @@ public static class CoastFireWorkbook
         InlineString = new InlineString(new Text(value))
     };
 
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
     // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
     // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
@@ -174,6 +172,8 @@ public static class CoastFireWorkbook
     private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
         CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new()
         {

--- a/app/MyFireNumber.Core/Exports/CoastFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/CoastFireWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -48,23 +49,24 @@ public static class CoastFireWorkbook
             new(CreateTextCell("A4", "Input"), CreateTextCell("B4", "Value"))
         };
 
-        var inputs = new (string Label, double Value, uint Style)[]
+        var inputs = new (string Label, Cell Value)[]
         {
-            ("Current age", draft.CurrentAge, DecimalStyleIndex),
-            ("Retirement age", draft.RetirementAge, DecimalStyleIndex),
-            ("Current savings", draft.CurrentSavings, CurrencyStyleIndex),
-            ("Annual contribution", draft.AnnualContribution, CurrencyStyleIndex),
-            ("Annual retirement spending (today's dollars)", draft.AnnualExpenses, CurrencyStyleIndex),
-            ("Expected return", draft.ExpectedReturn, PercentageStyleIndex),
-            ("Inflation rate", draft.InflationRate, PercentageStyleIndex),
-            ("Safe withdrawal rate", draft.WithdrawalRate, PercentageStyleIndex)
+            ("Current age", CreateNumberCell("", draft.CurrentAge, IntegerFormat.Plain)),
+            ("Retirement age", CreateNumberCell("", draft.RetirementAge, IntegerFormat.Plain)),
+            ("Current savings", CreateNumberCell("", draft.CurrentSavings, CurrencyStyleIndex)),
+            ("Annual contribution", CreateNumberCell("", draft.AnnualContribution, CurrencyStyleIndex)),
+            ("Annual retirement spending (today's dollars)", CreateNumberCell("", draft.AnnualExpenses, CurrencyStyleIndex)),
+            ("Expected return", CreateNumberCell("", draft.ExpectedReturn, PercentageStyleIndex)),
+            ("Inflation rate", CreateNumberCell("", draft.InflationRate, PercentageStyleIndex)),
+            ("Safe withdrawal rate", CreateNumberCell("", draft.WithdrawalRate, PercentageStyleIndex))
         };
 
         for (var index = 0; index < inputs.Length; index++)
         {
             var rowNumber = index + 5;
             var input = inputs[index];
-            rows.Add(new Row(CreateTextCell($"A{rowNumber}", input.Label), CreateNumberCell($"B{rowNumber}", input.Value, input.Style)));
+            input.Value.CellReference = $"B{rowNumber}";
+            rows.Add(new Row(CreateTextCell($"A{rowNumber}", input.Label), input.Value));
         }
 
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
@@ -108,10 +110,10 @@ public static class CoastFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
                     CreateNumberCell($"D{rowNumber}", contribution, CurrencyStyleIndex),
-                    CreateNumberCell($"E{rowNumber}", 0, CurrencyStyleIndex),
+                    CreateNumberCell($"E{rowNumber}", 0d, CurrencyStyleIndex),
                     CreateNumberCell($"F{rowNumber}", point.InflationAdjusted, CurrencyStyleIndex)));
                 continue;
             }
@@ -119,7 +121,7 @@ public static class CoastFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$10)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", contribution, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -157,6 +159,21 @@ public static class CoastFireWorkbook
 
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new()
         {

--- a/app/MyFireNumber.Core/Exports/DebtPayoffWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/DebtPayoffWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -49,7 +50,7 @@ public static class DebtPayoffWorkbook
             new Row(CreateTextCell("A6", "Strategy"), CreateTextCell("B6", draft.Strategy.ToString())),
             new Row(CreateTextCell("A7", "Monthly budget"), CreateNumberCell("B7", draft.MonthlyBudget, CurrencyStyleIndex)),
             new Row(CreateTextCell("A8", "Extra payment"), CreateNumberCell("B8", draft.ExtraPayment, CurrencyStyleIndex)),
-            new Row(CreateTextCell("A9", "Target months"), CreateNumberCell("B9", draft.TargetMonths, IntegerStyleIndex))
+            new Row(CreateTextCell("A9", "Target months"), CreateNumberCell("B9", draft.TargetMonths, IntegerFormat.Grouped))
         ], 28, 20);
     }
 
@@ -60,7 +61,7 @@ public static class DebtPayoffWorkbook
             new Row(CreateTextCell("A1", "Debt Payoff Results")),
             new Row(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new Row(CreateTextCell("A4", "Result"), CreateTextCell("B4", "Value")),
-            new Row(CreateTextCell("A5", "Total months"), CreateNumberCell("B5", result.TotalMonths, IntegerStyleIndex)),
+            new Row(CreateTextCell("A5", "Total months"), CreateNumberCell("B5", result.TotalMonths, IntegerFormat.Grouped)),
             new Row(CreateTextCell("A6", "Total interest"), CreateNumberCell("B6", result.TotalInterest, CurrencyStyleIndex)),
             new Row(CreateTextCell("A7", "Total principal"), CreateNumberCell("B7", result.TotalPrincipal, CurrencyStyleIndex)),
             new Row(CreateTextCell("A8", "Monthly payment"), CreateNumberCell("B8", result.MonthlyPayment, CurrencyStyleIndex)),
@@ -92,7 +93,7 @@ public static class DebtPayoffWorkbook
         foreach (var point in projections)
         {
             var row = point.Month + 1;
-            rows.Add(new Row(CreateNumberCell($"A{row}", point.Month, IntegerStyleIndex), CreateNumberCell($"B{row}", point.TotalBalance, CurrencyStyleIndex), CreateNumberCell($"C{row}", point.PrincipalPaid, CurrencyStyleIndex), CreateNumberCell($"D{row}", point.InterestPaid, CurrencyStyleIndex), CreateNumberCell($"E{row}", point.CumulativeInterest, CurrencyStyleIndex)));
+            rows.Add(new Row(CreateNumberCell($"A{row}", point.Month, IntegerFormat.Grouped), CreateNumberCell($"B{row}", point.TotalBalance, CurrencyStyleIndex), CreateNumberCell($"C{row}", point.PrincipalPaid, CurrencyStyleIndex), CreateNumberCell($"D{row}", point.InterestPaid, CurrencyStyleIndex), CreateNumberCell($"E{row}", point.CumulativeInterest, CurrencyStyleIndex)));
         }
         AddWorksheet(workbookPart, sheets, "Payoff Projection", 4, rows, 12, 20, 20, 20, 22);
     }
@@ -108,6 +109,21 @@ public static class DebtPayoffWorkbook
     private static Cell CreateTextCell(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/DebtPayoffWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/DebtPayoffWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class DebtPayoffWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, DebtPayoffDraft draft, DebtPayoffResult result, DateTimeOffset generatedAt)
     {
@@ -47,7 +49,7 @@ public static class DebtPayoffWorkbook
             new Row(CreateTextCell("A6", "Strategy"), CreateTextCell("B6", draft.Strategy.ToString())),
             new Row(CreateTextCell("A7", "Monthly budget"), CreateNumberCell("B7", draft.MonthlyBudget, CurrencyStyleIndex)),
             new Row(CreateTextCell("A8", "Extra payment"), CreateNumberCell("B8", draft.ExtraPayment, CurrencyStyleIndex)),
-            new Row(CreateTextCell("A9", "Target months"), CreateNumberCell("B9", draft.TargetMonths, DecimalStyleIndex))
+            new Row(CreateTextCell("A9", "Target months"), CreateNumberCell("B9", draft.TargetMonths, IntegerStyleIndex))
         ], 28, 20);
     }
 
@@ -58,7 +60,7 @@ public static class DebtPayoffWorkbook
             new Row(CreateTextCell("A1", "Debt Payoff Results")),
             new Row(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new Row(CreateTextCell("A4", "Result"), CreateTextCell("B4", "Value")),
-            new Row(CreateTextCell("A5", "Total months"), CreateNumberCell("B5", result.TotalMonths, DecimalStyleIndex)),
+            new Row(CreateTextCell("A5", "Total months"), CreateNumberCell("B5", result.TotalMonths, IntegerStyleIndex)),
             new Row(CreateTextCell("A6", "Total interest"), CreateNumberCell("B6", result.TotalInterest, CurrencyStyleIndex)),
             new Row(CreateTextCell("A7", "Total principal"), CreateNumberCell("B7", result.TotalPrincipal, CurrencyStyleIndex)),
             new Row(CreateTextCell("A8", "Monthly payment"), CreateNumberCell("B8", result.MonthlyPayment, CurrencyStyleIndex)),
@@ -90,7 +92,7 @@ public static class DebtPayoffWorkbook
         foreach (var point in projections)
         {
             var row = point.Month + 1;
-            rows.Add(new Row(CreateNumberCell($"A{row}", point.Month, DecimalStyleIndex), CreateNumberCell($"B{row}", point.TotalBalance, CurrencyStyleIndex), CreateNumberCell($"C{row}", point.PrincipalPaid, CurrencyStyleIndex), CreateNumberCell($"D{row}", point.InterestPaid, CurrencyStyleIndex), CreateNumberCell($"E{row}", point.CumulativeInterest, CurrencyStyleIndex)));
+            rows.Add(new Row(CreateNumberCell($"A{row}", point.Month, IntegerStyleIndex), CreateNumberCell($"B{row}", point.TotalBalance, CurrencyStyleIndex), CreateNumberCell($"C{row}", point.PrincipalPaid, CurrencyStyleIndex), CreateNumberCell($"D{row}", point.InterestPaid, CurrencyStyleIndex), CreateNumberCell($"E{row}", point.CumulativeInterest, CurrencyStyleIndex)));
         }
         AddWorksheet(workbookPart, sheets, "Payoff Projection", 4, rows, 12, 20, 20, 20, 22);
     }
@@ -110,9 +112,5 @@ public static class DebtPayoffWorkbook
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(new NumberingFormats(new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" }, new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" }, new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }), new Fonts(new Font()), new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })), new Borders(new Border()), new CellStyleFormats(new CellFormat()), new CellFormats(new CellFormat(), new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/DebtPayoffWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/DebtPayoffWorkbook.cs
@@ -107,8 +107,6 @@ public static class DebtPayoffWorkbook
     }
 
     private static Cell CreateTextCell(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
     // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
     // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
@@ -124,6 +122,8 @@ public static class DebtPayoffWorkbook
     private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
         CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/DeferredCompensationWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/DeferredCompensationWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -26,28 +27,28 @@ public static class DeferredCompensationWorkbook
         AddStyles(workbookPart);
         var sheets = workbookPart.Workbook.AppendChild(new Sheets());
         AddWorksheet(workbookPart, sheets, "Inputs", 1,
-        [new Row(Text("A1", "Retirement Cash Flow Inputs")), new Row(Text("A2", "Generated UTC"), Text("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))), new Row(Text("A4", "Input"), Text("B4", "Value")), new Row(Text("A5", "Current age"), Number("B5", draft.CurrentAge, PlainIntegerStyleIndex)), new Row(Text("A6", "Semi-retirement age"), Number("B6", draft.SemiRetirementAge, PlainIntegerStyleIndex)), new Row(Text("A7", "Plan through age"), Number("B7", draft.PlanThroughAge, PlainIntegerStyleIndex)), new Row(Text("A8", "Annual retirement spending (today's dollars)"), Number("B8", draft.AnnualExpenses, CurrencyStyleIndex)), new Row(Text("A9", "Inflation rate"), Number("B9", draft.InflationRate, PercentageStyleIndex))], 42, 22);
+        [new Row(Text("A1", "Retirement Cash Flow Inputs")), new Row(Text("A2", "Generated UTC"), Text("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))), new Row(Text("A4", "Input"), Text("B4", "Value")), new Row(Text("A5", "Current age"), Number("B5", draft.CurrentAge, IntegerFormat.Plain)), new Row(Text("A6", "Semi-retirement age"), Number("B6", draft.SemiRetirementAge, IntegerFormat.Plain)), new Row(Text("A7", "Plan through age"), Number("B7", draft.PlanThroughAge, IntegerFormat.Plain)), new Row(Text("A8", "Annual retirement spending (today's dollars)"), Number("B8", draft.AnnualExpenses, CurrencyStyleIndex)), new Row(Text("A9", "Inflation rate"), Number("B9", draft.InflationRate, PercentageStyleIndex))], 42, 22);
         AddWorksheet(workbookPart, sheets, "Results", 2,
-        [new Row(Text("A1", "Retirement Cash Flow Results")), new Row(Text("A4", "Result"), Text("B4", "Value")), new Row(Text("A5", "Current balance"), Number("B5", result.CurrentBalance, CurrencyStyleIndex)), new Row(Text("A6", "Balance at semi-retirement"), Number("B6", result.BalanceAtSemiRetirement, CurrencyStyleIndex)), new Row(Text("A7", "First-year income (after tax)"), Number("B7", result.FirstYearIncome, CurrencyStyleIndex)), new Row(Text("A8", "First-year surplus"), Number("B8", result.FirstYearSurplus, CurrencyStyleIndex)), new Row(Text("A9", "Ending balance"), Number("B9", result.EndingBalance, CurrencyStyleIndex)), new Row(Text("A10", "Consecutive funded years from retirement"), Number("B10", result.FundedYears, IntegerStyleIndex)), new Row(Text("A11", "Retirement years projected"), Number("B11", result.RetirementYears, IntegerStyleIndex)), new Row(Text("A12", "Years fully covered (any year)"), Number("B12", result.YearsFullyCovered, IntegerStyleIndex)), new Row(Text("A13", "First shortfall age"), result.FirstShortfallAge is int shortfallAge ? Number("B13", shortfallAge, PlainIntegerStyleIndex) : Text("B13", "None projected"))], 40, 24);
-        AddWorksheet(workbookPart, sheets, "Annual Cash Flow", 3, result.Projections.Select((point, index) => new Row(Number($"A{index + 2}", point.Age, PlainIntegerStyleIndex), Number($"B{index + 2}", point.Year, PlainIntegerStyleIndex), Number($"C{index + 2}", point.TotalBalance, CurrencyStyleIndex), Number($"D{index + 2}", point.TotalIncome, CurrencyStyleIndex), Number($"E{index + 2}", point.Expenses, CurrencyStyleIndex), Number($"F{index + 2}", point.Surplus, CurrencyStyleIndex), Number($"G{index + 2}", point.WithdrawalTaxes, CurrencyStyleIndex))).Prepend(new Row(Text("A1", "Age"), Text("B1", "Year"), Text("C1", "Total balance"), Text("D1", "Income (after tax)"), Text("E1", "Expenses"), Text("F1", "Surplus"), Text("G1", "Estimated withdrawal tax"))), 12, 14, 20, 20, 20, 20, 24);
+        [new Row(Text("A1", "Retirement Cash Flow Results")), new Row(Text("A4", "Result"), Text("B4", "Value")), new Row(Text("A5", "Current balance"), Number("B5", result.CurrentBalance, CurrencyStyleIndex)), new Row(Text("A6", "Balance at semi-retirement"), Number("B6", result.BalanceAtSemiRetirement, CurrencyStyleIndex)), new Row(Text("A7", "First-year income (after tax)"), Number("B7", result.FirstYearIncome, CurrencyStyleIndex)), new Row(Text("A8", "First-year surplus"), Number("B8", result.FirstYearSurplus, CurrencyStyleIndex)), new Row(Text("A9", "Ending balance"), Number("B9", result.EndingBalance, CurrencyStyleIndex)), new Row(Text("A10", "Consecutive funded years from retirement"), Number("B10", result.FundedYears, IntegerFormat.Grouped)), new Row(Text("A11", "Retirement years projected"), Number("B11", result.RetirementYears, IntegerFormat.Grouped)), new Row(Text("A12", "Years fully covered (any year)"), Number("B12", result.YearsFullyCovered, IntegerFormat.Grouped)), new Row(Text("A13", "First shortfall age"), result.FirstShortfallAge is int shortfallAge ? Number("B13", shortfallAge, IntegerFormat.Plain) : Text("B13", "None projected"))], 40, 24);
+        AddWorksheet(workbookPart, sheets, "Annual Cash Flow", 3, result.Projections.Select((point, index) => new Row(Number($"A{index + 2}", point.Age, IntegerFormat.Plain), Number($"B{index + 2}", point.Year, IntegerFormat.Plain), Number($"C{index + 2}", point.TotalBalance, CurrencyStyleIndex), Number($"D{index + 2}", point.TotalIncome, CurrencyStyleIndex), Number($"E{index + 2}", point.Expenses, CurrencyStyleIndex), Number($"F{index + 2}", point.Surplus, CurrencyStyleIndex), Number($"G{index + 2}", point.WithdrawalTaxes, CurrencyStyleIndex))).Prepend(new Row(Text("A1", "Age"), Text("B1", "Year"), Text("C1", "Total balance"), Text("D1", "Income (after tax)"), Text("E1", "Expenses"), Text("F1", "Surplus"), Text("G1", "Estimated withdrawal tax"))), 12, 14, 20, 20, 20, 20, 24);
         AddWorksheet(workbookPart, sheets, "Accounts", 4, draft.Accounts.Select((account, index) => new Row(
             Text($"A{index + 2}", account.Name),
             Text($"B{index + 2}", account.Type.ToString()),
             Number($"C{index + 2}", account.Balance, CurrencyStyleIndex),
             Number($"D{index + 2}", account.AnnualContribution, CurrencyStyleIndex),
             Number($"E{index + 2}", account.AnnualReturn, PercentageStyleIndex),
-            Number($"F{index + 2}", account.AvailableAge, PlainIntegerStyleIndex),
+            Number($"F{index + 2}", account.AvailableAge, IntegerFormat.Plain),
             Text($"G{index + 2}", account.Type == RetirementAccountType.Deferred ? "Equal annual payouts" : "Withdrawal rate"),
             account.Type == RetirementAccountType.Deferred
-                ? Number($"H{index + 2}", account.PayoutYears, IntegerStyleIndex)
+                ? Number($"H{index + 2}", account.PayoutYears, IntegerFormat.Grouped)
                 : Number($"H{index + 2}", account.WithdrawalRate, PercentageStyleIndex),
             Number($"I{index + 2}", account.EffectiveWithdrawalTaxRate, PercentageStyleIndex)))
             .Prepend(new Row(Text("A1", "Name"), Text("B1", "Type"), Text("C1", "Balance"), Text("D1", "Annual contribution (today's dollars)"), Text("E1", "Annual return"), Text("F1", "Available age"), Text("G1", "Distribution method"), Text("H1", "Value"), Text("I1", "Withdrawal tax rate"))), 28, 18, 18, 30, 18, 16, 22, 16, 20);
         AddWorksheet(workbookPart, sheets, "Income Sources", 5, draft.IncomeSources.Select((income, index) => new Row(
             Text($"A{index + 2}", income.Name),
             Number($"B{index + 2}", income.AnnualAmount, CurrencyStyleIndex),
-            Number($"C{index + 2}", income.StartAge, PlainIntegerStyleIndex),
-            Number($"D{index + 2}", income.EndAge, PlainIntegerStyleIndex),
+            Number($"C{index + 2}", income.StartAge, IntegerFormat.Plain),
+            Number($"D{index + 2}", income.EndAge, IntegerFormat.Plain),
             Number($"E{index + 2}", income.AnnualGrowth, PercentageStyleIndex),
             Text($"F{index + 2}", income.IsAfterTax ? "Yes" : "No"),
             Number($"G{index + 2}", income.TaxRate, PercentageStyleIndex)))
@@ -55,7 +56,7 @@ public static class DeferredCompensationWorkbook
         AddWorksheet(workbookPart, sheets, "Additional Expenses", 6, draft.AdditionalExpenses.Select((expense, index) => new Row(
             Text($"A{index + 2}", expense.Name),
             Number($"B{index + 2}", expense.AnnualAmount, CurrencyStyleIndex),
-            Number($"C{index + 2}", expense.StartAge, PlainIntegerStyleIndex)))
+            Number($"C{index + 2}", expense.StartAge, IntegerFormat.Plain)))
             .Prepend(new Row(Text("A1", "Name"), Text("B1", "Annual amount (today's dollars)"), Text("C1", "Start age"))), 30, 30, 14);
         workbookPart.Workbook.Save();
     }
@@ -70,6 +71,13 @@ public static class DeferredCompensationWorkbook
     private static Cell Text(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell Number(string reference, int value, uint style) =>
+        throw new InvalidOperationException();
+
+    private static Cell Number(string reference, int value, IntegerFormat format) =>
+        Number(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell Number(string reference, double value, uint style) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = style, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : Text(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/DeferredCompensationWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/DeferredCompensationWorkbook.cs
@@ -69,8 +69,10 @@ public static class DeferredCompensationWorkbook
     }
 
     private static Cell Text(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, Number("B5", someInt, DecimalStyleIndex)
+    // would bind to the (double, uint) overload via int->double widening and silently reintroduce #69.
+    // Making the (int, uint) shape a compile error (error: true) forces every integer cell through the
+    // IntegerFormat overload, so the guarantee holds at compile time rather than merely by convention.
     [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
     private static Cell Number(string reference, int value, uint style) =>
         throw new InvalidOperationException();
@@ -78,6 +80,8 @@ public static class DeferredCompensationWorkbook
     private static Cell Number(string reference, int value, IntegerFormat format) =>
         Number(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell Number(string reference, double value, uint style) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = style, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : Text(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/DeferredCompensationWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/DeferredCompensationWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class DeferredCompensationWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, DeferredCompensationDraft draft, DeferredCompensationResult result, DateTimeOffset generatedAt)
     {
@@ -24,28 +26,28 @@ public static class DeferredCompensationWorkbook
         AddStyles(workbookPart);
         var sheets = workbookPart.Workbook.AppendChild(new Sheets());
         AddWorksheet(workbookPart, sheets, "Inputs", 1,
-        [new Row(Text("A1", "Retirement Cash Flow Inputs")), new Row(Text("A2", "Generated UTC"), Text("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))), new Row(Text("A4", "Input"), Text("B4", "Value")), new Row(Text("A5", "Current age"), Number("B5", draft.CurrentAge, DecimalStyleIndex)), new Row(Text("A6", "Semi-retirement age"), Number("B6", draft.SemiRetirementAge, DecimalStyleIndex)), new Row(Text("A7", "Plan through age"), Number("B7", draft.PlanThroughAge, DecimalStyleIndex)), new Row(Text("A8", "Annual retirement spending (today's dollars)"), Number("B8", draft.AnnualExpenses, CurrencyStyleIndex)), new Row(Text("A9", "Inflation rate"), Number("B9", draft.InflationRate, PercentageStyleIndex))], 42, 22);
+        [new Row(Text("A1", "Retirement Cash Flow Inputs")), new Row(Text("A2", "Generated UTC"), Text("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))), new Row(Text("A4", "Input"), Text("B4", "Value")), new Row(Text("A5", "Current age"), Number("B5", draft.CurrentAge, PlainIntegerStyleIndex)), new Row(Text("A6", "Semi-retirement age"), Number("B6", draft.SemiRetirementAge, PlainIntegerStyleIndex)), new Row(Text("A7", "Plan through age"), Number("B7", draft.PlanThroughAge, PlainIntegerStyleIndex)), new Row(Text("A8", "Annual retirement spending (today's dollars)"), Number("B8", draft.AnnualExpenses, CurrencyStyleIndex)), new Row(Text("A9", "Inflation rate"), Number("B9", draft.InflationRate, PercentageStyleIndex))], 42, 22);
         AddWorksheet(workbookPart, sheets, "Results", 2,
-        [new Row(Text("A1", "Retirement Cash Flow Results")), new Row(Text("A4", "Result"), Text("B4", "Value")), new Row(Text("A5", "Current balance"), Number("B5", result.CurrentBalance, CurrencyStyleIndex)), new Row(Text("A6", "Balance at semi-retirement"), Number("B6", result.BalanceAtSemiRetirement, CurrencyStyleIndex)), new Row(Text("A7", "First-year income (after tax)"), Number("B7", result.FirstYearIncome, CurrencyStyleIndex)), new Row(Text("A8", "First-year surplus"), Number("B8", result.FirstYearSurplus, CurrencyStyleIndex)), new Row(Text("A9", "Ending balance"), Number("B9", result.EndingBalance, CurrencyStyleIndex)), new Row(Text("A10", "Consecutive funded years from retirement"), Number("B10", result.FundedYears, DecimalStyleIndex)), new Row(Text("A11", "Retirement years projected"), Number("B11", result.RetirementYears, DecimalStyleIndex)), new Row(Text("A12", "Years fully covered (any year)"), Number("B12", result.YearsFullyCovered, DecimalStyleIndex)), new Row(Text("A13", "First shortfall age"), result.FirstShortfallAge is int shortfallAge ? Number("B13", shortfallAge, DecimalStyleIndex) : Text("B13", "None projected"))], 40, 24);
-        AddWorksheet(workbookPart, sheets, "Annual Cash Flow", 3, result.Projections.Select((point, index) => new Row(Number($"A{index + 2}", point.Age, DecimalStyleIndex), Number($"B{index + 2}", point.Year, DecimalStyleIndex), Number($"C{index + 2}", point.TotalBalance, CurrencyStyleIndex), Number($"D{index + 2}", point.TotalIncome, CurrencyStyleIndex), Number($"E{index + 2}", point.Expenses, CurrencyStyleIndex), Number($"F{index + 2}", point.Surplus, CurrencyStyleIndex), Number($"G{index + 2}", point.WithdrawalTaxes, CurrencyStyleIndex))).Prepend(new Row(Text("A1", "Age"), Text("B1", "Year"), Text("C1", "Total balance"), Text("D1", "Income (after tax)"), Text("E1", "Expenses"), Text("F1", "Surplus"), Text("G1", "Estimated withdrawal tax"))), 12, 14, 20, 20, 20, 20, 24);
+        [new Row(Text("A1", "Retirement Cash Flow Results")), new Row(Text("A4", "Result"), Text("B4", "Value")), new Row(Text("A5", "Current balance"), Number("B5", result.CurrentBalance, CurrencyStyleIndex)), new Row(Text("A6", "Balance at semi-retirement"), Number("B6", result.BalanceAtSemiRetirement, CurrencyStyleIndex)), new Row(Text("A7", "First-year income (after tax)"), Number("B7", result.FirstYearIncome, CurrencyStyleIndex)), new Row(Text("A8", "First-year surplus"), Number("B8", result.FirstYearSurplus, CurrencyStyleIndex)), new Row(Text("A9", "Ending balance"), Number("B9", result.EndingBalance, CurrencyStyleIndex)), new Row(Text("A10", "Consecutive funded years from retirement"), Number("B10", result.FundedYears, IntegerStyleIndex)), new Row(Text("A11", "Retirement years projected"), Number("B11", result.RetirementYears, IntegerStyleIndex)), new Row(Text("A12", "Years fully covered (any year)"), Number("B12", result.YearsFullyCovered, IntegerStyleIndex)), new Row(Text("A13", "First shortfall age"), result.FirstShortfallAge is int shortfallAge ? Number("B13", shortfallAge, PlainIntegerStyleIndex) : Text("B13", "None projected"))], 40, 24);
+        AddWorksheet(workbookPart, sheets, "Annual Cash Flow", 3, result.Projections.Select((point, index) => new Row(Number($"A{index + 2}", point.Age, PlainIntegerStyleIndex), Number($"B{index + 2}", point.Year, PlainIntegerStyleIndex), Number($"C{index + 2}", point.TotalBalance, CurrencyStyleIndex), Number($"D{index + 2}", point.TotalIncome, CurrencyStyleIndex), Number($"E{index + 2}", point.Expenses, CurrencyStyleIndex), Number($"F{index + 2}", point.Surplus, CurrencyStyleIndex), Number($"G{index + 2}", point.WithdrawalTaxes, CurrencyStyleIndex))).Prepend(new Row(Text("A1", "Age"), Text("B1", "Year"), Text("C1", "Total balance"), Text("D1", "Income (after tax)"), Text("E1", "Expenses"), Text("F1", "Surplus"), Text("G1", "Estimated withdrawal tax"))), 12, 14, 20, 20, 20, 20, 24);
         AddWorksheet(workbookPart, sheets, "Accounts", 4, draft.Accounts.Select((account, index) => new Row(
             Text($"A{index + 2}", account.Name),
             Text($"B{index + 2}", account.Type.ToString()),
             Number($"C{index + 2}", account.Balance, CurrencyStyleIndex),
             Number($"D{index + 2}", account.AnnualContribution, CurrencyStyleIndex),
             Number($"E{index + 2}", account.AnnualReturn, PercentageStyleIndex),
-            Number($"F{index + 2}", account.AvailableAge, DecimalStyleIndex),
+            Number($"F{index + 2}", account.AvailableAge, PlainIntegerStyleIndex),
             Text($"G{index + 2}", account.Type == RetirementAccountType.Deferred ? "Equal annual payouts" : "Withdrawal rate"),
             account.Type == RetirementAccountType.Deferred
-                ? Number($"H{index + 2}", account.PayoutYears, DecimalStyleIndex)
+                ? Number($"H{index + 2}", account.PayoutYears, IntegerStyleIndex)
                 : Number($"H{index + 2}", account.WithdrawalRate, PercentageStyleIndex),
             Number($"I{index + 2}", account.EffectiveWithdrawalTaxRate, PercentageStyleIndex)))
             .Prepend(new Row(Text("A1", "Name"), Text("B1", "Type"), Text("C1", "Balance"), Text("D1", "Annual contribution (today's dollars)"), Text("E1", "Annual return"), Text("F1", "Available age"), Text("G1", "Distribution method"), Text("H1", "Value"), Text("I1", "Withdrawal tax rate"))), 28, 18, 18, 30, 18, 16, 22, 16, 20);
         AddWorksheet(workbookPart, sheets, "Income Sources", 5, draft.IncomeSources.Select((income, index) => new Row(
             Text($"A{index + 2}", income.Name),
             Number($"B{index + 2}", income.AnnualAmount, CurrencyStyleIndex),
-            Number($"C{index + 2}", income.StartAge, DecimalStyleIndex),
-            Number($"D{index + 2}", income.EndAge, DecimalStyleIndex),
+            Number($"C{index + 2}", income.StartAge, PlainIntegerStyleIndex),
+            Number($"D{index + 2}", income.EndAge, PlainIntegerStyleIndex),
             Number($"E{index + 2}", income.AnnualGrowth, PercentageStyleIndex),
             Text($"F{index + 2}", income.IsAfterTax ? "Yes" : "No"),
             Number($"G{index + 2}", income.TaxRate, PercentageStyleIndex)))
@@ -53,7 +55,7 @@ public static class DeferredCompensationWorkbook
         AddWorksheet(workbookPart, sheets, "Additional Expenses", 6, draft.AdditionalExpenses.Select((expense, index) => new Row(
             Text($"A{index + 2}", expense.Name),
             Number($"B{index + 2}", expense.AnnualAmount, CurrencyStyleIndex),
-            Number($"C{index + 2}", expense.StartAge, DecimalStyleIndex)))
+            Number($"C{index + 2}", expense.StartAge, PlainIntegerStyleIndex)))
             .Prepend(new Row(Text("A1", "Name"), Text("B1", "Annual amount (today's dollars)"), Text("C1", "Start age"))), 30, 30, 14);
         workbookPart.Workbook.Save();
     }
@@ -71,5 +73,5 @@ public static class DeferredCompensationWorkbook
     private static Cell Number(string reference, double value, uint style) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = style, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : Text(reference, WorkbookValues.Unreachable);
-    private static void AddStyles(WorkbookPart workbookPart) => workbookPart.AddNewPart<WorkbookStylesPart>().Stylesheet = new Stylesheet(new NumberingFormats(new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" }, new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" }, new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }), new Fonts(new Font()), new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })), new Borders(new Border()), new CellStyleFormats(new CellFormat()), new CellFormats(new CellFormat(), new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/HealthcareGapWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/HealthcareGapWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class HealthcareGapWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, HealthcareGapDraft draft, HealthcareGapResult result, DateTimeOffset generatedAt)
     {
@@ -42,9 +44,9 @@ public static class HealthcareGapWorkbook
             new(CreateTextCell("A1", "Healthcare Gap Inputs")),
             new(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new(CreateTextCell("A4", "Input"), CreateTextCell("B4", "Value")),
-            new(CreateTextCell("A5", "Current age"), CreateNumberCell("B5", draft.CurrentAge, DecimalStyleIndex)),
-            new(CreateTextCell("A6", "Early retirement age"), CreateNumberCell("B6", draft.EarlyRetirementAge, DecimalStyleIndex)),
-            new(CreateTextCell("A7", "Medicare age"), CreateNumberCell("B7", draft.MedicareAge, DecimalStyleIndex)),
+            new(CreateTextCell("A5", "Current age"), CreateNumberCell("B5", draft.CurrentAge, PlainIntegerStyleIndex)),
+            new(CreateTextCell("A6", "Early retirement age"), CreateNumberCell("B6", draft.EarlyRetirementAge, PlainIntegerStyleIndex)),
+            new(CreateTextCell("A7", "Medicare age"), CreateNumberCell("B7", draft.MedicareAge, PlainIntegerStyleIndex)),
             new(CreateTextCell("A8", "Monthly premium"), CreateNumberCell("B8", draft.MonthlyPremium, CurrencyStyleIndex)),
             new(CreateTextCell("A9", "Annual deductible"), CreateNumberCell("B9", draft.AnnualDeductible, CurrencyStyleIndex)),
             new(CreateTextCell("A10", "Annual out-of-pocket"), CreateNumberCell("B10", draft.AnnualOutOfPocket, CurrencyStyleIndex)),
@@ -60,7 +62,7 @@ public static class HealthcareGapWorkbook
             new(CreateTextCell("A1", "Healthcare Gap Results")),
             new(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new(CreateTextCell("A4", "Result"), CreateTextCell("B4", "Value")),
-            new(CreateTextCell("A5", "Coverage gap years"), CreateFormulaCell("B5", "MAX(0,Inputs!B7-Inputs!B6)", DecimalStyleIndex)),
+            new(CreateTextCell("A5", "Coverage gap years"), CreateFormulaCell("B5", "MAX(0,Inputs!B7-Inputs!B6)", IntegerStyleIndex)),
             new(CreateTextCell("A6", "First-year annual cost"), CreateFormulaCell("B6", "Inputs!B8*12+Inputs!B9+Inputs!B10", CurrencyStyleIndex)),
             new(CreateTextCell("A7", "Total projected cost"), CreateNumberCell("B7", result.TotalCost, CurrencyStyleIndex)),
             new(CreateTextCell("A8", "Average annual cost"), CreateNumberCell("B8", result.AverageAnnualCost, CurrencyStyleIndex))
@@ -79,8 +81,8 @@ public static class HealthcareGapWorkbook
             var rowNumber = index + 2;
             var year = years[index];
             rows.Add(new Row(
-                CreateNumberCell($"A{rowNumber}", year.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", year.Year, DecimalStyleIndex),
+                CreateNumberCell($"A{rowNumber}", year.Age, PlainIntegerStyleIndex),
+                CreateNumberCell($"B{rowNumber}", year.Year, PlainIntegerStyleIndex),
                 CreateFormulaCell($"C{rowNumber}", $"D{rowNumber}+E{rowNumber}+F{rowNumber}", CurrencyStyleIndex),
                 CreateFormulaCell($"D{rowNumber}", $"Inputs!$B$8*12*((1+Inputs!$B$11)^(A{rowNumber}-Inputs!$B$6))", CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"Inputs!$B$9*((1+Inputs!$B$11)^(A{rowNumber}-Inputs!$B$6))", CurrencyStyleIndex),
@@ -107,15 +109,5 @@ public static class HealthcareGapWorkbook
 
     private static Cell CreateFormulaCell(string reference, string formula, uint styleIndex) => new() { CellReference = reference, StyleIndex = styleIndex, CellFormula = new CellFormula(formula) };
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(
-            new NumberingFormats(new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" }, new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" }, new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }),
-            new Fonts(new Font()),
-            new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
-            new Borders(new Border()),
-            new CellStyleFormats(new CellFormat()),
-            new CellFormats(new CellFormat(), new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/HealthcareGapWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/HealthcareGapWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -44,9 +45,9 @@ public static class HealthcareGapWorkbook
             new(CreateTextCell("A1", "Healthcare Gap Inputs")),
             new(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new(CreateTextCell("A4", "Input"), CreateTextCell("B4", "Value")),
-            new(CreateTextCell("A5", "Current age"), CreateNumberCell("B5", draft.CurrentAge, PlainIntegerStyleIndex)),
-            new(CreateTextCell("A6", "Early retirement age"), CreateNumberCell("B6", draft.EarlyRetirementAge, PlainIntegerStyleIndex)),
-            new(CreateTextCell("A7", "Medicare age"), CreateNumberCell("B7", draft.MedicareAge, PlainIntegerStyleIndex)),
+            new(CreateTextCell("A5", "Current age"), CreateNumberCell("B5", draft.CurrentAge, IntegerFormat.Plain)),
+            new(CreateTextCell("A6", "Early retirement age"), CreateNumberCell("B6", draft.EarlyRetirementAge, IntegerFormat.Plain)),
+            new(CreateTextCell("A7", "Medicare age"), CreateNumberCell("B7", draft.MedicareAge, IntegerFormat.Plain)),
             new(CreateTextCell("A8", "Monthly premium"), CreateNumberCell("B8", draft.MonthlyPremium, CurrencyStyleIndex)),
             new(CreateTextCell("A9", "Annual deductible"), CreateNumberCell("B9", draft.AnnualDeductible, CurrencyStyleIndex)),
             new(CreateTextCell("A10", "Annual out-of-pocket"), CreateNumberCell("B10", draft.AnnualOutOfPocket, CurrencyStyleIndex)),
@@ -81,8 +82,8 @@ public static class HealthcareGapWorkbook
             var rowNumber = index + 2;
             var year = years[index];
             rows.Add(new Row(
-                CreateNumberCell($"A{rowNumber}", year.Age, PlainIntegerStyleIndex),
-                CreateNumberCell($"B{rowNumber}", year.Year, PlainIntegerStyleIndex),
+                CreateNumberCell($"A{rowNumber}", year.Age, IntegerFormat.Plain),
+                CreateNumberCell($"B{rowNumber}", year.Year, IntegerFormat.Plain),
                 CreateFormulaCell($"C{rowNumber}", $"D{rowNumber}+E{rowNumber}+F{rowNumber}", CurrencyStyleIndex),
                 CreateFormulaCell($"D{rowNumber}", $"Inputs!$B$8*12*((1+Inputs!$B$11)^(A{rowNumber}-Inputs!$B$6))", CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"Inputs!$B$9*((1+Inputs!$B$11)^(A{rowNumber}-Inputs!$B$6))", CurrencyStyleIndex),
@@ -103,6 +104,21 @@ public static class HealthcareGapWorkbook
 
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/HealthcareGapWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/HealthcareGapWorkbook.cs
@@ -102,8 +102,6 @@ public static class HealthcareGapWorkbook
 
     private static Cell CreateTextCell(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
 
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
     // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
     // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
@@ -119,6 +117,8 @@ public static class HealthcareGapWorkbook
     private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
         CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/ReverseFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/ReverseFireWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class ReverseFireWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, ReverseFireDraft draft, ReverseFireResult result, DateTimeOffset generatedAt)
     {
@@ -46,8 +48,8 @@ public static class ReverseFireWorkbook
         };
         var inputs = new (string Label, double Value, uint Style)[]
         {
-            ("Current age", draft.CurrentAge, DecimalStyleIndex),
-            ("Target FIRE age", draft.TargetRetirementAge, DecimalStyleIndex),
+            ("Current age", draft.CurrentAge, PlainIntegerStyleIndex),
+            ("Target FIRE age", draft.TargetRetirementAge, PlainIntegerStyleIndex),
             ("Current savings", draft.CurrentSavings, CurrencyStyleIndex),
             ("Annual retirement spending (today's dollars)", draft.AnnualExpenses, CurrencyStyleIndex),
             ("Expected return", draft.ExpectedReturn, PercentageStyleIndex),
@@ -72,7 +74,7 @@ public static class ReverseFireWorkbook
             new(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new(CreateTextCell("A4", "Result"), CreateTextCell("B4", "Value")),
             new(CreateTextCell("A5", "FIRE Number"), CreateFormulaCell("B5", "Inputs!B8/Inputs!B11", CurrencyStyleIndex)),
-            new(CreateTextCell("A6", "Years to FIRE"), CreateFormulaCell("B6", "Inputs!B6-Inputs!B5", DecimalStyleIndex)),
+            new(CreateTextCell("A6", "Years to FIRE"), CreateFormulaCell("B6", "Inputs!B6-Inputs!B5", IntegerStyleIndex)),
             new(CreateTextCell("A7", "Required annual savings"), CreateNumberCell("B7", result.RequiredAnnualSavings, CurrencyStyleIndex)),
             new(CreateTextCell("A8", "Required monthly savings"), CreateNumberCell("B8", result.RequiredMonthlySavings, CurrencyStyleIndex)),
             new(CreateTextCell("A9", "Current savings will grow to"), CreateNumberCell("B9", result.CurrentWillGrowTo, CurrencyStyleIndex))
@@ -95,7 +97,7 @@ public static class ReverseFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
                     CreateNumberCell($"D{rowNumber}", 0, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.InflationAdjusted, CurrencyStyleIndex)));
@@ -105,7 +107,7 @@ public static class ReverseFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$9)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"C{rowNumber}/((1+Inputs!$B$10)^(A{rowNumber}-$A$2))", CurrencyStyleIndex)));
@@ -132,15 +134,5 @@ public static class ReverseFireWorkbook
 
     private static Cell CreateFormulaCell(string reference, string formula, uint styleIndex) => new() { CellReference = reference, StyleIndex = styleIndex, CellFormula = new CellFormula(formula) };
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(
-            new NumberingFormats(new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" }, new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" }, new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }),
-            new Fonts(new Font()),
-            new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
-            new Borders(new Border()),
-            new CellStyleFormats(new CellFormat()),
-            new CellFormats(new CellFormat(), new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/ReverseFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/ReverseFireWorkbook.cs
@@ -128,8 +128,6 @@ public static class ReverseFireWorkbook
 
     private static Cell CreateTextCell(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
 
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
     // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
     // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
@@ -145,6 +143,8 @@ public static class ReverseFireWorkbook
     private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
         CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/ReverseFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/ReverseFireWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -46,21 +47,22 @@ public static class ReverseFireWorkbook
             new(CreateTextCell("A2", "Generated UTC"), CreateTextCell("B2", generatedAt.UtcDateTime.ToString("O", CultureInfo.InvariantCulture))),
             new(CreateTextCell("A4", "Input"), CreateTextCell("B4", "Value"))
         };
-        var inputs = new (string Label, double Value, uint Style)[]
+        var inputs = new (string Label, Cell Value)[]
         {
-            ("Current age", draft.CurrentAge, PlainIntegerStyleIndex),
-            ("Target FIRE age", draft.TargetRetirementAge, PlainIntegerStyleIndex),
-            ("Current savings", draft.CurrentSavings, CurrencyStyleIndex),
-            ("Annual retirement spending (today's dollars)", draft.AnnualExpenses, CurrencyStyleIndex),
-            ("Expected return", draft.ExpectedReturn, PercentageStyleIndex),
-            ("Inflation rate", draft.InflationRate, PercentageStyleIndex),
-            ("Safe withdrawal rate", draft.WithdrawalRate, PercentageStyleIndex)
+            ("Current age", CreateNumberCell("", draft.CurrentAge, IntegerFormat.Plain)),
+            ("Target FIRE age", CreateNumberCell("", draft.TargetRetirementAge, IntegerFormat.Plain)),
+            ("Current savings", CreateNumberCell("", draft.CurrentSavings, CurrencyStyleIndex)),
+            ("Annual retirement spending (today's dollars)", CreateNumberCell("", draft.AnnualExpenses, CurrencyStyleIndex)),
+            ("Expected return", CreateNumberCell("", draft.ExpectedReturn, PercentageStyleIndex)),
+            ("Inflation rate", CreateNumberCell("", draft.InflationRate, PercentageStyleIndex)),
+            ("Safe withdrawal rate", CreateNumberCell("", draft.WithdrawalRate, PercentageStyleIndex))
         };
         for (var index = 0; index < inputs.Length; index++)
         {
             var rowNumber = index + 5;
             var input = inputs[index];
-            rows.Add(new Row(CreateTextCell($"A{rowNumber}", input.Label), CreateNumberCell($"B{rowNumber}", input.Value, input.Style)));
+            input.Value.CellReference = $"B{rowNumber}";
+            rows.Add(new Row(CreateTextCell($"A{rowNumber}", input.Label), input.Value));
         }
 
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
@@ -97,9 +99,9 @@ public static class ReverseFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
-                    CreateNumberCell($"D{rowNumber}", 0, CurrencyStyleIndex),
+                    CreateNumberCell($"D{rowNumber}", 0d, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.InflationAdjusted, CurrencyStyleIndex)));
                 continue;
             }
@@ -107,7 +109,7 @@ public static class ReverseFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$9)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"C{rowNumber}/((1+Inputs!$B$10)^(A{rowNumber}-$A$2))", CurrencyStyleIndex)));
@@ -128,6 +130,21 @@ public static class ReverseFireWorkbook
 
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/SavingsInvestmentWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/SavingsInvestmentWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -47,11 +48,11 @@ public static class SavingsInvestmentWorkbook
             new(CreateTextCell("A5", "Starting amount"), CreateNumberCell("B5", draft.StartingAmount, CurrencyStyleIndex)),
             new(CreateTextCell("A6", "Contribution amount"), CreateNumberCell("B6", draft.ContributionAmount, CurrencyStyleIndex)),
             new(CreateTextCell("A7", "Contribution frequency"), CreateTextCell("B7", draft.ContributionFrequency.ToString())),
-            new(CreateTextCell("A8", "Years investing"), CreateNumberCell("B8", draft.YearsInvesting, IntegerStyleIndex)),
+            new(CreateTextCell("A8", "Years investing"), CreateNumberCell("B8", draft.YearsInvesting, IntegerFormat.Grouped)),
             new(CreateTextCell("A9", "Expected return"), CreateNumberCell("B9", draft.ExpectedReturn, PercentageStyleIndex)),
             new(CreateTextCell("A10", "Inflation rate"), CreateNumberCell("B10", draft.InflationRate, PercentageStyleIndex)),
             new(CreateTextCell("A11", "Annual take-home income (after tax)"), CreateNumberCell("B11", draft.AnnualIncome, CurrencyStyleIndex)),
-            new(CreateTextCell("A12", "Current age"), CreateNumberCell("B12", draft.CurrentAge, PlainIntegerStyleIndex))
+            new(CreateTextCell("A12", "Current age"), CreateNumberCell("B12", draft.CurrentAge, IntegerFormat.Plain))
         };
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
     }
@@ -88,9 +89,9 @@ public static class SavingsInvestmentWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
-                    CreateNumberCell($"D{rowNumber}", 0, CurrencyStyleIndex),
+                    CreateNumberCell($"D{rowNumber}", 0d, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.TotalContributions, CurrencyStyleIndex),
                     CreateNumberCell($"F{rowNumber}", point.InflationAdjusted, CurrencyStyleIndex)));
                 continue;
@@ -99,7 +100,7 @@ public static class SavingsInvestmentWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$9)+D{rowNumber}", CurrencyStyleIndex),
                 CreateFormulaCell($"D{rowNumber}", "Results!B5", CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -120,6 +121,21 @@ public static class SavingsInvestmentWorkbook
 
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/SavingsInvestmentWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/SavingsInvestmentWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class SavingsInvestmentWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, SavingsInvestmentDraft draft, InvestmentGrowthResult result, DateTimeOffset generatedAt)
     {
@@ -45,11 +47,11 @@ public static class SavingsInvestmentWorkbook
             new(CreateTextCell("A5", "Starting amount"), CreateNumberCell("B5", draft.StartingAmount, CurrencyStyleIndex)),
             new(CreateTextCell("A6", "Contribution amount"), CreateNumberCell("B6", draft.ContributionAmount, CurrencyStyleIndex)),
             new(CreateTextCell("A7", "Contribution frequency"), CreateTextCell("B7", draft.ContributionFrequency.ToString())),
-            new(CreateTextCell("A8", "Years investing"), CreateNumberCell("B8", draft.YearsInvesting, DecimalStyleIndex)),
+            new(CreateTextCell("A8", "Years investing"), CreateNumberCell("B8", draft.YearsInvesting, IntegerStyleIndex)),
             new(CreateTextCell("A9", "Expected return"), CreateNumberCell("B9", draft.ExpectedReturn, PercentageStyleIndex)),
             new(CreateTextCell("A10", "Inflation rate"), CreateNumberCell("B10", draft.InflationRate, PercentageStyleIndex)),
             new(CreateTextCell("A11", "Annual take-home income (after tax)"), CreateNumberCell("B11", draft.AnnualIncome, CurrencyStyleIndex)),
-            new(CreateTextCell("A12", "Current age"), CreateNumberCell("B12", draft.CurrentAge, DecimalStyleIndex))
+            new(CreateTextCell("A12", "Current age"), CreateNumberCell("B12", draft.CurrentAge, PlainIntegerStyleIndex))
         };
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
     }
@@ -86,7 +88,7 @@ public static class SavingsInvestmentWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
                     CreateNumberCell($"D{rowNumber}", 0, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.TotalContributions, CurrencyStyleIndex),
@@ -97,7 +99,7 @@ public static class SavingsInvestmentWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$9)+D{rowNumber}", CurrencyStyleIndex),
                 CreateFormulaCell($"D{rowNumber}", "Results!B5", CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -124,15 +126,5 @@ public static class SavingsInvestmentWorkbook
 
     private static Cell CreateFormulaCell(string reference, string formula, uint styleIndex) => new() { CellReference = reference, StyleIndex = styleIndex, CellFormula = new CellFormula(formula) };
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(
-            new NumberingFormats(new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" }, new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" }, new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }),
-            new Fonts(new Font()),
-            new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
-            new Borders(new Border()),
-            new CellStyleFormats(new CellFormat()),
-            new CellFormats(new CellFormat(), new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/SavingsInvestmentWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/SavingsInvestmentWorkbook.cs
@@ -119,8 +119,6 @@ public static class SavingsInvestmentWorkbook
 
     private static Cell CreateTextCell(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
 
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
     // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
     // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
@@ -136,6 +134,8 @@ public static class SavingsInvestmentWorkbook
     private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
         CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/StandardFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/StandardFireWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -84,26 +85,27 @@ public static class StandardFireWorkbook
             new(CreateTextCell("A4", "Input"), CreateTextCell("B4", "Value"))
         };
 
-        var inputs = new (string Label, double Value, uint Style)[]
+        var inputs = new (string Label, Cell Value)[]
         {
-            ("Current age", draft.CurrentAge, DecimalStyleIndex),
-            ("Retirement age", draft.RetirementAge, DecimalStyleIndex),
-            ("Current savings", draft.CurrentSavings, CurrencyStyleIndex),
-            ("Annual contribution", draft.AnnualContribution, CurrencyStyleIndex),
-            ("Annual take-home income (after tax)", draft.AnnualIncome, CurrencyStyleIndex),
-            ("Annual retirement spending (today's dollars)", draft.AnnualExpenses, CurrencyStyleIndex),
-            ("Expected return", draft.ExpectedReturn, PercentageStyleIndex),
-            ("Inflation rate", draft.InflationRate, PercentageStyleIndex),
-            ("Safe withdrawal rate", draft.WithdrawalRate, PercentageStyleIndex)
+            ("Current age", CreateNumberCell("", draft.CurrentAge, IntegerFormat.Plain)),
+            ("Retirement age", CreateNumberCell("", draft.RetirementAge, IntegerFormat.Plain)),
+            ("Current savings", CreateNumberCell("", draft.CurrentSavings, CurrencyStyleIndex)),
+            ("Annual contribution", CreateNumberCell("", draft.AnnualContribution, CurrencyStyleIndex)),
+            ("Annual take-home income (after tax)", CreateNumberCell("", draft.AnnualIncome, CurrencyStyleIndex)),
+            ("Annual retirement spending (today's dollars)", CreateNumberCell("", draft.AnnualExpenses, CurrencyStyleIndex)),
+            ("Expected return", CreateNumberCell("", draft.ExpectedReturn, PercentageStyleIndex)),
+            ("Inflation rate", CreateNumberCell("", draft.InflationRate, PercentageStyleIndex)),
+            ("Safe withdrawal rate", CreateNumberCell("", draft.WithdrawalRate, PercentageStyleIndex))
         };
 
         for (var index = 0; index < inputs.Length; index++)
         {
             var rowNumber = index + 5;
             var input = inputs[index];
+            input.Value.CellReference = $"B{rowNumber}";
             rows.Add(new Row(
                 CreateTextCell($"A{rowNumber}", input.Label),
-                CreateNumberCell($"B{rowNumber}", input.Value, input.Style)));
+                input.Value));
         }
 
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
@@ -150,7 +152,7 @@ public static class StandardFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
                     CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.TotalContributions, CurrencyStyleIndex),
@@ -161,7 +163,7 @@ public static class StandardFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, IntegerFormat.Plain),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$11)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -199,6 +201,21 @@ public static class StandardFireWorkbook
             InlineString = new InlineString(new Text(value))
         };
     }
+
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex)
     {

--- a/app/MyFireNumber.Core/Exports/StandardFireWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/StandardFireWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class StandardFireWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, StandardFireDraft draft, StandardFireResult result, DateTimeOffset generatedAt)
     {
@@ -148,7 +150,7 @@ public static class StandardFireWorkbook
             {
                 rows.Add(new Row(
                     CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                    CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                    CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                     CreateNumberCell($"C{rowNumber}", point.Portfolio, CurrencyStyleIndex),
                     CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                     CreateNumberCell($"E{rowNumber}", point.TotalContributions, CurrencyStyleIndex),
@@ -159,7 +161,7 @@ public static class StandardFireWorkbook
             var previousRowNumber = rowNumber - 1;
             rows.Add(new Row(
                 CreateNumberCell($"A{rowNumber}", point.Age, DecimalStyleIndex),
-                CreateNumberCell($"B{rowNumber}", point.Year, DecimalStyleIndex),
+                CreateNumberCell($"B{rowNumber}", point.Year, PlainIntegerStyleIndex),
                 CreateFormulaCell($"C{rowNumber}", $"C{previousRowNumber}*(1+Inputs!$B$11)+D{rowNumber}", CurrencyStyleIndex),
                 CreateNumberCell($"D{rowNumber}", point.Contributions, CurrencyStyleIndex),
                 CreateFormulaCell($"E{rowNumber}", $"E{previousRowNumber}+D{rowNumber}", CurrencyStyleIndex),
@@ -225,22 +227,5 @@ public static class StandardFireWorkbook
         };
     }
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(
-            new NumberingFormats(
-                new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" },
-                new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" },
-                new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }),
-            new Fonts(new Font()),
-            new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
-            new Borders(new Border()),
-            new CellStyleFormats(new CellFormat()),
-            new CellFormats(
-                new CellFormat(),
-                new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true },
-                new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true },
-                new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/WithdrawalRateWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/WithdrawalRateWorkbook.cs
@@ -1,3 +1,4 @@
+using System;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Spreadsheet;
@@ -50,7 +51,7 @@ public static class WithdrawalRateWorkbook
             new(CreateTextCell("A6", "Withdrawal rate"), CreateNumberCell("B6", draft.WithdrawalRate, PercentageStyleIndex)),
             new(CreateTextCell("A7", "Expected return"), CreateNumberCell("B7", draft.ExpectedReturn, PercentageStyleIndex)),
             new(CreateTextCell("A8", "Inflation rate"), CreateNumberCell("B8", draft.InflationRate, PercentageStyleIndex)),
-            new(CreateTextCell("A9", "Retirement duration"), CreateNumberCell("B9", draft.RetirementYears, IntegerStyleIndex))
+            new(CreateTextCell("A9", "Retirement duration"), CreateNumberCell("B9", draft.RetirementYears, IntegerFormat.Grouped))
         };
 
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
@@ -136,6 +137,21 @@ public static class WithdrawalRateWorkbook
 
     // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
     // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
+    // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
+    // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
+    // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
+    // every integer cell through the IntegerFormat overload, so an int can never carry a fractional
+    // format. This is what makes the guarantee hold at compile time rather than merely by convention.
+    [Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
+    private static Cell CreateNumberCell(string reference, int value, uint styleIndex) =>
+        throw new InvalidOperationException();
+
+    // Integer cells route through IntegerFormat, never a raw style index, so an int can never be
+    // written with the fractional DecimalStyleIndex (issue #69). Overload resolution prefers this
+    // exact-type method over widening the int to the double overload.
+    private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
+        CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
+
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/WithdrawalRateWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/WithdrawalRateWorkbook.cs
@@ -135,8 +135,6 @@ public static class WithdrawalRateWorkbook
 
     private static Cell CreateTextCell(string reference, string value) => new() { CellReference = reference, DataType = CellValues.InlineString, InlineString = new InlineString(new Text(value)) };
 
-    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
-    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     // This overload exists solely to be un-callable. Without it, CreateNumberCell("B5", someInt,
     // DecimalStyleIndex) would bind to the (double, uint) overload via int->double widening and
     // silently reintroduce #69. Making the (int, uint) shape a compile error (error: true) forces
@@ -152,6 +150,8 @@ public static class WithdrawalRateWorkbook
     private static Cell CreateNumberCell(string reference, int value, IntegerFormat format) =>
         CreateNumberCell(reference, (double)value, WorkbookStyles.StyleIndexFor(format));
 
+    // A non-finite result is a legitimate outcome (an unreachable target), but "Infinity" inside a
+    // numeric cell is not a number Excel can read. Emit the same wording the apps show on screen.
     private static Cell CreateNumberCell(string reference, double value, uint styleIndex) => double.IsFinite(value)
         ? new() { CellReference = reference, StyleIndex = styleIndex, CellValue = new CellValue(value.ToString(CultureInfo.InvariantCulture)) }
         : CreateTextCell(reference, WorkbookValues.Unreachable);

--- a/app/MyFireNumber.Core/Exports/WithdrawalRateWorkbook.cs
+++ b/app/MyFireNumber.Core/Exports/WithdrawalRateWorkbook.cs
@@ -8,9 +8,11 @@ namespace MyFireNumber.Core.Exports;
 
 public static class WithdrawalRateWorkbook
 {
-    private const uint CurrencyStyleIndex = 1;
-    private const uint PercentageStyleIndex = 2;
-    private const uint DecimalStyleIndex = 3;
+    private const uint CurrencyStyleIndex = WorkbookStyles.CurrencyStyleIndex;
+    private const uint PercentageStyleIndex = WorkbookStyles.PercentageStyleIndex;
+    private const uint DecimalStyleIndex = WorkbookStyles.DecimalStyleIndex;
+    private const uint IntegerStyleIndex = WorkbookStyles.IntegerStyleIndex;
+    private const uint PlainIntegerStyleIndex = WorkbookStyles.PlainIntegerStyleIndex;
 
     public static void Create(string filePath, WithdrawalRateDraft draft, WithdrawalResult result, DateTimeOffset generatedAt)
     {
@@ -48,7 +50,7 @@ public static class WithdrawalRateWorkbook
             new(CreateTextCell("A6", "Withdrawal rate"), CreateNumberCell("B6", draft.WithdrawalRate, PercentageStyleIndex)),
             new(CreateTextCell("A7", "Expected return"), CreateNumberCell("B7", draft.ExpectedReturn, PercentageStyleIndex)),
             new(CreateTextCell("A8", "Inflation rate"), CreateNumberCell("B8", draft.InflationRate, PercentageStyleIndex)),
-            new(CreateTextCell("A9", "Retirement duration"), CreateNumberCell("B9", draft.RetirementYears, DecimalStyleIndex))
+            new(CreateTextCell("A9", "Retirement duration"), CreateNumberCell("B9", draft.RetirementYears, IntegerStyleIndex))
         };
 
         AddWorksheet(workbookPart, sheets, "Inputs", 1, rows, 32, 20);
@@ -140,15 +142,5 @@ public static class WithdrawalRateWorkbook
 
     private static Cell CreateFormulaCell(string reference, string formula, uint styleIndex) => new() { CellReference = reference, StyleIndex = styleIndex, CellFormula = new CellFormula(formula) };
 
-    private static void AddStyles(WorkbookPart workbookPart)
-    {
-        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
-        stylesPart.Stylesheet = new Stylesheet(
-            new NumberingFormats(new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" }, new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" }, new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" }),
-            new Fonts(new Font()),
-            new Fills(new Fill(new PatternFill { PatternType = PatternValues.None }), new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
-            new Borders(new Border()),
-            new CellStyleFormats(new CellFormat()),
-            new CellFormats(new CellFormat(), new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true }, new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true }));
-    }
+    private static void AddStyles(WorkbookPart workbookPart) => WorkbookStyles.Apply(workbookPart);
 }

--- a/app/MyFireNumber.Core/Exports/WorkbookStyles.cs
+++ b/app/MyFireNumber.Core/Exports/WorkbookStyles.cs
@@ -62,4 +62,36 @@ public static class WorkbookStyles
                 new CellFormat { NumberFormatId = 167U, ApplyNumberFormat = true },
                 new CellFormat { NumberFormatId = 168U, ApplyNumberFormat = true }));
     }
+
+    /// <summary>
+    /// Resolves the style index for an integer cell. The only inputs are the two integer formats, so an
+    /// <c>int</c> routed through this helper can never land on <see cref="DecimalStyleIndex"/>.
+    ///
+    /// On its own the enum makes the correct call the easy one but not the only one: because <c>int</c>
+    /// widens implicitly to <c>double</c>, a raw <c>CreateNumberCell(reference, someInt, DecimalStyleIndex)</c>
+    /// would otherwise bind to the <c>(double, uint)</c> overload and silently reintroduce #69. Each
+    /// exporter therefore also declares an <c>[Obsolete(error: true)]</c> <c>(int, uint)</c> overload whose
+    /// sole purpose is to be un-callable, turning that shape into a compile error. Enum plus poison
+    /// overload together make the defect genuinely unrepresentable at compile time, not merely unlikely.
+    /// </summary>
+    public static uint StyleIndexFor(IntegerFormat format) => format switch
+    {
+        IntegerFormat.Plain => PlainIntegerStyleIndex,
+        IntegerFormat.Grouped => IntegerStyleIndex,
+        _ => throw new ArgumentOutOfRangeException(nameof(format))
+    };
+}
+
+/// <summary>
+/// How a whole-number (<c>int</c>) cell should render. There is deliberately no "decimal" member: an
+/// <c>int</c> must never carry a fractional format (issue #69), and forcing every integer cell through
+/// this enum makes that mistake impossible to express at a call site.
+/// </summary>
+public enum IntegerFormat
+{
+    /// <summary><c>0</c> — an identifier or small count (a calendar year or an age); no separator.</summary>
+    Plain,
+
+    /// <summary><c>#,##0</c> — a magnitude where a thousands separator can help (a month or year count).</summary>
+    Grouped
 }

--- a/app/MyFireNumber.Core/Exports/WorkbookStyles.cs
+++ b/app/MyFireNumber.Core/Exports/WorkbookStyles.cs
@@ -1,0 +1,65 @@
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+
+namespace MyFireNumber.Core.Exports;
+
+/// <summary>
+/// The single source of truth for the number formats and style indexes every workbook exporter uses.
+/// Keeping the stylesheet here (rather than duplicated per exporter) is deliberate: the duplicated
+/// stylesheet is exactly what let the exporters drift and ship without an integer format, so a whole
+/// number such as a calendar year rendered as "2026.0". See issue #69.
+/// </summary>
+public static class WorkbookStyles
+{
+    /// <summary><c>$#,##0</c> — currency, no cents.</summary>
+    public const uint CurrencyStyleIndex = 1;
+
+    /// <summary><c>0.0%</c> — percentage with one decimal.</summary>
+    public const uint PercentageStyleIndex = 2;
+
+    /// <summary><c>0.0</c> — a genuinely fractional value (a <c>double</c> such as years-to-FIRE).</summary>
+    public const uint DecimalStyleIndex = 3;
+
+    /// <summary>
+    /// <c>#,##0</c> — a whole-number <em>magnitude</em> where a thousands separator can help a reader
+    /// (a month or year count). Sourced from an <c>int</c>. Using <see cref="DecimalStyleIndex"/> here
+    /// is the #69 defect.
+    /// </summary>
+    public const uint IntegerStyleIndex = 4;
+
+    /// <summary>
+    /// <c>0</c> — a whole-number <em>identifier or small count</em> where grouping is meaningless: a
+    /// calendar year or an age. A separator would turn the year 2026 into "2,026", so these must not
+    /// use <see cref="IntegerStyleIndex"/>. Also sourced from an <c>int</c>.
+    /// </summary>
+    public const uint PlainIntegerStyleIndex = 5;
+
+    /// <summary>
+    /// Builds and attaches the shared stylesheet to the workbook. The <see cref="CellFormats"/> order
+    /// must match the style-index constants above.
+    /// </summary>
+    public static void Apply(WorkbookPart workbookPart)
+    {
+        var stylesPart = workbookPart.AddNewPart<WorkbookStylesPart>();
+        stylesPart.Stylesheet = new Stylesheet(
+            new NumberingFormats(
+                new NumberingFormat { NumberFormatId = 164U, FormatCode = "$#,##0" },
+                new NumberingFormat { NumberFormatId = 165U, FormatCode = "0.0%" },
+                new NumberingFormat { NumberFormatId = 166U, FormatCode = "0.0" },
+                new NumberingFormat { NumberFormatId = 167U, FormatCode = "#,##0" },
+                new NumberingFormat { NumberFormatId = 168U, FormatCode = "0" }),
+            new Fonts(new Font()),
+            new Fills(
+                new Fill(new PatternFill { PatternType = PatternValues.None }),
+                new Fill(new PatternFill { PatternType = PatternValues.Gray125 })),
+            new Borders(new Border()),
+            new CellStyleFormats(new CellFormat()),
+            new CellFormats(
+                new CellFormat(),
+                new CellFormat { NumberFormatId = 164U, ApplyNumberFormat = true },
+                new CellFormat { NumberFormatId = 165U, ApplyNumberFormat = true },
+                new CellFormat { NumberFormatId = 166U, ApplyNumberFormat = true },
+                new CellFormat { NumberFormatId = 167U, ApplyNumberFormat = true },
+                new CellFormat { NumberFormatId = 168U, ApplyNumberFormat = true }));
+    }
+}

--- a/app/MyFireNumber.Tests/Exports/IntegerCellFactoryGuardTests.cs
+++ b/app/MyFireNumber.Tests/Exports/IntegerCellFactoryGuardTests.cs
@@ -1,0 +1,79 @@
+using System.Reflection;
+using MyFireNumber.Core.Exports;
+
+namespace MyFireNumber.Tests.Exports;
+
+/// <summary>
+/// The structural guard for issue #69. The per-exporter format tests assert representative cells, but a
+/// hand-enumerated list checked by hand-enumerated assertions shares its own blind spot: an omission in
+/// the list is invisible to assertions derived from the same list, so a missed <c>int</c> cell (as
+/// happened with three draft ages) passes at full green.
+///
+/// The real defense against that is the type system, not a list: integer cells route through
+/// <see cref="IntegerFormat"/>, which has no decimal member, and each exporter declares an
+/// <c>[Obsolete(error: true)]</c> <c>(string, int, uint)</c> overload of its number-cell factory whose
+/// only purpose is to be un-callable. Without that poison overload, <c>int</c> would widen implicitly to
+/// <c>double</c> and a raw style index would silently reintroduce the defect.
+///
+/// This test enforces the mechanism itself: every exporter that builds numeric cells must keep the
+/// poison overload, marked as an error. If someone deletes it — reopening the implicit-widening hole —
+/// this fails, even though no individual cell assertion would notice.
+/// </summary>
+public sealed class IntegerCellFactoryGuardTests
+{
+    public static IEnumerable<object[]> Exporters()
+    {
+        var assembly = typeof(WorkbookStyles).Assembly;
+        foreach (var type in assembly.GetTypes())
+        {
+            if (type.Namespace != "MyFireNumber.Core.Exports" || !type.Name.EndsWith("Workbook", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // Only exporters that actually build numeric cells need the guard.
+            if (NumberFactories(type).Any())
+            {
+                yield return [type];
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(Exporters))]
+    public void EveryExporterKeepsAnUncallablePoisonOverloadForIntStyleIndexPairs(Type exporter)
+    {
+        var poison = NumberFactories(exporter)
+            .Where(method => HasSignature(method, typeof(string), typeof(int), typeof(uint)))
+            .ToArray();
+
+        Assert.True(
+            poison.Length == 1,
+            $"{exporter.Name} must declare exactly one (string, int, uint) number-cell overload to poison the int+raw-style shape; found {poison.Length}.");
+
+        var obsolete = poison[0].GetCustomAttribute<ObsoleteAttribute>();
+        Assert.NotNull(obsolete);
+        Assert.True(obsolete!.IsError, $"{exporter.Name}'s poison overload must set error: true so an int+raw-style call fails to compile.");
+    }
+
+    [Theory]
+    [MemberData(nameof(Exporters))]
+    public void EveryExporterExposesAnIntegerFormatOverload(Type exporter)
+    {
+        var safe = NumberFactories(exporter)
+            .Any(method => HasSignature(method, typeof(string), typeof(int), typeof(IntegerFormat)));
+
+        Assert.True(safe, $"{exporter.Name} must offer a (string, int, IntegerFormat) overload so integer cells have a type-safe path.");
+    }
+
+    private static IEnumerable<MethodInfo> NumberFactories(Type type) => type
+        .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+        .Where(method => method.Name is "CreateNumberCell" or "Number");
+
+    private static bool HasSignature(MethodInfo method, params Type[] parameterTypes)
+    {
+        var parameters = method.GetParameters();
+        return parameters.Length == parameterTypes.Length
+            && parameters.Select(parameter => parameter.ParameterType).SequenceEqual(parameterTypes);
+    }
+}

--- a/app/MyFireNumber.Tests/Exports/WorkbookNumberFormatTests.cs
+++ b/app/MyFireNumber.Tests/Exports/WorkbookNumberFormatTests.cs
@@ -40,6 +40,11 @@ public sealed class WorkbookNumberFormatTests : IDisposable
         var result = FinancialCalculator.CalculateStandardFire(draft.ToFireInputs(2026));
         StandardFireWorkbook.Create(workbookPath, draft, result, GeneratedAt);
 
+        // Draft ages on the Inputs sheet are int and were the omission the reviewer caught (#69) — they
+        // must be plain integers, not "45.0".
+        Assert.Equal("0", ResolveFormat(0, "B5"));      // StandardFireDraft.CurrentAge (int)
+        Assert.Equal("0", ResolveFormat(0, "B6"));      // StandardFireDraft.RetirementAge (int)
+
         // A calendar year must have no thousands separator, or 2026 renders as "2,026".
         Assert.Equal("0", ResolveFormat(2, "B2"));      // ProjectionPoint.Year (int) -> "0"
         Assert.Equal("2026", ReadCellValue(2, "B2"));
@@ -49,6 +54,27 @@ public sealed class WorkbookNumberFormatTests : IDisposable
         Assert.Equal("0.0", ResolveFormat(1, "B6"));    // YearsToFire (double)
         // RetirementGoalAssessment.TargetRetirementAge is double, not int, so it stays decimal.
         Assert.Equal("0.0", ResolveFormat(1, "B11"));
+    }
+
+    [Fact]
+    public void BaristaFire_DraftAgeIsPlainInteger()
+    {
+        var draft = BaristaFireDraft.Default;
+        var result = FinancialCalculator.CalculateBaristaFire(draft.ToFireInputs(2026), draft.PartTimeAnnualIncome);
+        BaristaFireWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("0", ResolveFormat(0, "B5"));      // BaristaFireDraft.CurrentAge (int)
+    }
+
+    [Fact]
+    public void CoastFire_DraftAgesArePlainIntegers()
+    {
+        var draft = CoastFireDraft.Default;
+        var result = FinancialCalculator.CalculateCoastFire(draft.ToFireInputs(2026));
+        CoastFireWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("0", ResolveFormat(0, "B5"));      // CoastFireDraft.CurrentAge (int)
+        Assert.Equal("0", ResolveFormat(0, "B6"));      // CoastFireDraft.RetirementAge (int)
     }
 
     [Fact]

--- a/app/MyFireNumber.Tests/Exports/WorkbookNumberFormatTests.cs
+++ b/app/MyFireNumber.Tests/Exports/WorkbookNumberFormatTests.cs
@@ -1,0 +1,184 @@
+using System.Globalization;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Spreadsheet;
+using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Exports;
+
+namespace MyFireNumber.Tests.Exports;
+
+/// <summary>
+/// Guards issue #69: the exporters had no integer number format, so every whole-number field landed
+/// on the "0.0" decimal style and a calendar year exported as "2026.0". These tests read the number
+/// format actually resolved on the generated cell — the string a user opening the file would see —
+/// rather than trusting the style-index constant the exporter passed.
+///
+/// The invariant is mechanical: an <c>int</c>-typed cell must carry an integer format, a <c>double</c>
+/// must keep "0.0". Ages and calendar years use "0" (no thousands separator, so 2026 is not "2,026");
+/// magnitudes such as month and year counts use "#,##0".
+/// </summary>
+public sealed class WorkbookNumberFormatTests : IDisposable
+{
+    private readonly string workbookPath = Path.Combine(Path.GetTempPath(), $"my-fire-number-format-{Guid.NewGuid():N}.xlsx");
+    private static readonly DateTimeOffset GeneratedAt = new(2026, 8, 9, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void DebtPayoff_IntegerFieldsUseGroupedInteger_NotDecimal()
+    {
+        var draft = DebtPayoffDraft.Default with { Debts = [new DebtItem("card", "Credit card", 1_000, 0.1, 100)], MonthlyBudget = 500 };
+        var result = FinancialCalculator.CalculateSnowballPayoff(draft.Debts, draft.MonthlyBudget);
+        DebtPayoffWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("#,##0", ResolveFormat(0, "B9"));  // TargetMonths (int)
+        Assert.Equal("#,##0", ResolveFormat(1, "B5"));  // TotalMonths (int)
+        Assert.Equal("#,##0", ResolveFormat(3, "A2"));  // DebtPayoffMonth.Month (int)
+    }
+
+    [Fact]
+    public void StandardFire_YearIsPlainInteger_AgeStaysDecimal_YearsToFireStaysDecimal()
+    {
+        var draft = StandardFireDraft.Default;
+        var result = FinancialCalculator.CalculateStandardFire(draft.ToFireInputs(2026));
+        StandardFireWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        // A calendar year must have no thousands separator, or 2026 renders as "2,026".
+        Assert.Equal("0", ResolveFormat(2, "B2"));      // ProjectionPoint.Year (int) -> "0"
+        Assert.Equal("2026", ReadCellValue(2, "B2"));
+
+        // ProjectionPoint.Age is double and genuinely fractional; it must not be forced to an integer.
+        Assert.Equal("0.0", ResolveFormat(2, "A2"));    // ProjectionPoint.Age (double)
+        Assert.Equal("0.0", ResolveFormat(1, "B6"));    // YearsToFire (double)
+        // RetirementGoalAssessment.TargetRetirementAge is double, not int, so it stays decimal.
+        Assert.Equal("0.0", ResolveFormat(1, "B11"));
+    }
+
+    [Fact]
+    public void HealthcareGap_AgesAndYearsArePlainIntegers()
+    {
+        var draft = HealthcareGapDraft.Default;
+        var result = FinancialCalculator.CalculateHealthcareGap(draft.ToInputs(2026));
+        HealthcareGapWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("0", ResolveFormat(0, "B5"));      // CurrentAge (int)
+        Assert.Equal("0", ResolveFormat(0, "B6"));      // EarlyRetirementAge (int)
+        Assert.Equal("0", ResolveFormat(0, "B7"));      // MedicareAge (int)
+        Assert.Equal("0", ResolveFormat(2, "A2"));      // HealthcareYear.Age (int)
+        Assert.Equal("0", ResolveFormat(2, "B2"));      // HealthcareYear.Year (int)
+        // "Coverage gap years" is an integer duration despite the formula source.
+        Assert.Equal("#,##0", ResolveFormat(1, "B5"));
+    }
+
+    [Fact]
+    public void SavingsInvestment_YearsInvestingGrouped_AgeAndProjectionYearPlain()
+    {
+        var draft = SavingsInvestmentDraft.Default;
+        var result = FinancialCalculator.CalculateInvestmentGrowth(draft.ToInputs(2026));
+        SavingsInvestmentWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("#,##0", ResolveFormat(0, "B8"));  // YearsInvesting (int magnitude)
+        Assert.Equal("0", ResolveFormat(0, "B12"));     // CurrentAge (int)
+        Assert.Equal("0", ResolveFormat(2, "B2"));      // InvestmentProjectionPoint.Year (int)
+        Assert.Equal("0.0", ResolveFormat(2, "A2"));    // InvestmentProjectionPoint.Age (double)
+    }
+
+    [Fact]
+    public void ReverseFire_AgesPlain_YearsToFireDurationGrouped()
+    {
+        var draft = ReverseFireDraft.Default;
+        var result = FinancialCalculator.CalculateReverseFire(draft.ToFireInputs(2026));
+        ReverseFireWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("0", ResolveFormat(0, "B5"));      // CurrentAge (int)
+        Assert.Equal("0", ResolveFormat(0, "B6"));      // TargetRetirementAge (int)
+        Assert.Equal("#,##0", ResolveFormat(1, "B6"));  // "Years to FIRE" duration formula
+        Assert.Equal("0", ResolveFormat(2, "B2"));      // ProjectionPoint.Year (int)
+        Assert.Equal("0.0", ResolveFormat(2, "A2"));    // ProjectionPoint.Age (double)
+    }
+
+    [Fact]
+    public void WithdrawalRate_RetirementYearsGrouped_ButProjectionYearStaysDecimal()
+    {
+        var draft = WithdrawalRateDraft.Default;
+        var result = FinancialCalculator.CalculateWithdrawal(draft.PortfolioValue, draft.WithdrawalRate, draft.ExpectedReturn, draft.InflationRate, draft.RetirementYears);
+        WithdrawalRateWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("#,##0", ResolveFormat(0, "B9"));  // draft.RetirementYears (int magnitude)
+
+        // The single most counterintuitive cell in the exporters: WithdrawalProjection.Year is declared
+        // "double", not int (it is a 1-based retirement-year offset, not a calendar year), so it must
+        // stay on the decimal format. Do not "fix" this to an integer format.
+        Assert.Equal("0.0", ResolveFormat(2, "A2"));
+        Assert.Equal("0.0", ResolveFormat(1, "B7"));    // PortfolioLongevity (double)
+    }
+
+    [Fact]
+    public void DeferredCompensation_AgesPlain_YearCountsGrouped_ProjectionAgeIsInt()
+    {
+        var draft = DeferredCompensationDraft.Default;
+        var result = DeferredCompensationCalculator.Calculate(draft.ToInputs(2026));
+        DeferredCompensationWorkbook.Create(workbookPath, draft, result, GeneratedAt);
+
+        Assert.Equal("0", ResolveFormat(0, "B5"));      // draft.CurrentAge (int)
+        Assert.Equal("0", ResolveFormat(0, "B6"));      // SemiRetirementAge (int)
+        Assert.Equal("0", ResolveFormat(0, "B7"));      // PlanThroughAge (int)
+        Assert.Equal("#,##0", ResolveFormat(1, "B11")); // result.RetirementYears (int magnitude)
+        // RetirementCashFlowPoint.Age is int (unlike ProjectionPoint.Age which is double), so plain.
+        Assert.Equal("0", ResolveFormat(2, "A2"));      // point.Age (int)
+        Assert.Equal("0", ResolveFormat(2, "B2"));      // point.Year (int)
+    }
+
+    /// <summary>
+    /// Resolves the number format code applied to a cell by walking
+    /// StyleIndex -> CellFormats -> NumberFormatId -> NumberingFormats. A missing StyleIndex means the
+    /// General format, which we surface as an empty string so an unstyled cell fails an integer assertion.
+    /// </summary>
+    private string ResolveFormat(int sheetIndex, string cellReference)
+    {
+        using var document = SpreadsheetDocument.Open(workbookPath, false);
+        var workbookPart = document.WorkbookPart ?? throw new InvalidOperationException("Workbook part was not created.");
+        var cell = GetCell(workbookPart, sheetIndex, cellReference);
+
+        if (cell.StyleIndex?.Value is not uint styleIndex)
+        {
+            return string.Empty;
+        }
+
+        var stylesheet = (workbookPart.WorkbookStylesPart ?? throw new InvalidOperationException("Styles part was not created.")).Stylesheet
+            ?? throw new InvalidOperationException("Stylesheet was not created.");
+        var cellFormat = (CellFormat)(stylesheet.CellFormats ?? throw new InvalidOperationException("Cell formats were not created."))
+            .ElementAt((int)styleIndex);
+        var numberFormatId = cellFormat.NumberFormatId?.Value ?? 0U;
+        var numberingFormat = (stylesheet.NumberingFormats?.Elements<NumberingFormat>() ?? [])
+            .FirstOrDefault(format => format.NumberFormatId?.Value == numberFormatId);
+        return numberingFormat?.FormatCode?.Value ?? string.Empty;
+    }
+
+    private string ReadCellValue(int sheetIndex, string cellReference)
+    {
+        using var document = SpreadsheetDocument.Open(workbookPath, false);
+        var workbookPart = document.WorkbookPart ?? throw new InvalidOperationException("Workbook part was not created.");
+        var value = GetCell(workbookPart, sheetIndex, cellReference).CellValue?.Text ?? string.Empty;
+        // Normalize so a stored "2026" and "2026.0" compare on numeric intent, not text formatting.
+        return double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed.ToString("0.##", CultureInfo.InvariantCulture)
+            : value;
+    }
+
+    private static Cell GetCell(WorkbookPart workbookPart, int sheetIndex, string cellReference)
+    {
+        var sheet = (workbookPart.Workbook?.Sheets ?? throw new InvalidOperationException("Workbook sheets were not created."))
+            .Elements<Sheet>()
+            .ElementAt(sheetIndex);
+        var relationshipId = sheet.Id?.Value ?? throw new InvalidOperationException("Worksheet relationship ID was not created.");
+        var worksheetPart = (WorksheetPart)workbookPart.GetPartById(relationshipId);
+        var worksheet = worksheetPart.Worksheet ?? throw new InvalidOperationException("Worksheet was not created.");
+        return (Cell)Assert.Single(worksheet.Descendants<Cell>(), cell => cell.CellReference?.Value == cellReference);
+    }
+
+    public void Dispose()
+    {
+        if (File.Exists(workbookPath))
+        {
+            File.Delete(workbookPath);
+        }
+    }
+}

--- a/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
+++ b/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
@@ -25,9 +25,7 @@
 
   <ItemGroup>
     <!-- Same file the web Vitest suite reads, so both platforms are pinned to one set of numbers. -->
-    <None Include="..\..\shared\parity\fire-parity-cases.json"
-          Link="SharedParity\fire-parity-cases.json"
-          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\shared\parity\fire-parity-cases.json" Link="SharedParity\fire-parity-cases.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -73,6 +73,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2779,6 +2780,7 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -2911,6 +2913,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3124,6 +3127,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3504,6 +3508,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6258,6 +6263,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6267,6 +6273,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6286,6 +6293,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6421,7 +6429,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6623,6 +6632,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
       "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7723,6 +7733,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -8217,6 +8228,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/web/src/utils/__tests__/excelExport.test.ts
+++ b/web/src/utils/__tests__/excelExport.test.ts
@@ -547,7 +547,6 @@ describe('declared formats', () => {
     ['yearsToFIRE', 'years'],
     ['yearsToCoast', 'years'],
     ['portfolioLongevity', 'years'],
-    ['gapYears', 'years'],
     // An age, but the calculators round it to one decimal, so the integer 'age' format would show
     // 51.5 as 52 — a silent change to the number rather than to its styling.
     ['fireAge', 'years'],
@@ -571,6 +570,10 @@ describe('declared formats', () => {
     ['incomeSourceCount', 'number'],
     ['accountCount', 'number'],
     ['retirementYears', 'number'],
+    // gapYears looks like fireAge/portfolioLongevity above but is provably integral
+    // (max(0, 65 - earlyRetirementAge), an int minus a parseInt/step=1 age), so it renders as a
+    // whole count with no trailing '.0'. This matches MAUI (#69); keep it out of the decimal bucket.
+    ['gapYears', 'number'],
   ] as const)('%s renders as a whole count', (key, expected) => {
     expect(format(key, 25)).toBe(expected)
   })

--- a/web/src/utils/excelExport.ts
+++ b/web/src/utils/excelExport.ts
@@ -433,11 +433,15 @@ const EXPORT_FIELD_FORMATS: Record<string, ExportFormat> = {
   // integer 'age' format would silently show 51.5 as 52.
   fireAge: 'years',
   portfolioLongevity: 'years',
-  gapYears: 'years',
 
   // --- Whole counts -----------------------------------------------------------------------------
   // Integers, so '#,##0' rather than the '0.0' of the duration formats above. `totalMonths` is the
   // #62 defect: it used to render as '$25' for a 25-month payoff.
+  // gapYears looks like it belongs in the fractional bucket above with fireAge/portfolioLongevity,
+  // but it is provably integral: gapYears = max(0, MEDICARE_AGE - earlyRetirementAge), the constant
+  // 65 minus an age parsed with parseInt/step=1, so it can never be fractional. It gets '#,##0' so
+  // web matches MAUI (#69), which renders it as 20, not 20.0. Do not move it back up.
+  gapYears: 'number',
   totalMonths: 'number',
   targetMonths: 'number',
   retirementYears: 'number',


### PR DESCRIPTION
Fixes #69.

## Root cause

The nine MAUI workbook exporters in `app/MyFireNumber.Core/Exports/` each declared an identical stylesheet with only three custom number formats — `$#,##0` (currency), `0.0%` (percent), and `0.0` (decimal). **There was no integer format at all.** `DecimalStyleIndex` (`0.0`) was therefore the only non-currency/non-percent numeric option, so every whole-number field rendered with a trailing `.0`: a calendar year exported as `2026.0`, an age as `45.0`, a 25-month payoff as `25.0`. Web was already fixed (#68); MAUI still diverged.

## The rule

An `int`-typed value written with `DecimalStyleIndex` is a defect; a `double` written with it is correct. The fix adds integer formats and re-points every `int`-sourced cell.

**Two integer formats, not one.** `#,##0` inserts a thousands separator, which would turn a calendar year `2026` into `2,026` — trading one wrong rendering for another on the headline field. So:
- `PlainIntegerStyleIndex` → `"0"` — identifiers, ages, and calendar years, where a separator is meaningless or wrong (every `Year`, all ages).
- `IntegerStyleIndex` → `"#,##0"` — genuine magnitudes where grouping helps a reader (`TotalMonths`, `TargetMonths`, `Month`, `YearsInvesting`, `RetirementYears`, `FundedYears`, `YearsFullyCovered`, `PayoutYears`).

## Fields that moved, and fields that deliberately did not

Genuinely fractional `double` fields stay on `DecimalStyleIndex` (`0.0`) and were **not** touched: `YearsToFire`, `FireAge`, `YearsToCoast`, `YearsToBaristaFire`, `PortfolioLongevity`, `WithdrawalRateAnalysis.Years`, `ProjectionPoint.Age`, `InvestmentProjectionPoint.Age`, `RetirementGoalAssessment.TargetRetirementAge`, and — the most counterintuitive cell in the codebase — `WithdrawalProjection.Year`, which is a `double` 1-based retirement-year offset, not a calendar year. There is an explicit test asserting it stays `0.0`.

### Corrections to the issue's field list (the declared types were the source of truth)

- `RetirementGoalAssessment.TargetRetirementAge` is `double`, not `int` — stays decimal.
- `ProjectionPoint.Age` / `InvestmentProjectionPoint.Age` are `double` — stay decimal. The `int` `Age` fields are `HealthcareYear.Age` and `RetirementCashFlowPoint.Age`.
- `WithdrawalProjection.Year` is `double` despite the name — stays decimal.
- The Deferred **exporter** was in scope (only `DeferredCompensationCalculator.cs` was off-limits); `RetirementCashFlowPoint.Age`/`Year` are `int` there, unlike `ProjectionPoint`.

## Shared-helper decision

Only the **stylesheet and its style-index constants** were byte-identical across all nine files — that duplication is what let the defect drift in unnoticed. Those are extracted into one `WorkbookStyles` helper (`Apply()`, the five style-index constants, and the format definitions). The per-cell helpers vary per exporter (compact vs. expanded, formula vs. none), so they were left in place; extracting them would be a larger, riskier diff for little gain.

## Why this can't regress: the type system, not the test suite

The number-cell factory now has an `int` overload taking an `IntegerFormat` enum that has **no decimal member**, so an integer cell simply cannot name a fractional format through that path.

That alone is not airtight: `CreateNumberCell(ref, someInt, DecimalStyleIndex)` would still compile by implicitly widening `int` → `double` and binding the `(double, uint)` overload — silently reintroducing #69. To close that hole, each exporter also carries a poison overload:

```csharp
[Obsolete("An int cell must use IntegerFormat, never a raw style index (issue #69).", error: true)]
private static Cell CreateNumberCell(string reference, int value, uint styleIndex) => throw ...;
```

Its only purpose is to be un-callable: any `(string, int, uint)` call site is now a **hard compile error (CS0619)**. This is the guarantee — the assertions in `WorkbookNumberFormatTests` are a second line of defense, not the only one. (Adding the poison overload immediately surfaced four literal-`0` currency cells that were relying on int→double widening; they are now written as `0d`.)

The earlier guard was a hand-enumerated list checked by hand-enumerated assertions, which share a blind spot — an omission in the list is invisible to assertions derived from it. That is exactly how five `int` draft ages (`Barista`/`Coast`/`Standard` `CurrentAge`/`RetirementAge`, which flowed through a type-erasing `(string, double, uint)` tuple) were missed on the first pass. The tuples are refactored to carry `Cell` values built where the source type is visible, and `IntegerCellFactoryGuardTests` now reflects over every exporter and fails if the poison or `IntegerFormat` overload is removed.

## Web parity (one file under `web/`)

This PR fixes the same field on the web side to avoid introducing a fresh divergence: `web/src/utils/excelExport.ts` mapped `gapYears` to `'years'` (`0.0`), so web exported a 20-year coverage gap as `20.0` while the MAUI fix renders `20`. `gapYears` is provably integral (`max(0, 65 - earlyRetirementAge)`, a constant minus a `parseInt`/`step=1` age), so it now maps to `'number'` (`#,##0`), with a test and a comment explaining why it is not in the fractional `fireAge`/`portfolioLongevity` bucket.

## Validation

- Core builds; `dotnet test` green — **200 passing**.
- Web `excelExport` suite green — **108 passing**.
- Rebased onto current `main` (`c71a968`).
