### PR TITLE
Fix #75: round the reverse FIRE number on web and MAUI

### DIFF
--- a/app/MyFireNumber.Core/Calculations/FinancialCalculator.cs
+++ b/app/MyFireNumber.Core/Calculations/FinancialCalculator.cs
@@ -382,7 +382,7 @@ public static class FinancialCalculator
         var safeAnnualSavings = Math.Max(0, requiredAnnualSavings);
 
         return new ReverseFireResult(
-            fireNumber,
+            Round(fireNumber),
             yearsToFire,
             safeAnnualSavings,
             safeAnnualSavings / 12,

--- a/app/MyFireNumber.Tests/Calculations/FinancialCalculatorTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/FinancialCalculatorTests.cs
@@ -384,6 +384,38 @@ public class FinancialCalculatorTests
     }
 
     [Fact]
+    public void ReverseFire_RoundsFireNumberLikeEveryOtherCalculator()
+    {
+        // Issue #75: this was the one calculator returning the raw quotient. The default 48,000/0.04
+        // is exactly 1,200,000 in IEEE 754, so the assertions above cannot see the difference — the
+        // 3.5% rate is what makes it observable: 70,000/0.035 is 1999999.9999999998, not 2,000,000.
+        var inputs = DefaultInputs with { WithdrawalRate = 0.035, AnnualExpenses = 70_000 };
+
+        Assert.NotEqual(2_000_000, inputs.AnnualExpenses / inputs.WithdrawalRate);
+
+        var result = FinancialCalculator.CalculateReverseFire(inputs);
+
+        Assert.Equal(2_000_000, result.FireNumber);
+        // And it must be the same target the forward calculator reports for the same inputs.
+        Assert.Equal(FinancialCalculator.CalculateStandardFire(inputs).FireNumber, result.FireNumber);
+    }
+
+    [Fact]
+    public void ReverseFire_RoundsHalvesAwayFromZeroLikeJavaScript()
+    {
+        // Round(double) is MidpointRounding.AwayFromZero, not C#'s banker's default, so that the
+        // MAUI figure matches JS Math.round on web. 1.25/0.5 is exactly 2.5, a true midpoint:
+        // banker's rounding returns 2 where Math.round(2.5) is 3. Shipping the default is the #63
+        // class of divergence. fireNumber = expenses/rate is never negative, which is the only
+        // place AwayFromZero and Math.round disagree, so this pairing is safe here.
+        var midpoint = DefaultInputs with { WithdrawalRate = 0.5, AnnualExpenses = 1.25 };
+
+        Assert.Equal(2.5, midpoint.AnnualExpenses / midpoint.WithdrawalRate);
+        Assert.Equal(3, FinancialCalculator.CalculateReverseFire(midpoint).FireNumber);
+        Assert.Equal(2d, Math.Round(2.5, MidpointRounding.ToEven));
+    }
+
+    [Fact]
     public void InvestmentGrowth_MatchesWebAnnualContributionModel()
     {
         var result = FinancialCalculator.CalculateInvestmentGrowth(new InvestmentGrowthInputs(

--- a/app/MyFireNumber.Tests/Calculations/SharedParityFixtureTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/SharedParityFixtureTests.cs
@@ -173,6 +173,12 @@ public class SharedParityFixtureTests
 
         var result = FinancialCalculator.CalculateReverseFire(ToFireInputs(parityCase.Inputs));
 
+        // ExactTolerance is 0.0 deliberately. A currency tolerance would also hide the raw-vs-rounded
+        // gap this pins (issue #75): on the non-default cases 70000/0.035 is 1999999.9999999998, so
+        // anything looser than exact equality passes with the rounding removed.
+        Assert.Equal(Number(expected, "fireNumber"), result.FireNumber, ExactTolerance);
+        // Reverse must solve for the same target the forward calculators report, not its own.
+        Assert.Equal(Number(parityCase.Expected, "fireNumber"), result.FireNumber, ExactTolerance);
         Assert.Equal(Number(expected, "requiredAnnualSavings"), result.RequiredAnnualSavings, CurrencyTolerance);
         Assert.Equal(Number(expected, "requiredMonthlySavings"), result.RequiredMonthlySavings, CurrencyTolerance);
         Assert.Equal(Number(expected, "currentWillGrowTo"), result.CurrentWillGrowTo, ExactTolerance);

--- a/shared/parity/fire-parity-cases.json
+++ b/shared/parity/fire-parity-cases.json
@@ -60,6 +60,7 @@
           }
         ],
         "reverse": {
+          "fireNumber": 1200000,
           "requiredAnnualSavings": 22946.80026660227,
           "requiredMonthlySavings": 1912.2333555501891,
           "currentWillGrowTo": 259217,
@@ -127,6 +128,7 @@
           }
         ],
         "reverse": {
+          "fireNumber": 1200000,
           "requiredAnnualSavings": 31143.402693590488,
           "requiredMonthlySavings": 2595.2835577992073,
           "currentWillGrowTo": 259217,
@@ -194,6 +196,7 @@
           }
         ],
         "reverse": {
+          "fireNumber": 2000000,
           "requiredAnnualSavings": 63449.60980843576,
           "requiredMonthlySavings": 5287.467484036313,
           "currentWillGrowTo": 457526,
@@ -261,6 +264,7 @@
           }
         ],
         "reverse": {
+          "fireNumber": 2000000,
           "requiredAnnualSavings": 77841.18595800038,
           "requiredMonthlySavings": 6486.765496500032,
           "currentWillGrowTo": 457526,
@@ -328,6 +332,7 @@
           }
         ],
         "reverse": {
+          "fireNumber": 1250000,
           "requiredAnnualSavings": 40000.0,
           "requiredMonthlySavings": 3333.3333333333335,
           "currentWillGrowTo": 50000,
@@ -387,6 +392,7 @@
           }
         ],
         "reverse": {
+          "fireNumber": 1250000,
           "requiredAnnualSavings": 59420.4203852185,
           "requiredMonthlySavings": 4951.701698768208,
           "currentWillGrowTo": 41911,
@@ -438,6 +444,7 @@
           }
         ],
         "reverse": {
+          "fireNumber": 1200000,
           "requiredAnnualSavings": 0.0,
           "requiredMonthlySavings": 0.0,
           "currentWillGrowTo": 2927491,

--- a/web/src/utils/__tests__/excelFormulaEquivalence.test.ts
+++ b/web/src/utils/__tests__/excelFormulaEquivalence.test.ts
@@ -600,10 +600,14 @@ const SCENARIOS: Array<{ id: string; why: string; params: CalculatorParams }> = 
 type Agreement = 'exact' | 'whole'
 
 /**
- * Keyed by page and field, not by field name, because the same name does not round the same way
- * everywhere: `fireNumber` is `Math.round`ed by calculateStandardFIRE and calculateCoastFIRE but
- * returned raw by calculateReverseFIRE. Keying on the name alone quietly mis-declared it, and this
- * suite's own self-check is what caught that on its first run.
+ * Keyed by page and field, not by field name, because nothing guarantees that the same name rounds
+ * the same way on every page. That used to be demonstrable rather than hypothetical: `fireNumber`
+ * was `Math.round`ed by calculateStandardFIRE and calculateCoastFIRE but returned raw by
+ * calculateReverseFIRE, keying on the name alone quietly mis-declared it, and this suite's own
+ * self-check is what caught that on its first run. Issue #75 then fixed the calculator rather than
+ * the declaration, so every `fireNumber` below now agrees on 'whole' and the example is historical.
+ * The per-page keying stays: it is what made the divergence expressible instead of averaging it
+ * away, and it is what a future one-page-rounds-differently change would need again.
  */
 const AGREEMENT: Record<string, Agreement> = {
   // Rounded by calculations.ts at the line noted, so the unrounded formula is compared through the
@@ -613,6 +617,7 @@ const AGREEMENT: Record<string, Agreement> = {
   'CoastFIRE.tsx::fireNumber': 'whole', //            :550
   'FatFIRE.tsx::fireNumber': 'whole', //              :433 via calculateStandardFIRE
   'LeanFIRE.tsx::fireNumber': 'whole', //             :433 via calculateStandardFIRE
+  'ReverseFIRE.tsx::fireNumber': 'whole', //          :1047
   'StandardFIRE.tsx::fireNumber': 'whole', //         :433
   'WithdrawalRate.tsx::annualWithdrawal': 'whole', // :767
   'WithdrawalRate.tsx::monthlyWithdrawal': 'whole', //:768
@@ -621,7 +626,6 @@ const AGREEMENT: Record<string, Agreement> = {
   'HealthcareGap.tsx::annualCost': 'exact', //        :1191
   'HealthcareGap.tsx::gapYears': 'exact', //          :1190
   'LeanFIRE.tsx::savingsRate': 'exact', //            :437
-  'ReverseFIRE.tsx::fireNumber': 'exact', //          :1047 — raw, unlike every other page
   'SavingsRate.tsx::savingsRate': 'exact', //         :1109
   'StandardFIRE.tsx::monthlyContribution': 'exact', //:438
   'StandardFIRE.tsx::savingsRate': 'exact', //        :437

--- a/web/src/utils/__tests__/fixtureSelfCheck.test.ts
+++ b/web/src/utils/__tests__/fixtureSelfCheck.test.ts
@@ -61,6 +61,19 @@ describe('fire cases match closed-form algebra', () => {
   )
 
   it.each(fireCases.map((c) => [c.id, c] as const))(
+    '%s reverse fireNumber is the same rounded target the forward calculators use',
+    (_id, testCase) => {
+      // Derived from the inputs here, not copied from expected.fireNumber, so this stays an
+      // independent check. Rounding is part of the expectation: the reverse page reports a display
+      // dollar figure, and issue #75 was it alone shipping the raw quotient. On the non-default
+      // cases 70000/0.035 is 1999999.9999999998, so `toBe` separates the two.
+      const { annualExpenses, withdrawalRate } = testCase.inputs
+      expect(testCase.expected.reverse.fireNumber).toBe(Math.round(annualExpenses / withdrawalRate))
+      expect(testCase.expected.reverse.fireNumber).toBe(testCase.expected.fireNumber)
+    },
+  )
+
+  it.each(fireCases.map((c) => [c.id, c] as const))(
     '%s yearsToFire matches n = ln((C + T*rho)/(C + PV*rho)) / ln(1+rho)',
     (_id, testCase) => {
       const { currentSavings, annualContribution, expectedReturn, inflationRate, contributionGrowth } =

--- a/web/src/utils/__tests__/parity.test.ts
+++ b/web/src/utils/__tests__/parity.test.ts
@@ -69,6 +69,12 @@ describe('standard FIRE parity', () => {
       i.contributionGrowth,
     )
     const expected = testCase.expected.reverse
+    // Rounded for display, so pinned exactly rather than with a tolerance: a tolerance wide enough
+    // for float noise would also swallow the raw-vs-rounded gap this pins (issue #75), which on the
+    // non-default cases is only 70000/0.035 = 1999999.9999999998 against 2000000.
+    expect(result.fireNumber).toBe(expected.fireNumber)
+    // Reverse must solve for the same target the forward calculators report, not its own.
+    expect(result.fireNumber).toBe(testCase.expected.fireNumber)
     expect(result.requiredAnnualSavings).toBeCloseTo(expected.requiredAnnualSavings, 6)
     expect(result.requiredMonthlySavings).toBeCloseTo(expected.requiredMonthlySavings, 6)
     expect(result.currentWillGrowTo).toBe(expected.currentWillGrowTo)

--- a/web/src/utils/__tests__/parityFixtures.ts
+++ b/web/src/utils/__tests__/parityFixtures.ts
@@ -84,6 +84,7 @@ export interface FireCase {
     projectionCount: number
     projectionSamples: ProjectionSample[]
     reverse: {
+      fireNumber: number
       requiredAnnualSavings: number
       requiredMonthlySavings: number
       currentWillGrowTo: number

--- a/web/src/utils/__tests__/reverseFire.test.ts
+++ b/web/src/utils/__tests__/reverseFire.test.ts
@@ -52,6 +52,47 @@ describe('calculateReverseFIRE', () => {
     expect(reverse().fireNumber).toBe(1_200_000)
   })
 
+  it('reports the FIRE number rounded to whole dollars, like every other calculator', () => {
+    // Issue #75: this was the one page returning the raw quotient. The default 48,000/0.04 is
+    // exactly 1,200,000 in IEEE 754, so the assertion above cannot see the difference. A 3.5% rate
+    // makes it observable, and 61,234/0.035 = 1,749,542.857... is not even close to an integer.
+    expect(48_000 / 0.04).toBe(1_200_000)
+    expect(70_000 / 0.035).not.toBe(2_000_000)
+
+    expect(reverse({ annualExpenses: 70_000, withdrawalRate: 0.035 }).fireNumber).toBe(2_000_000)
+    expect(reverse({ annualExpenses: 61_234, withdrawalRate: 0.035 }).fireNumber).toBe(1_749_543)
+  })
+
+  it('agrees with calculateStandardFIRE on the target for the same inputs', () => {
+    // The two solvers must aim at the same number; #75 was them disagreeing by a fraction.
+    for (const [annualExpenses, withdrawalRate] of [
+      [48_000, 0.04],
+      [70_000, 0.035],
+      [61_234, 0.035],
+    ] as const) {
+      const forward = calculateStandardFIRE({
+        currentAge: 30,
+        retirementAge: 55,
+        currentSavings: 100_000,
+        annualContribution: 24_000,
+        annualIncome: 72_000,
+        expectedReturn: 0.07,
+        inflationRate: 0.03,
+        withdrawalRate,
+        annualExpenses,
+        contributionGrowth: 'inflation',
+      })
+      expect(reverse({ annualExpenses, withdrawalRate }).fireNumber).toBe(forward.fireNumber)
+    }
+  })
+
+  it('rounds halves up, matching the away-from-zero rule the fixtures document', () => {
+    // 1.25/0.5 is exactly 2.5. Math.round gives 3; C#'s default banker's rounding would give 2,
+    // and MAUI uses MidpointRounding.AwayFromZero so the two platforms agree (issue #63).
+    expect(1.25 / 0.5).toBe(2.5)
+    expect(reverse({ annualExpenses: 1.25, withdrawalRate: 0.5 }).fireNumber).toBe(3)
+  })
+
   it('lands exactly on the target in today\u2019s dollars', () => {
     // The defining property: saving the reported amount for the reported horizon reaches the FIRE
     // number precisely. Checked against an independently written closed form, not the projections.

--- a/web/src/utils/calculations.ts
+++ b/web/src/utils/calculations.ts
@@ -1044,7 +1044,7 @@ export function calculateReverseFIRE(
   const safeAnnualSavings = Math.max(0, requiredAnnualSavings)
 
   return {
-    fireNumber,
+    fireNumber: Math.round(fireNumber),
     yearsToFIRE,
     requiredAnnualSavings: safeAnnualSavings,
     requiredMonthlySavings: safeAnnualSavings / 12,


### PR DESCRIPTION
Fixes #75.

`calculateReverseFIRE` returned `annualExpenses / withdrawalRate` raw while every other calculator rounds it. **The issue as filed says web only — that is incomplete. The defect is cross-platform**, and I have updated the issue body to say so.

| | Location | Before |
|---|---|---|
| Web | `web/src/utils/calculations.ts:1047` | `fireNumber,` |
| MAUI | `app/MyFireNumber.Core/Calculations/FinancialCalculator.cs:385` | `fireNumber,` — in a return statement that already calls `Round(futureValueOfCurrent)` six lines below |

## The fix follows the existing convention

Round at the **return boundary only**, leaving the internal math unrounded — exactly what `calculateStandardFIRE` (`:386` compute, `:433` round) and `calculateCoastFIRE` (`:498` / `:550`) do.

`requiredAnnualSavings`, `requiredMonthlySavings`, `projections` and `alreadyAchievable` are deliberately **unchanged**: they already derive from the unrounded local, which is correct and matches Standard/Coast. No downstream value moved.

### Why `MidpointRounding.AwayFromZero` on MAUI

The MAUI side uses the existing private `Round(double)` helper (`FinancialCalculator.cs:605`), which is `Math.Round(value, MidpointRounding.AwayFromZero)`. Putting the reasoning on the record, because this repo has already shipped a JS/C# midpoint divergence (#63):

- C#'s **default is banker's rounding**, which diverges from JS on *positive* midpoints: `2.5` → `2` in C#, `3` in JS.
- `AwayFromZero` matches `Math.round` on positive midpoints and diverges only on negatives.
- `fireNumber = annualExpenses / withdrawalRate` is always non-negative, so the pairing is safe here.

`ReverseFire_RoundsHalvesAwayFromZeroLikeJavaScript` pins this directly, asserting both that `1.25 / 0.5` is exactly `2.5` and that the calculator returns `3`, alongside `Math.Round(2.5, MidpointRounding.ToEven) == 2` so the contrast is explicit.

## The paired test-table edit

PR #74's `excelFormulaEquivalence.test.ts` self-checks its `AGREEMENT` table, so the fix forces the `ReverseFIRE.tsx::fireNumber` entry from `'exact'` to `'whole'`. Two pieces of prose became false and were fixed rather than left stranded:

- The trailing `— raw, unlike every other page` comment, which was the whole point of the issue.
- The doc comment at `:602`, which used ReverseFIRE as its **worked example** of why the table is keyed by `page::field` rather than by field name. **I checked whether another genuinely-divergent field could be cited instead, and there is none** — after this fix `fireNumber` is `'whole'` on all six pages that export it and `savingsRate` is `'exact'` on all four, so no field name disagrees across pages any more. The comment therefore records ReverseFIRE as the historical case with a pointer to #75, and keeps the keying rationale live for the next time one page rounds where another does not.

## Parity fixture: gap closed

`shared/parity/fire-parity-cases.json` pinned `requiredAnnualSavings`, `requiredMonthlySavings`, `currentWillGrowTo` and `alreadyAchievable` under `expected.reverse` — but **not `fireNumber`**, the one field at the centre of this issue. That is why the two platforms were free to diverge here.

`reverse.fireNumber` is now pinned on all seven fire cases and consumed by both harnesses. I checked the constraints before doing it:

- **No `PayloadVersion` bump.** `PayloadVersion` is draft-persistence versioning (`CalculatorViewModelBase.cs`); it has nothing to do with the parity fixture.
- **Adding a field to an existing `kind` needs no new wiring** per `shared/parity/README.md` — only a new *kind* does.
- **Both harnesses are strict**, verified by sabotage rather than assumed (below). Neither silently ignores the key.
- It is **not vacuous**: `70000 / 0.035` is `1999999.9999999998`, not `2000000`, so the two non-default cases separate rounded from raw. Compared at `ExactTolerance = 0.0` on .NET and `toBe` on web — a currency tolerance would have swallowed the 2.3e-7 gap and made the guard useless.

The fixture value is also independently re-derived in `fixtureSelfCheck.test.ts` from the inputs (not copied from `expected.fireNumber`), plus asserted equal to the top-level `expected.fireNumber` on both platforms — reverse must solve for the same target the forward calculator reports.

## Anti-vacuity: every guard broken and shown to fail

No guard here is asserted to work; each was broken, the failure captured, and the change reverted.

**1. Revert the MAUI rounding** (`Round(fireNumber)` → `fireNumber`) — 4 named failures:

```
[FAIL] SharedParityFixtureTests.ReverseFire_MatchesSharedFixture(caseId: "fire-non-default-inflation")
   Assert.Equal() Failure: Values are not within tolerance 0
   Expected: 2000000
   Actual:   1999999.9999999998
[FAIL] SharedParityFixtureTests.ReverseFire_MatchesSharedFixture(caseId: "fire-non-default-flat")
   Assert.Equal() Failure: Values are not within tolerance 0
   Expected: 2000000
   Actual:   1999999.9999999998
[FAIL] FinancialCalculatorTests.ReverseFire_RoundsFireNumberLikeEveryOtherCalculator
   Assert.Equal() Failure: Values differ
   Expected: 2000000
   Actual:   1999999.9999999998
[FAIL] FinancialCalculatorTests.ReverseFire_RoundsHalvesAwayFromZeroLikeJavaScript
   Assert.Equal() Failure: Values differ
   Expected: 3
   Actual:   2.5
Failed!  - Failed: 4, Passed: 198, Skipped: 0, Total: 202
```

**2. Revert the web rounding** (`calculations.ts:1047`) — 6 failures across 3 files:

```
× fire-non-default-inflation reverse FIRE
× fire-non-default-flat reverse FIRE
× reports the FIRE number rounded to whole dollars, like every other calculator
× agrees with calculateStandardFIRE on the target for the same inputs
× rounds halves up, matching the away-from-zero rule the fixtures document
× ReverseFIRE.tsx fireNumber @ alternate-rates

AssertionError: fireNumber is declared 'whole' — mirroring a Math.round in calculations.ts —
but the app returned the non-integer 1749542.857142857 for it in the alternate-rates scenario.
Either the rounding is gone and this should be 'exact', or the field changed shape.
AssertionError: expected 1999999.9999999998 to be 2000000
AssertionError: expected 2.5 to be 3

Test Files  3 failed | 11 passed (14)
     Tests  6 failed | 808 passed (814)
```

**3. Delete `reverse.fireNumber` from one fixture case** — confirms both harnesses consume it strictly, so a new key cannot be silently ignored on either side:

```
web:  × fire-non-default-inflation reverse fireNumber is the same rounded target the forward calculators use
      × fire-non-default-inflation reverse FIRE
      AssertionError: expected undefined to be 2000000
      AssertionError: expected 2000000 to be undefined

.NET: [FAIL] SharedParityFixtureTests.ReverseFire_MatchesSharedFixture(caseId: "fire-non-default-inflation")
      System.Collections.Generic.KeyNotFoundException : The given key was not present in the dictionary.
        at System.Text.Json.JsonElement.GetProperty(String propertyName)
```

Note the pre-existing `ReverseFire_MatchesWebDefaultRequirement` already asserted `FireNumber == 1_200_000`, but `48000 / 0.04` is exactly `1200000.0` in IEEE 754, so it passed with **and** without the fix. It was vacuous for this defect, which is why the new tests use a 3.5% rate.

## Validation

| | Before | After |
|---|---|---|
| Web (`npx vitest run`) | 804 passed / 14 files | **814 passed / 14 files** |
| .NET (`dotnet test`) | 200 passed | **202 passed** |

`npm run build` is clean, and the .NET build has no warnings. No `node_modules/`, `bin/`, `obj/`, or `package-lock.json` churn.

No overlap with the in-flight `motz-maui-period-toggle` work: this touches only `FinancialCalculator.cs:384-391` and no `ViewModels/`.