### PR TITLE
Add a monthly/annual display toggle to the MAUI calculators

### DIFF
--- a/app/MyFireNumber.Core/Presentation/CurrencyPeriod.cs
+++ b/app/MyFireNumber.Core/Presentation/CurrencyPeriod.cs
@@ -1,0 +1,50 @@
+namespace MyFireNumber.Core.Presentation;
+
+/// <summary>
+/// The period a currency amount is <b>displayed</b> in.
+/// </summary>
+/// <remarks>
+/// <para>This is a presentation concern only, and it lives in <c>Presentation</c> rather than
+/// <c>Calculations</c> for that reason. Every recurring amount is stored in one canonical period
+/// (annual, except the healthcare premium which is canonically monthly) and every calculation runs on
+/// that canonical value. Showing an annual amount as a monthly one divides by 12 at the display edge
+/// and nothing else: it never introduces intra-year compounding and never changes the math.</para>
+/// <para><b>Not to be confused with <see cref="Calculations.ContributionFrequency"/>.</b> That one is
+/// a semantic input frequency that genuinely changes the arithmetic — it selects between
+/// <c>amount * 12</c> and <c>amount</c> for the Savings &amp; Investment Rate calculator, and it is
+/// persisted in <see cref="Calculations.SavingsInvestmentDraft"/> because it is a calculation input.
+/// A <see cref="CurrencyPeriod"/> never reaches a draft, a workbook, or
+/// <see cref="Calculations.FinancialCalculator"/>.</para>
+/// <para>Mirrors <c>web/src/utils/currencyPeriod.ts</c>.</para>
+/// </remarks>
+public enum CurrencyPeriod
+{
+    Annual,
+    Monthly
+}
+
+public static class CurrencyPeriodExtensions
+{
+    /// <summary>
+    /// Throws unless <paramref name="period"/> is a declared member.
+    /// </summary>
+    /// <remarks>
+    /// An enum does not make an out-of-range value unrepresentable in C#: <c>(CurrencyPeriod)99</c>
+    /// compiles and carries through any <c>switch</c> that has a <c>default</c> arm. Every entry point
+    /// in this namespace therefore validates explicitly and throws, rather than quietly treating an
+    /// unknown value as <see cref="CurrencyPeriod.Annual"/> — a silent fallback would turn a caller's
+    /// bug into a plausible-looking wrong number on screen.
+    /// </remarks>
+    public static CurrencyPeriod Validated(this CurrencyPeriod period, string paramName)
+    {
+        if (!Enum.IsDefined(period))
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                period,
+                $"'{(int)period}' is not a declared {nameof(CurrencyPeriod)}.");
+        }
+
+        return period;
+    }
+}

--- a/app/MyFireNumber.Core/Presentation/CurrencyPeriodMath.cs
+++ b/app/MyFireNumber.Core/Presentation/CurrencyPeriodMath.cs
@@ -1,0 +1,126 @@
+namespace MyFireNumber.Core.Presentation;
+
+/// <summary>
+/// Conversion and formatting for the monthly/annual display period. Mirrors the behaviour of
+/// <c>web/src/utils/currencyPeriod.ts</c>.
+/// </summary>
+/// <remarks>
+/// Nothing here changes a calculation. Callers convert a canonical stored amount for display and
+/// convert an edited display amount back; the value handed to
+/// <see cref="Calculations.FinancialCalculator"/> is always the canonical one.
+/// </remarks>
+public static class CurrencyPeriodMath
+{
+    public const int MonthsPerYear = 12;
+
+    /// <summary>
+    /// Convert an amount between periods. Exact for equal periods, so it is safe to call
+    /// unconditionally.
+    /// </summary>
+    public static double Convert(double value, CurrencyPeriod from, CurrencyPeriod to)
+    {
+        from.Validated(nameof(from));
+        to.Validated(nameof(to));
+
+        if (from == to)
+        {
+            return value;
+        }
+
+        return to == CurrencyPeriod.Monthly
+            ? value / MonthsPerYear
+            : value * MonthsPerYear;
+    }
+
+    /// <summary>True when two amounts are indistinguishable once rounded to whole cents.</summary>
+    public static bool IsSameToCent(double a, double b)
+    {
+        if (!double.IsFinite(a) || !double.IsFinite(b))
+        {
+            return false;
+        }
+
+        return RoundHalfUp(a * 100) == RoundHalfUp(b * 100);
+    }
+
+    /// <summary>
+    /// Round half **up** (toward positive infinity), matching JavaScript's <c>Math.round</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>This is deliberately not <see cref="Math.Round(double)"/> and deliberately not
+    /// <see cref="MidpointRounding.AwayFromZero"/>. The web side of this feature rounds with
+    /// <c>Math.round</c>, and the three rules disagree in different places:</para>
+    /// <code>
+    /// value    JS Math.round    C# default (banker's)    C# AwayFromZero
+    ///   0.5          1                   0                     1
+    ///   2.5          3                   2                     3
+    ///   4.5          5                   4                     5
+    ///  -0.5         -0                  -0                    -1
+    ///  -1.5         -1                  -2                    -2
+    /// </code>
+    /// <para>The default disagrees on <b>positive</b> midpoints — every even boundary — which is
+    /// exactly where currency lives: half a cent on a positive amount. <c>AwayFromZero</c> matches
+    /// on positives and diverges on negatives. Pairing C# <c>AwayFromZero</c> with JS
+    /// <c>Math.round</c> is what shipped as issue #63, so this repo has already paid for getting it
+    /// wrong once.</para>
+    /// <para>Implemented by comparing the fraction rather than as <c>Math.Floor(x + 0.5)</c>: the
+    /// latter disagrees with JS at <c>0.49999999999999994</c>, where the addition itself rounds up to
+    /// exactly 1.</para>
+    /// </remarks>
+    public static double RoundHalfUp(double value)
+    {
+        var floor = Math.Floor(value);
+        return value - floor >= 0.5 ? floor + 1 : floor;
+    }
+
+    /// <summary>
+    /// Resolve what a field edit should store.
+    /// </summary>
+    /// <remarks>
+    /// The displayed figure is rounded for readability, so converting it straight back would drift:
+    /// $50,000/yr shows as $4,166.67/mo, and $4,166.67 x 12 is $50,000.04. Whenever the amount that
+    /// was typed is the same (to the cent) as the amount already on screen, the user did not actually
+    /// change anything, so the stored value is returned untouched and the round trip is exactly
+    /// lossless. A genuine edit converts normally.
+    /// </remarks>
+    public static double ResolveEditedAmount(
+        double typedDisplayAmount,
+        double storedValue,
+        CurrencyPeriod displayPeriod,
+        CurrencyPeriod storedPeriod)
+    {
+        var currentDisplayAmount = Convert(storedValue, storedPeriod, displayPeriod);
+        return IsSameToCent(typedDisplayAmount, currentDisplayAmount)
+            ? storedValue
+            : Convert(typedDisplayAmount, displayPeriod, storedPeriod);
+    }
+
+    /// <summary>
+    /// Format an amount for a currency entry. Cents are shown only when the amount has them, so
+    /// annual figures stay clean while monthly conversions keep the precision needed to edit them
+    /// accurately.
+    /// </summary>
+    /// <remarks>
+    /// <c>"0.##"</c> is the format the calculator entries already use, so the display period does not
+    /// change how any amount is written. It is also why this type has no counterpart to the web
+    /// helper <c>formatTypedAmount</c>: that exists purely to stop comma grouping from eating a
+    /// trailing <c>"."</c> mid-keystroke, and nothing here groups digits or rewrites text while the
+    /// user is typing.
+    /// </remarks>
+    public static string Format(double value, IFormatProvider formatProvider)
+    {
+        return double.IsFinite(value) ? value.ToString("0.##", formatProvider) : "0";
+    }
+
+    /// <summary>Short suffix shown inside the entry, e.g. <c>/mo</c>.</summary>
+    public static string Suffix(CurrencyPeriod period)
+    {
+        return period.Validated(nameof(period)) == CurrencyPeriod.Monthly ? "/mo" : "/yr";
+    }
+
+    /// <summary>Long qualifier appended to a field label, e.g. <c>per month</c>.</summary>
+    public static string Qualifier(CurrencyPeriod period)
+    {
+        return period.Validated(nameof(period)) == CurrencyPeriod.Monthly ? "per month" : "per year";
+    }
+}

--- a/app/MyFireNumber.Core/Presentation/PeriodicAmountField.cs
+++ b/app/MyFireNumber.Core/Presentation/PeriodicAmountField.cs
@@ -1,0 +1,119 @@
+using System.Globalization;
+
+namespace MyFireNumber.Core.Presentation;
+
+/// <summary>
+/// One recurring currency input: the canonical amount, the period it is displayed in, and the text
+/// the entry is currently showing.
+/// </summary>
+/// <remarks>
+/// <para><b>Why this type exists and the web has no counterpart.</b> On web the stored value is a
+/// number and the field text is derived from it. In this app the view models hold <i>text</i> as the
+/// source of truth and parse it to build a draft, so a display period would have nowhere lossless to
+/// live: annual 50000 shown as monthly rounds to <c>"4166.67"</c>, and parsing that back gives
+/// 50000.04. This type supplies the canonical numeric shadow the view models lack, so toggling the
+/// display never edits the value.</para>
+/// <para><b>The entry echo is the reason <see cref="CurrencyPeriodMath.ResolveEditedAmount"/> is
+/// still needed even though <see cref="Text"/> is always written from
+/// <see cref="StoredValue"/>.</b> The MAUI <c>Entry</c> binds <c>Mode=TwoWay</c>, so assigning
+/// <see cref="Text"/> fires the binding back through the setter and the rounded string is
+/// re-submitted as if the user had typed it. <see cref="TrySetText"/> recognises an amount that
+/// matches what is already on screen to the cent and keeps the stored value untouched, so the round
+/// trip is exactly lossless however many times it happens.</para>
+/// <para>Text is written only when the value is loaded or the period changes. It is never rewritten
+/// while the user types, which is why there is no counterpart to the web helper
+/// <c>formatTypedAmount</c>: typing <c>"1234."</c> leaves <c>"1234."</c> on screen.</para>
+/// </remarks>
+public sealed class PeriodicAmountField
+{
+    private readonly IFormatProvider formatProvider;
+
+    public PeriodicAmountField(
+        CurrencyPeriod storedPeriod,
+        CurrencyPeriod displayPeriod = CurrencyPeriod.Annual,
+        IFormatProvider? formatProvider = null)
+    {
+        StoredPeriod = storedPeriod.Validated(nameof(storedPeriod));
+        DisplayPeriod = displayPeriod.Validated(nameof(displayPeriod));
+        this.formatProvider = formatProvider ?? CultureInfo.CurrentCulture;
+        Text = FormatFromStoredValue();
+        HasValidText = true;
+    }
+
+    /// <summary>The period <see cref="StoredValue"/> is expressed in. Fixed for the field's life.</summary>
+    public CurrencyPeriod StoredPeriod { get; }
+
+    /// <summary>The period <see cref="Text"/> is expressed in.</summary>
+    public CurrencyPeriod DisplayPeriod { get; private set; }
+
+    /// <summary>The canonical amount, in <see cref="StoredPeriod"/>. This is what calculations use.</summary>
+    public double StoredValue { get; private set; }
+
+    /// <summary>What the entry shows. Left exactly as typed while the user is editing.</summary>
+    public string Text { get; private set; }
+
+    /// <summary>
+    /// False when <see cref="Text"/> is not a non-negative number, matching the existing
+    /// <c>TryParseNonNegative</c> rule the calculators validate with. <see cref="StoredValue"/> keeps
+    /// its last good value so a half-typed entry does not destroy it.
+    /// </summary>
+    public bool HasValidText { get; private set; }
+
+    /// <summary>Load a canonical amount, e.g. when a draft or saved plan is applied.</summary>
+    public void SetStoredValue(double value)
+    {
+        StoredValue = double.IsFinite(value) ? value : 0;
+        Text = FormatFromStoredValue();
+        HasValidText = true;
+    }
+
+    /// <summary>
+    /// Accept text from the entry — either typed by the user or echoed back by the two-way binding.
+    /// </summary>
+    /// <returns><c>true</c> when the text parsed to a non-negative amount.</returns>
+    public bool TrySetText(string? raw)
+    {
+        Text = raw ?? string.Empty;
+
+        if (!double.TryParse(Text, NumberStyles.Number, formatProvider, out var typed)
+            || !double.IsFinite(typed)
+            || typed < 0)
+        {
+            HasValidText = false;
+            return false;
+        }
+
+        HasValidText = true;
+        StoredValue = CurrencyPeriodMath.ResolveEditedAmount(typed, StoredValue, DisplayPeriod, StoredPeriod);
+        return true;
+    }
+
+    /// <summary>Switch which period the amount is shown in. The stored amount does not move.</summary>
+    /// <remarks>
+    /// <see cref="DisplayPeriod"/> is updated before the text is rewritten. The other order would
+    /// hand the new text to the binding while the field still claims the old period, so the echo
+    /// through <see cref="TrySetText"/> would read a monthly figure as an annual one and multiply the
+    /// stored value by 144.
+    /// </remarks>
+    public void SetDisplayPeriod(CurrencyPeriod period)
+    {
+        period.Validated(nameof(period));
+        if (period == DisplayPeriod)
+        {
+            return;
+        }
+
+        DisplayPeriod = period;
+        // Any half-typed text belongs to the period the user was looking at, so it is replaced rather
+        // than reinterpreted. Web does the same by clearing its draft when the period changes.
+        Text = FormatFromStoredValue();
+        HasValidText = true;
+    }
+
+    private string FormatFromStoredValue()
+    {
+        return CurrencyPeriodMath.Format(
+            CurrencyPeriodMath.Convert(StoredValue, StoredPeriod, DisplayPeriod),
+            formatProvider);
+    }
+}

--- a/app/MyFireNumber.Core/Presentation/PeriodicFieldCatalog.cs
+++ b/app/MyFireNumber.Core/Presentation/PeriodicFieldCatalog.cs
@@ -1,0 +1,103 @@
+namespace MyFireNumber.Core.Presentation;
+
+/// <summary>One recurring currency input on a calculator, and the period it is stored in.</summary>
+/// <param name="Key">
+/// Stable identifier, deliberately the same string the web calculator uses for the parameter
+/// (<c>annualContribution</c>, <c>healthcareMonthlyPremium</c>, …). Sharing the vocabulary means the
+/// cross-platform inventory in <c>shared/parity/periodic-fields.json</c> can be compared directly,
+/// with no name translation table for the two sides to drift apart in.
+/// </param>
+/// <param name="StoredPeriod">
+/// The period the canonical value is held in. Annual for everything except the healthcare premium.
+/// </param>
+public sealed record PeriodicFieldDefinition(string Key, CurrencyPeriod StoredPeriod);
+
+/// <summary>
+/// Which fields on each calculator follow the monthly/annual display toggle.
+/// </summary>
+/// <remarks>
+/// <para>Recurring amounts only. Balances and one-off amounts — current savings, portfolio value,
+/// starting amount — are not periodic, because "your portfolio, monthly" means nothing.</para>
+/// <para><c>withdrawal-rate</c> and <c>debt-payoff</c> declare an empty list rather than being
+/// omitted. Omission and "deliberately none" would otherwise be the same state, and a calculator
+/// added later would look like it had already been considered.</para>
+/// </remarks>
+public static class PeriodicFieldCatalog
+{
+    public const string AnnualContribution = "annualContribution";
+    public const string AnnualIncome = "annualIncome";
+    public const string AnnualExpenses = "annualExpenses";
+    public const string PartTimeIncome = "partTimeIncome";
+    public const string HealthcareMonthlyPremium = "healthcareMonthlyPremium";
+    public const string HealthcareAnnualDeductible = "healthcareAnnualDeductible";
+    public const string HealthcareAnnualOutOfPocket = "healthcareAnnualOutOfPocket";
+
+    private static readonly IReadOnlyList<PeriodicFieldDefinition> FireFamily =
+    [
+        new(AnnualContribution, CurrencyPeriod.Annual),
+        new(AnnualIncome, CurrencyPeriod.Annual),
+        new(AnnualExpenses, CurrencyPeriod.Annual)
+    ];
+
+    private static readonly Dictionary<string, IReadOnlyList<PeriodicFieldDefinition>> Definitions =
+        new(StringComparer.Ordinal)
+        {
+            ["standard-fire"] = FireFamily,
+            ["lean-fire"] = FireFamily,
+            ["fat-fire"] = FireFamily,
+            ["coast-fire"] =
+            [
+                new(AnnualContribution, CurrencyPeriod.Annual),
+                new(AnnualExpenses, CurrencyPeriod.Annual)
+            ],
+            ["barista-fire"] =
+            [
+                new(AnnualContribution, CurrencyPeriod.Annual),
+                new(AnnualExpenses, CurrencyPeriod.Annual),
+                new(PartTimeIncome, CurrencyPeriod.Annual)
+            ],
+            ["reverse-fire"] =
+            [
+                new(AnnualExpenses, CurrencyPeriod.Annual)
+            ],
+            ["savings-rate"] =
+            [
+                // The contribution is governed by ContributionFrequency, which changes the arithmetic,
+                // so it is not a display-period field. Only take-home income is.
+                new(AnnualIncome, CurrencyPeriod.Annual)
+            ],
+            ["healthcare-gap"] =
+            [
+                // The one canonically monthly amount in the app. A mechanism that assumed everything
+                // was annual would show $600/mo as $50/mo and be wrong by 144x after a round trip.
+                new(HealthcareMonthlyPremium, CurrencyPeriod.Monthly),
+                new(HealthcareAnnualDeductible, CurrencyPeriod.Annual),
+                new(HealthcareAnnualOutOfPocket, CurrencyPeriod.Annual)
+            ],
+            ["retirement-cash-flow"] =
+            [
+                new(AnnualExpenses, CurrencyPeriod.Annual)
+            ],
+            // Every currency input here is a portfolio balance or a rate, so there is nothing
+            // recurring to restate. Web gives this calculator no toggle either.
+            ["withdrawal-rate"] = [],
+            // The payoff model steps monthly, so the budget, extra payment, and per-debt minimum are
+            // genuinely monthly inputs rather than monthly views of an annual amount. Changing the
+            // number would change the schedule.
+            ["debt-payoff"] = []
+        };
+
+    /// <summary>Every calculator ID this catalog covers.</summary>
+    public static IReadOnlyCollection<string> CalculatorIds => Definitions.Keys;
+
+    /// <summary>The periodic fields for a calculator, possibly empty.</summary>
+    /// <exception cref="KeyNotFoundException">The calculator has no declaration at all.</exception>
+    public static IReadOnlyList<PeriodicFieldDefinition> For(string calculatorId)
+    {
+        return Definitions.TryGetValue(calculatorId, out var fields)
+            ? fields
+            : throw new KeyNotFoundException(
+                $"No periodic field declaration for calculator '{calculatorId}'. Declare its recurring "
+                + "currency fields, or declare an empty list if it has none.");
+    }
+}

--- a/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
+++ b/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <!-- Same file the web Vitest suite reads, so both platforms are pinned to one set of numbers. -->
     <None Include="..\..\shared\parity\fire-parity-cases.json" Link="SharedParity\fire-parity-cases.json" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\..\shared\parity\periodic-fields.json" Link="SharedParity\periodic-fields.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
@@ -79,6 +79,9 @@ public class CurrencyPeriodMathTests
     /// only pinned negatives would still fail a naive default via -1.5, but it would leave the
     /// likeliest real divergence untested and imply the risk is a negative-number edge case. Issue
     /// #63 shipped this bug class in this repo already.</para>
+    /// <para>The -0.5 row is written as <c>0</c> because <c>-0.0 == 0.0</c> makes the two
+    /// indistinguishable to <c>Assert.Equal</c>; the sign is pinned separately in
+    /// <see cref="RoundHalfUp_does_not_produce_negative_zero"/>.</para>
     /// </summary>
     [Theory]
     [InlineData(0.5, 1)]
@@ -96,6 +99,55 @@ public class CurrencyPeriodMathTests
     public void RoundHalfUp_matches_javascript_Math_round(double value, double expected)
     {
         Assert.Equal(expected, CurrencyPeriodMath.RoundHalfUp(value));
+    }
+
+    /// <summary>
+    /// The -0.5 row above cannot see the sign of its own result, so it is pinned separately.
+    ///
+    /// <para>JavaScript's <c>Math.round(-0.5)</c> is <c>-0</c>, not <c>0</c>. In C# — as in JS —
+    /// <c>-0.0 == 0.0</c> is <c>true</c>, so <c>Assert.Equal(0, ...)</c> passes whichever zero comes
+    /// back and proves nothing about the sign. That matters because a negative zero reaching
+    /// <see cref="CurrencyPeriodMath.Format"/> would render as the string <c>"-0"</c> in an entry.
+    /// </para>
+    /// <para>This implementation returns <b>positive</b> zero: <c>Math.Floor(-0.5)</c> is
+    /// <c>-1.0</c>, and IEEE-754 addition of exact opposites yields <c>+0.0</c> under
+    /// round-to-nearest, so the <c>-0</c> path is never taken. So it is one step *safer* than the JS
+    /// original here rather than a match, and this test pins that rather than the JS bit pattern —
+    /// picking the behaviour that cannot surface "-0" in the UI.</para>
+    /// <para>All three negative rows are defensive only. <c>RoundHalfUp</c> is reachable from the
+    /// field solely through <c>IsSameToCent</c> &lt;- <c>ResolveEditedAmount</c> &lt;-
+    /// <c>PeriodicAmountField.TrySetText</c>, which rejects <c>typed &lt; 0</c> before it converts,
+    /// so no negative amount reaches this helper from a currency entry. They are pinned because the
+    /// helper is public Core surface, not because a user can produce them.</para>
+    /// </summary>
+    [Fact]
+    public void RoundHalfUp_does_not_produce_negative_zero()
+    {
+        var result = CurrencyPeriodMath.RoundHalfUp(-0.5);
+
+        Assert.Equal(0, result);
+        Assert.False(double.IsNegative(result), "-0.5 rounded to negative zero, which formats as \"-0\".");
+        Assert.Equal("0", CurrencyPeriodMath.Format(result, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Pins the guard that makes the negative rows above unreachable in practice, so that if the
+    /// guard is ever removed this suite says so rather than the negative rows quietly becoming live.
+    /// </summary>
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("-0.5")]
+    [InlineData("-50000")]
+    public void A_negative_amount_never_reaches_the_rounding_helper(string typed)
+    {
+        var field = new PeriodicAmountField(
+            CurrencyPeriod.Annual,
+            CurrencyPeriod.Annual,
+            CultureInfo.InvariantCulture);
+        field.SetStoredValue(50_000);
+
+        Assert.False(field.TrySetText(typed));
+        Assert.Equal(50_000, field.StoredValue);
     }
 
     [Theory]

--- a/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
@@ -1,0 +1,186 @@
+using System.Globalization;
+
+using MyFireNumber.Core.Presentation;
+
+namespace MyFireNumber.Tests.Presentation;
+
+/// <summary>
+/// Pins the arithmetic behind the monthly/annual display toggle against
+/// <c>web/src/utils/currencyPeriod.ts</c>.
+///
+/// <para>The web module has no test file of its own, so these are the only tests either platform has
+/// for this behaviour. If the two implementations ever disagree, web's suite cannot say which one is
+/// right — which is a reason to be explicit here about what the expected values are derived from
+/// rather than copied from.</para>
+/// </summary>
+public class CurrencyPeriodMathTests
+{
+    [Theory]
+    [InlineData(50_000, CurrencyPeriod.Annual, CurrencyPeriod.Monthly, 50_000d / 12)]
+    [InlineData(600, CurrencyPeriod.Monthly, CurrencyPeriod.Annual, 7_200)]
+    [InlineData(1_234.56, CurrencyPeriod.Annual, CurrencyPeriod.Annual, 1_234.56)]
+    [InlineData(1_234.56, CurrencyPeriod.Monthly, CurrencyPeriod.Monthly, 1_234.56)]
+    [InlineData(0, CurrencyPeriod.Annual, CurrencyPeriod.Monthly, 0)]
+    public void Convert_scales_by_twelve_between_periods(
+        double value,
+        CurrencyPeriod from,
+        CurrencyPeriod to,
+        double expected)
+    {
+        Assert.Equal(expected, CurrencyPeriodMath.Convert(value, from, to));
+    }
+
+    [Fact]
+    public void Convert_between_equal_periods_is_bit_for_bit_identity()
+    {
+        // Called unconditionally by the display path, so "same period" must not introduce error of
+        // its own on a value that cannot be represented exactly.
+        const double awkward = 1 / 3d;
+
+        Assert.Equal(awkward, CurrencyPeriodMath.Convert(awkward, CurrencyPeriod.Annual, CurrencyPeriod.Annual));
+    }
+
+    /// <summary>
+    /// An enum does not stop an out-of-range value from existing in C#. <c>(CurrencyPeriod)99</c>
+    /// compiles, and a <c>switch</c> with a <c>default</c> arm would silently treat it as annual.
+    /// Every entry point throws instead.
+    /// </summary>
+    [Fact]
+    public void Undefined_period_values_throw_rather_than_defaulting_to_annual()
+    {
+        const CurrencyPeriod undefinedPeriod = (CurrencyPeriod)99;
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => CurrencyPeriodMath.Convert(1, undefinedPeriod, CurrencyPeriod.Annual));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => CurrencyPeriodMath.Convert(1, CurrencyPeriod.Annual, undefinedPeriod));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CurrencyPeriodMath.Suffix(undefinedPeriod));
+        Assert.Throws<ArgumentOutOfRangeException>(() => CurrencyPeriodMath.Qualifier(undefinedPeriod));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PeriodicAmountField(undefinedPeriod));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new PeriodicAmountField(CurrencyPeriod.Annual).SetDisplayPeriod(undefinedPeriod));
+    }
+
+    /// <summary>
+    /// Midpoint rounding, pinned in <b>both</b> directions.
+    ///
+    /// <para>Expected values are JavaScript's <c>Math.round</c>, because that is what the web module
+    /// rounds cents with. Neither C# default applies:</para>
+    /// <code>
+    /// value    expected (JS)    C# Math.Round    C# AwayFromZero
+    ///   0.5          1                0                1
+    ///   2.5          3                2                3
+    ///   4.5          5                4                5
+    ///  -0.5         -0               -0               -1
+    ///  -1.5         -1               -2               -2
+    /// </code>
+    /// <para>The positive rows are the ones that matter most: C#'s default disagrees at every even
+    /// boundary, and half a cent on a positive amount is exactly where currency lives. A table that
+    /// only pinned negatives would still fail a naive default via -1.5, but it would leave the
+    /// likeliest real divergence untested and imply the risk is a negative-number edge case. Issue
+    /// #63 shipped this bug class in this repo already.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(0.5, 1)]
+    [InlineData(1.5, 2)]
+    [InlineData(2.5, 3)]
+    [InlineData(3.5, 4)]
+    [InlineData(4.5, 5)]
+    [InlineData(-0.5, 0)]
+    [InlineData(-1.5, -1)]
+    [InlineData(-2.5, -2)]
+    [InlineData(0.4, 0)]
+    [InlineData(0.6, 1)]
+    [InlineData(-0.6, -1)]
+    [InlineData(0.49999999999999994, 0)]
+    public void RoundHalfUp_matches_javascript_Math_round(double value, double expected)
+    {
+        Assert.Equal(expected, CurrencyPeriodMath.RoundHalfUp(value));
+    }
+
+    [Theory]
+    [InlineData(4_166.67, 50_000d / 12, true)]
+    [InlineData(4_166.67, 4_166.67, true)]
+    [InlineData(4_166.67, 4_166.68, false)]
+    [InlineData(0, 0.004, true)]
+    [InlineData(0, 0.006, false)]
+    public void IsSameToCent_compares_whole_cents(double a, double b, bool expected)
+    {
+        Assert.Equal(expected, CurrencyPeriodMath.IsSameToCent(a, b));
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity)]
+    public void IsSameToCent_rejects_non_finite_amounts(double value)
+    {
+        Assert.False(CurrencyPeriodMath.IsSameToCent(value, value));
+        Assert.False(CurrencyPeriodMath.IsSameToCent(value, 1));
+    }
+
+    /// <summary>
+    /// Re-entering the figure already on screen stores nothing new, so the rounding done for
+    /// readability never leaks back into the value.
+    /// </summary>
+    [Fact]
+    public void ResolveEditedAmount_treats_the_displayed_figure_as_no_edit()
+    {
+        // 50000 / 12 = 4166.666..., displayed as 4166.67. Converting that back gives 50000.04.
+        var resolved = CurrencyPeriodMath.ResolveEditedAmount(
+            typedDisplayAmount: 4_166.67,
+            storedValue: 50_000,
+            displayPeriod: CurrencyPeriod.Monthly,
+            storedPeriod: CurrencyPeriod.Annual);
+
+        Assert.Equal(50_000, resolved);
+        // The drift the guard prevents: the displayed figure converted straight back is not 50000.
+        Assert.NotEqual(50_000, 4_166.67 * 12);
+        Assert.Equal(50_000.04, 4_166.67 * 12, 6);
+    }
+
+    [Fact]
+    public void ResolveEditedAmount_converts_a_genuine_edit()
+    {
+        var resolved = CurrencyPeriodMath.ResolveEditedAmount(
+            typedDisplayAmount: 5_000,
+            storedValue: 50_000,
+            displayPeriod: CurrencyPeriod.Monthly,
+            storedPeriod: CurrencyPeriod.Annual);
+
+        Assert.Equal(60_000, resolved);
+    }
+
+    [Fact]
+    public void ResolveEditedAmount_converts_a_genuine_edit_on_a_monthly_stored_field()
+    {
+        // Healthcare premium: stored monthly, edited while displayed annually.
+        var resolved = CurrencyPeriodMath.ResolveEditedAmount(
+            typedDisplayAmount: 9_600,
+            storedValue: 600,
+            displayPeriod: CurrencyPeriod.Annual,
+            storedPeriod: CurrencyPeriod.Monthly);
+
+        Assert.Equal(800, resolved);
+    }
+
+    [Theory]
+    [InlineData(50_000, "50000")]
+    [InlineData(50_000d / 12, "4166.67")]
+    [InlineData(0, "0")]
+    [InlineData(1_234.5, "1234.5")]
+    [InlineData(double.NaN, "0")]
+    public void Format_shows_cents_only_when_there_are_cents(double value, string expected)
+    {
+        Assert.Equal(expected, CurrencyPeriodMath.Format(value, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Suffix_and_qualifier_name_the_period()
+    {
+        Assert.Equal("/yr", CurrencyPeriodMath.Suffix(CurrencyPeriod.Annual));
+        Assert.Equal("/mo", CurrencyPeriodMath.Suffix(CurrencyPeriod.Monthly));
+        Assert.Equal("per year", CurrencyPeriodMath.Qualifier(CurrencyPeriod.Annual));
+        Assert.Equal("per month", CurrencyPeriodMath.Qualifier(CurrencyPeriod.Monthly));
+    }
+}

--- a/app/MyFireNumber.Tests/Presentation/PeriodicAmountFieldTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/PeriodicAmountFieldTests.cs
@@ -1,0 +1,285 @@
+using System.Globalization;
+
+using MyFireNumber.Core.Presentation;
+
+namespace MyFireNumber.Tests.Presentation;
+
+/// <summary>
+/// Pins the lossless round trip behind the monthly/annual display toggle.
+///
+/// <para><b>Read <see cref="ToggleWithBindingEcho"/> before anything else in this file.</b> Because
+/// <see cref="PeriodicAmountField.Text"/> is always written from the canonical value, simply calling
+/// <see cref="PeriodicAmountField.SetDisplayPeriod"/> in a loop cannot drift — such a test passes
+/// with <c>ResolveEditedAmount</c> deleted, and would be a guard whose blind spot is exactly the
+/// thing it claims to check.</para>
+///
+/// <para>The drift is real only because the MAUI <c>Entry</c> binds <c>Mode=TwoWay</c>: assigning
+/// <c>Text</c> fires the binding back through the setter, so the rounded string is resubmitted as if
+/// typed. Every round-trip test here simulates that echo, and
+/// <see cref="The_binding_echo_is_what_gives_the_round_trip_tests_teeth"/> computes what the
+/// unguarded path would have stored to prove the echo is load-bearing rather than decorative.</para>
+/// </summary>
+public class PeriodicAmountFieldTests
+{
+    private static PeriodicAmountField Field(
+        CurrencyPeriod storedPeriod,
+        double storedValue,
+        CurrencyPeriod displayPeriod = CurrencyPeriod.Annual)
+    {
+        var field = new PeriodicAmountField(storedPeriod, displayPeriod, CultureInfo.InvariantCulture);
+        field.SetStoredValue(storedValue);
+        return field;
+    }
+
+    /// <summary>
+    /// Switch period the way the running app does: the view model assigns the new text to the bound
+    /// property, and the two-way binding immediately hands that same text back to the setter.
+    /// Dropping the second line is what makes a round-trip test vacuous.
+    /// </summary>
+    private static void ToggleWithBindingEcho(PeriodicAmountField field, CurrencyPeriod period)
+    {
+        field.SetDisplayPeriod(period);
+        field.TrySetText(field.Text);
+    }
+
+    private static long Bits(double value) => BitConverter.DoubleToInt64Bits(value);
+
+    /// <summary>
+    /// Asserts the stored value has not moved at all. The double comparison runs first purely so a
+    /// failure reads as "Expected: 50000  Actual: 50000.04" instead of two raw bit patterns; the bit
+    /// comparison is what makes "unmoved" mean bit-for-bit rather than "close enough".
+    /// </summary>
+    private static void AssertUnmoved(double expected, PeriodicAmountField field)
+    {
+        Assert.Equal(expected, field.StoredValue);
+        Assert.Equal(Bits(expected), Bits(field.StoredValue));
+    }
+
+    [Theory]
+    [InlineData(50_000)]
+    [InlineData(48_000)]
+    [InlineData(24_000)]
+    [InlineData(72_000)]
+    [InlineData(1)]
+    [InlineData(0)]
+    [InlineData(0.01)]
+    [InlineData(100)]
+    [InlineData(12_345.67)]
+    [InlineData(1_000_000)]
+    [InlineData(33_333.33)]
+    public void Toggling_repeatedly_never_moves_an_annual_stored_value(double stored)
+    {
+        var field = Field(CurrencyPeriod.Annual, stored);
+
+        for (var i = 0; i < 50; i++)
+        {
+            ToggleWithBindingEcho(field, CurrencyPeriod.Monthly);
+            AssertUnmoved(stored, field);
+
+            ToggleWithBindingEcho(field, CurrencyPeriod.Annual);
+            AssertUnmoved(stored, field);
+        }
+
+        AssertUnmoved(stored, field);
+    }
+
+    [Theory]
+    [InlineData(600)]
+    [InlineData(1_234.5678)]
+    [InlineData(0)]
+    [InlineData(2_999.99)]
+    public void Toggling_repeatedly_never_moves_a_monthly_stored_value(double stored)
+    {
+        var field = Field(CurrencyPeriod.Monthly, stored);
+
+        for (var i = 0; i < 50; i++)
+        {
+            ToggleWithBindingEcho(field, CurrencyPeriod.Annual);
+            AssertUnmoved(stored, field);
+
+            ToggleWithBindingEcho(field, CurrencyPeriod.Monthly);
+            AssertUnmoved(stored, field);
+        }
+
+        AssertUnmoved(stored, field);
+    }
+
+    /// <summary>
+    /// Proves the echo in <see cref="ToggleWithBindingEcho"/> is load-bearing, by computing what a
+    /// field without <c>ResolveEditedAmount</c> would have stored from the very same text. If those
+    /// two numbers were equal, every round-trip test above would pass no matter what the production
+    /// code did.
+    /// </summary>
+    [Fact]
+    public void The_binding_echo_is_what_gives_the_round_trip_tests_teeth()
+    {
+        var field = Field(CurrencyPeriod.Annual, 50_000);
+        field.SetDisplayPeriod(CurrencyPeriod.Monthly);
+
+        Assert.Equal("4166.67", field.Text);
+
+        var unguarded = CurrencyPeriodMath.Convert(
+            double.Parse(field.Text, CultureInfo.InvariantCulture),
+            CurrencyPeriod.Monthly,
+            CurrencyPeriod.Annual);
+
+        // What a straight conversion would have stored: not 50000.
+        Assert.Equal(50_000.04, unguarded, 6);
+        Assert.NotEqual(Bits(50_000), Bits(unguarded));
+
+        // What the field actually stores from that identical text.
+        field.TrySetText(field.Text);
+        AssertUnmoved(50_000, field);
+    }
+
+    [Fact]
+    public void Display_period_changes_before_the_text_is_rewritten()
+    {
+        // Rewriting first would leave "50000" on screen while the field already claimed monthly, and
+        // the echo would then read an annual figure as monthly and store 600000.
+        var field = Field(CurrencyPeriod.Annual, 50_000);
+
+        field.SetDisplayPeriod(CurrencyPeriod.Monthly);
+
+        Assert.Equal(CurrencyPeriod.Monthly, field.DisplayPeriod);
+        Assert.Equal("4166.67", field.Text);
+
+        field.TrySetText(field.Text);
+        Assert.Equal(50_000, field.StoredValue);
+    }
+
+    [Fact]
+    public void A_monthly_stored_field_shows_twelve_times_the_stored_amount_when_annual()
+    {
+        // The healthcare premium is the one canonically monthly field. A mechanism that assumed
+        // every stored value was annual would show $600/mo as $50/mo here.
+        var field = Field(CurrencyPeriod.Monthly, 600);
+
+        Assert.Equal(CurrencyPeriod.Monthly, field.StoredPeriod);
+        Assert.Equal("7200", field.Text);
+
+        field.SetDisplayPeriod(CurrencyPeriod.Monthly);
+        Assert.Equal("600", field.Text);
+        Assert.Equal(600, field.StoredValue);
+    }
+
+    [Fact]
+    public void Editing_a_monthly_stored_field_while_annual_stores_the_monthly_amount()
+    {
+        var field = Field(CurrencyPeriod.Monthly, 600);
+
+        Assert.True(field.TrySetText("9600"));
+
+        Assert.Equal(800, field.StoredValue);
+    }
+
+    [Fact]
+    public void Editing_an_annual_stored_field_while_monthly_stores_the_annual_amount()
+    {
+        var field = Field(CurrencyPeriod.Annual, 50_000, CurrencyPeriod.Monthly);
+
+        Assert.True(field.TrySetText("5000"));
+
+        Assert.Equal(60_000, field.StoredValue);
+    }
+
+    [Fact]
+    public void An_edit_survives_a_toggle_round_trip()
+    {
+        var field = Field(CurrencyPeriod.Annual, 50_000, CurrencyPeriod.Monthly);
+        field.TrySetText("5000");
+
+        ToggleWithBindingEcho(field, CurrencyPeriod.Annual);
+        Assert.Equal("60000", field.Text);
+
+        ToggleWithBindingEcho(field, CurrencyPeriod.Monthly);
+        Assert.Equal("5000", field.Text);
+        Assert.Equal(60_000, field.StoredValue);
+    }
+
+    /// <summary>
+    /// Text is left exactly as typed, which is why there is no counterpart to the web helper
+    /// <c>formatTypedAmount</c>. Rewriting it here is what would eat the trailing separator.
+    /// </summary>
+    [Theory]
+    [InlineData("1234.", 1234)]
+    [InlineData("1234.5", 1234.5)]
+    [InlineData("1234.50", 1234.5)]
+    [InlineData("0", 0)]
+    [InlineData("0.0", 0)]
+    public void Typed_text_is_kept_verbatim_while_the_parsed_amount_is_stored(string typed, double expected)
+    {
+        var field = Field(CurrencyPeriod.Annual, 0);
+
+        Assert.True(field.TrySetText(typed));
+
+        Assert.Equal(typed, field.Text);
+        Assert.Equal(expected, field.StoredValue);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData(".")]
+    [InlineData("-5")]
+    [InlineData(null)]
+    public void Unusable_text_is_flagged_without_destroying_the_stored_amount(string? typed)
+    {
+        var field = Field(CurrencyPeriod.Annual, 48_000);
+
+        Assert.False(field.TrySetText(typed));
+
+        Assert.False(field.HasValidText);
+        Assert.Equal(48_000, field.StoredValue);
+        Assert.Equal(typed ?? string.Empty, field.Text);
+    }
+
+    [Fact]
+    public void Changing_period_replaces_unusable_text_with_the_stored_amount()
+    {
+        // Text the field could not parse belongs to the period the user was looking at. Leaving it on
+        // screen after a toggle would label an annual figure as monthly.
+        var field = Field(CurrencyPeriod.Annual, 48_000);
+        Assert.False(field.TrySetText("48,0x"));
+
+        field.SetDisplayPeriod(CurrencyPeriod.Monthly);
+
+        Assert.True(field.HasValidText);
+        Assert.Equal("4000", field.Text);
+        Assert.Equal(48_000, field.StoredValue);
+    }
+
+    [Fact]
+    public void Setting_the_same_period_twice_is_a_no_op()
+    {
+        var field = Field(CurrencyPeriod.Annual, 48_000);
+        field.TrySetText("48000.");
+
+        field.SetDisplayPeriod(CurrencyPeriod.Annual);
+
+        Assert.Equal("48000.", field.Text);
+    }
+
+    [Fact]
+    public void Loading_a_stored_amount_rewrites_the_text_in_the_current_display_period()
+    {
+        var field = Field(CurrencyPeriod.Annual, 0, CurrencyPeriod.Monthly);
+
+        field.SetStoredValue(60_000);
+
+        Assert.Equal("5000", field.Text);
+        Assert.True(field.HasValidText);
+    }
+
+    [Fact]
+    public void A_non_finite_stored_amount_falls_back_to_zero()
+    {
+        var field = Field(CurrencyPeriod.Annual, 0);
+
+        field.SetStoredValue(double.NaN);
+
+        Assert.Equal(0, field.StoredValue);
+        Assert.Equal("0", field.Text);
+    }
+}

--- a/app/MyFireNumber.Tests/Presentation/PeriodicFieldCatalogTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/PeriodicFieldCatalogTests.cs
@@ -1,0 +1,131 @@
+using System.Globalization;
+
+using MyFireNumber.Core.Calculators;
+using MyFireNumber.Core.Presentation;
+
+namespace MyFireNumber.Tests.Presentation;
+
+/// <summary>
+/// Structural checks on which calculators declare recurring currency fields.
+///
+/// <para>Nothing here asserts a count. <c>Assert.Equal(11, …)</c> would pass the day a twelfth
+/// calculator was added and forgotten, which is the failure mode these checks exist to prevent. The
+/// covered set is compared against <see cref="CalculatorCatalog"/> instead, so a new calculator turns
+/// this file red until someone decides — in writing — whether it has periodic fields.</para>
+/// </summary>
+public class PeriodicFieldCatalogTests
+{
+    private static readonly ICalculatorCatalog Calculators = new CalculatorCatalog();
+
+    [Fact]
+    public void Every_calculator_declares_its_periodic_fields()
+    {
+        var shipped = Calculators.All.Select(definition => definition.Id).OrderBy(id => id, StringComparer.Ordinal);
+        var declared = PeriodicFieldCatalog.CalculatorIds.OrderBy(id => id, StringComparer.Ordinal);
+
+        Assert.Equal(shipped, declared);
+    }
+
+    [Theory]
+    [InlineData("withdrawal-rate")]
+    [InlineData("debt-payoff")]
+    public void Calculators_without_recurring_amounts_declare_an_empty_list(string calculatorId)
+    {
+        // Declared and empty, not absent. Absence would be indistinguishable from an oversight.
+        Assert.Empty(PeriodicFieldCatalog.For(calculatorId));
+    }
+
+    [Fact]
+    public void The_healthcare_premium_is_the_only_field_stored_monthly()
+    {
+        var monthly = PeriodicFieldCatalog.CalculatorIds
+            .SelectMany(id => PeriodicFieldCatalog.For(id).Select(field => (id, field)))
+            .Where(entry => entry.field.StoredPeriod == CurrencyPeriod.Monthly)
+            .Select(entry => $"{entry.id}/{entry.field.Key}")
+            .OrderBy(name => name, StringComparer.Ordinal);
+
+        Assert.Equal(["healthcare-gap/healthcareMonthlyPremium"], monthly);
+    }
+
+    [Fact]
+    public void No_calculator_declares_the_same_field_twice()
+    {
+        foreach (var calculatorId in PeriodicFieldCatalog.CalculatorIds)
+        {
+            var keys = PeriodicFieldCatalog.For(calculatorId).Select(field => field.Key).ToList();
+
+            Assert.Equal(keys.Count, keys.Distinct(StringComparer.Ordinal).Count());
+        }
+    }
+
+    [Fact]
+    public void A_field_key_always_means_the_same_stored_period_everywhere_it_appears()
+    {
+        // The three FIRE variants share a field vocabulary. A key that meant annual on one screen and
+        // monthly on another would make the shared inventory ambiguous.
+        var periodsByKey = PeriodicFieldCatalog.CalculatorIds
+            .SelectMany(PeriodicFieldCatalog.For)
+            .GroupBy(field => field.Key, StringComparer.Ordinal);
+
+        foreach (var group in periodsByKey)
+        {
+            Assert.Single(group.Select(field => field.StoredPeriod).Distinct());
+        }
+    }
+
+    [Fact]
+    public void An_unknown_calculator_throws_rather_than_reporting_no_periodic_fields()
+    {
+        // Returning an empty list would let a typo'd ID look like a calculator with nothing to toggle.
+        Assert.Throws<KeyNotFoundException>(() => PeriodicFieldCatalog.For("not-a-calculator"));
+    }
+
+    /// <summary>
+    /// Exercises the declared stored period through a real field rather than only reading it back as a
+    /// string. Without this, flipping the healthcare premium to annual would break only an inventory
+    /// listing — the declaration has to be load-bearing for arithmetic or it is just documentation.
+    /// </summary>
+    [Fact]
+    public void A_600_dollar_healthcare_premium_shows_as_7200_a_year()
+    {
+        var premium = PeriodicFieldCatalog.For("healthcare-gap")
+            .Single(field => field.Key == PeriodicFieldCatalog.HealthcareMonthlyPremium);
+
+        var field = new PeriodicAmountField(
+            premium.StoredPeriod,
+            CurrencyPeriod.Monthly,
+            CultureInfo.InvariantCulture);
+        field.SetStoredValue(600);
+
+        Assert.Equal("600", field.Text);
+
+        field.SetDisplayPeriod(CurrencyPeriod.Annual);
+
+        // Read the premium as annual and it is 7200. If the catalog claimed the stored value was
+        // already annual, this would read 50 — the same 144x error web would make.
+        Assert.Equal("7200", field.Text);
+        Assert.Equal(600, field.StoredValue);
+    }
+
+    /// <summary>
+    /// The mirror of the above for an annual-canonical field, so the two stored periods are pinned
+    /// against each other rather than each in isolation.
+    /// </summary>
+    [Fact]
+    public void A_60000_dollar_annual_expense_shows_as_5000_a_month()
+    {
+        var expenses = PeriodicFieldCatalog.For("healthcare-gap")
+            .Single(field => field.Key == PeriodicFieldCatalog.HealthcareAnnualDeductible);
+
+        var field = new PeriodicAmountField(
+            expenses.StoredPeriod,
+            CurrencyPeriod.Annual,
+            CultureInfo.InvariantCulture);
+        field.SetStoredValue(60_000);
+
+        field.SetDisplayPeriod(CurrencyPeriod.Monthly);
+
+        Assert.Equal("5000", field.Text);
+        Assert.Equal(60_000, field.StoredValue);
+    }
+}

--- a/app/MyFireNumber.Tests/Presentation/SharedPeriodicFieldInventoryTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/SharedPeriodicFieldInventoryTests.cs
@@ -1,0 +1,108 @@
+using System.Text.Json;
+
+using MyFireNumber.Core.Calculators;
+using MyFireNumber.Core.Presentation;
+
+namespace MyFireNumber.Tests.Presentation;
+
+/// <summary>
+/// Pins <see cref="PeriodicFieldCatalog"/> to <c>shared/parity/periodic-fields.json</c>, the same file
+/// the web suite reads.
+///
+/// <para><b>Why this exists.</b> No unit test in this project can prove a XAML <c>Entry</c> is bound to
+/// a period-aware field: <c>MyFireNumber.Tests</c> cannot reference the MAUI single-project, so a page
+/// wired on one platform and forgotten on the other is invisible to both suites. Comparing each side
+/// against one shared artifact makes that omission fail on the platform that has it wrong instead of
+/// leaving it to review.</para>
+///
+/// <para><b>What is deliberately not here.</b> No conversion arithmetic. A case asserting
+/// <c>50000 / 12 = 4166.67</c> would restate the implementation rather than check it, which is the
+/// screenshot test <c>shared/parity/README.md</c> forbids. Conversion behaviour is pinned in
+/// <see cref="CurrencyPeriodMathTests"/> and <see cref="PeriodicAmountFieldTests"/> against a
+/// lossless-round-trip invariant, which is a property the implementation could actually fail.</para>
+/// </summary>
+public class SharedPeriodicFieldInventoryTests
+{
+    private static readonly ICalculatorCatalog Calculators = new CalculatorCatalog();
+    private static readonly IReadOnlyList<SharedCalculator> Shared = LoadShared();
+
+    [Fact]
+    public void The_shared_inventory_covers_exactly_the_shipped_calculators()
+    {
+        var shipped = Calculators.All.Select(definition => definition.Id).OrderBy(id => id, StringComparer.Ordinal);
+        var declared = Shared.Select(calculator => calculator.Id).OrderBy(id => id, StringComparer.Ordinal);
+
+        Assert.Equal(shipped, declared);
+    }
+
+    [Fact]
+    public void Every_calculator_declares_the_shared_periodic_fields_in_the_shared_periods()
+    {
+        foreach (var calculator in Shared)
+        {
+            var expected = calculator.Fields
+                .Select(field => $"{field.Key}:{field.StoredPeriod}")
+                .OrderBy(entry => entry, StringComparer.Ordinal);
+
+            var actual = PeriodicFieldCatalog.For(calculator.Id)
+                .Select(field => $"{field.Key}:{Serialize(field.StoredPeriod)}")
+                .OrderBy(entry => entry, StringComparer.Ordinal);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void The_shared_inventory_is_not_silently_empty()
+    {
+        // Guards the guard. If the artifact failed to load, or its shape changed so every field list
+        // parsed as empty, the comparison above would pass against a catalog that had also been
+        // emptied -- two blank lists agreeing is indistinguishable from success. These are the two
+        // facts that make the comparison meaningful, so they are asserted directly.
+        Assert.Contains(Shared, calculator => calculator.Fields.Count > 0);
+        Assert.Contains(
+            Shared.SelectMany(calculator => calculator.Fields),
+            field => field.StoredPeriod == "monthly");
+    }
+
+    [Fact]
+    public void Every_shared_stored_period_is_one_this_app_can_represent()
+    {
+        var allowed = Enum.GetValues<CurrencyPeriod>().Select(Serialize).ToHashSet(StringComparer.Ordinal);
+
+        foreach (var field in Shared.SelectMany(calculator => calculator.Fields))
+        {
+            Assert.Contains(field.StoredPeriod, allowed);
+        }
+    }
+
+    private static string Serialize(CurrencyPeriod period) =>
+        period.Validated(nameof(period)) == CurrencyPeriod.Monthly ? "monthly" : "annual";
+
+    private static IReadOnlyList<SharedCalculator> LoadShared()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "SharedParity", "periodic-fields.json");
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"Shared periodic field inventory not found at '{path}'. It is copied from shared/parity by MyFireNumber.Tests.csproj.",
+                path);
+        }
+
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+
+        return document.RootElement.GetProperty("calculators").EnumerateArray()
+            .Select(calculator => new SharedCalculator(
+                calculator.GetProperty("id").GetString()!,
+                calculator.GetProperty("fields").EnumerateArray()
+                    .Select(field => new SharedField(
+                        field.GetProperty("key").GetString()!,
+                        field.GetProperty("storedPeriod").GetString()!))
+                    .ToList()))
+            .ToList();
+    }
+
+    private sealed record SharedCalculator(string Id, IReadOnlyList<SharedField> Fields);
+
+    private sealed record SharedField(string Key, string StoredPeriod);
+}

--- a/app/MyFireNumber/MauiProgram.cs
+++ b/app/MyFireNumber/MauiProgram.cs
@@ -54,6 +54,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<ICalculatorDefaultsService, CalculatorDefaultsService>();
 		builder.Services.AddSingleton<IAppBehaviorPreferencesService, AppBehaviorPreferencesService>();
 		builder.Services.AddSingleton<ICurrencyPreferencesService, CurrencyPreferencesService>();
+		builder.Services.AddSingleton<IDisplayPeriodPreferencesService, DisplayPeriodPreferencesService>();
 		builder.Services.AddSingleton<ITemporaryExportCleanupService, TemporaryExportCleanupService>();
 		builder.Services.AddSingleton<IErrorPresentationService, ErrorPresentationService>();
 		builder.Services.AddSingleton<IExternalLinkService, ExternalLinkService>();

--- a/app/MyFireNumber/Services/DisplayPeriodPreferencesService.cs
+++ b/app/MyFireNumber/Services/DisplayPeriodPreferencesService.cs
@@ -1,0 +1,41 @@
+using MyFireNumber.Core.Presentation;
+
+namespace MyFireNumber.Services;
+
+/// <summary>
+/// Remembers whether a calculator's recurring amounts are shown monthly or annually.
+/// </summary>
+/// <remarks>
+/// <para>This is a display preference, not an input. It is stored per calculator in
+/// <see cref="Preferences"/> rather than in a draft, because it changes nothing about what a
+/// calculator computes — routing it through a draft would bump a payload version, alter saved plans
+/// and exported workbooks, and blur the line between this and
+/// <c>ContributionFrequency</c>, which genuinely is a calculation input.</para>
+/// <para>The service holds no logic on purpose: <see cref="Preferences"/> is unavailable to the unit
+/// test project, so everything worth testing lives in <see cref="CurrencyPeriodMath"/> and
+/// <see cref="PeriodicAmountField"/> instead.</para>
+/// </remarks>
+public interface IDisplayPeriodPreferencesService
+{
+    CurrencyPeriod Get(string calculatorId);
+
+    void Save(string calculatorId, CurrencyPeriod period);
+}
+
+public sealed class DisplayPeriodPreferencesService : IDisplayPeriodPreferencesService
+{
+    private const string KeyPrefix = "display-period:";
+
+    public CurrencyPeriod Get(string calculatorId)
+    {
+        var stored = Preferences.Default.Get(KeyPrefix + calculatorId, string.Empty);
+        return Enum.TryParse(stored, out CurrencyPeriod period) && Enum.IsDefined(period)
+            ? period
+            : CurrencyPeriod.Annual;
+    }
+
+    public void Save(string calculatorId, CurrencyPeriod period)
+    {
+        Preferences.Default.Set(KeyPrefix + calculatorId, period.Validated(nameof(period)).ToString());
+    }
+}

--- a/app/MyFireNumber/ViewModels/BaristaFireViewModel.cs
+++ b/app/MyFireNumber/ViewModels/BaristaFireViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using SkiaSharp;
 using System.Globalization;
@@ -9,6 +10,28 @@ namespace MyFireNumber.ViewModels;
 public sealed partial class BaristaFireViewModel : CalculatorViewModelBase<BaristaFireDraft>
 {
     private readonly IBaristaFireExportService exportService;
+
+    // Recurring amounts. These delegate to Core periodic fields instead of holding their own text, so
+    // the canonical amount is the single source of truth and the monthly/annual toggle only changes
+    // how it is rendered.
+
+    public string AnnualContributionText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualContribution);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualContribution, value);
+    }
+
+    public string AnnualExpensesText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualExpenses);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualExpenses, value);
+    }
+
+    public string PartTimeAnnualIncomeText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.PartTimeIncome);
+        set => SetPeriodicText(PeriodicFieldCatalog.PartTimeIncome, value);
+    }
 
     public BaristaFireViewModel(
         CalculatorViewModelServices services,
@@ -23,15 +46,6 @@ public sealed partial class BaristaFireViewModel : CalculatorViewModelBase<Baris
 
     [ObservableProperty]
     private string currentSavingsText = string.Empty;
-
-    [ObservableProperty]
-    private string annualContributionText = string.Empty;
-
-    [ObservableProperty]
-    private string annualExpensesText = string.Empty;
-
-    [ObservableProperty]
-    private string partTimeAnnualIncomeText = string.Empty;
 
     [ObservableProperty]
     private string expectedReturnText = string.Empty;
@@ -74,9 +88,6 @@ public sealed partial class BaristaFireViewModel : CalculatorViewModelBase<Baris
 
     partial void OnCurrentAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnCurrentSavingsTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualContributionTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualExpensesTextChanged(string value) => OnDraftInputChanged();
-    partial void OnPartTimeAnnualIncomeTextChanged(string value) => OnDraftInputChanged();
     partial void OnExpectedReturnTextChanged(string value) => OnDraftInputChanged();
     partial void OnInflationRateTextChanged(string value) => OnDraftInputChanged();
     partial void OnWithdrawalRateTextChanged(string value) => OnDraftInputChanged();
@@ -85,9 +96,9 @@ public sealed partial class BaristaFireViewModel : CalculatorViewModelBase<Baris
     {
         CurrentAgeText = draft.CurrentAge.ToString(CultureInfo.CurrentCulture);
         CurrentSavingsText = FormatNumber(draft.CurrentSavings);
-        AnnualContributionText = FormatNumber(draft.AnnualContribution);
-        AnnualExpensesText = FormatNumber(draft.AnnualExpenses);
-        PartTimeAnnualIncomeText = FormatNumber(draft.PartTimeAnnualIncome);
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualContribution, draft.AnnualContribution, nameof(AnnualContributionText));
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, draft.AnnualExpenses, nameof(AnnualExpensesText));
+        LoadPeriodicValue(PeriodicFieldCatalog.PartTimeIncome, draft.PartTimeAnnualIncome, nameof(PartTimeAnnualIncomeText));
         ExpectedReturnText = FormatNumber(draft.ExpectedReturn * 100);
         InflationRateText = FormatNumber(draft.InflationRate * 100);
         WithdrawalRateText = FormatNumber(draft.WithdrawalRate * 100);
@@ -103,9 +114,9 @@ public sealed partial class BaristaFireViewModel : CalculatorViewModelBase<Baris
         }
 
         if (!TryParseNonNegative(CurrentSavingsText, out var currentSavings)
-            || !TryParseNonNegative(AnnualContributionText, out var annualContribution)
-            || !TryParseNonNegative(AnnualExpensesText, out var annualExpenses)
-            || !TryParseNonNegative(PartTimeAnnualIncomeText, out var partTimeIncome))
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualContribution, out var annualContribution)
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, out var annualExpenses)
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.PartTimeIncome, out var partTimeIncome))
         {
             ValidationMessage = "Enter zero or a positive amount for each dollar value.";
             return false;

--- a/app/MyFireNumber/ViewModels/CalculatorViewModelBase.cs
+++ b/app/MyFireNumber/ViewModels/CalculatorViewModelBase.cs
@@ -4,10 +4,12 @@ using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
 using LiveChartsCore.SkiaSharpView.Painting;
 using MyFireNumber.Core.Calculators;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using MyFireNumber.Storage;
 using SkiaSharp;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 
 namespace MyFireNumber.ViewModels;
@@ -25,6 +27,8 @@ public abstract partial class CalculatorViewModelBase<TDraft> : ObservableObject
     private readonly ICalculatorCatalog catalog;
     private readonly ICorruptPayloadRepository corruptPayloadRepository;
     private readonly ICurrencyPreferencesService currencyPreferences;
+    private readonly IDisplayPeriodPreferencesService displayPeriodPreferences;
+    private readonly Dictionary<string, PeriodicAmountField> periodicFields = new(StringComparer.Ordinal);
     private readonly IDraftRepository draftRepository;
     private readonly INavigationService navigation;
     private readonly IPlanRepository planRepository;
@@ -43,6 +47,7 @@ public abstract partial class CalculatorViewModelBase<TDraft> : ObservableObject
         CalculatorDefaults = services.CalculatorDefaults;
         corruptPayloadRepository = services.CorruptPayloadRepository;
         currencyPreferences = services.CurrencyPreferences;
+        displayPeriodPreferences = services.DisplayPeriodPreferences;
         draftRepository = services.DraftRepository;
         navigation = services.Navigation;
         planRepository = services.PlanRepository;
@@ -88,6 +93,139 @@ public abstract partial class CalculatorViewModelBase<TDraft> : ObservableObject
 
     /// <summary>Suppresses recalculation while inputs are being populated from a draft.</summary>
     protected bool IsApplyingDraft { get; private set; }
+
+    #region Display period
+
+    // Presentation only. Nothing below reaches a draft, a saved plan, an exported workbook, or a
+    // FinancialCalculator call — recurring amounts stay canonical and every calculation keeps running
+    // on the canonical value. This is deliberately not ContributionFrequency, which is an input
+    // frequency that does change the math and does belong in a draft.
+
+    private CurrencyPeriod? displayPeriod;
+
+    /// <summary>The period recurring amounts are currently shown in.</summary>
+    public CurrencyPeriod DisplayPeriod
+    {
+        get
+        {
+            EnsurePeriodicFields();
+            return displayPeriod!.Value;
+        }
+    }
+
+    public bool IsMonthlyDisplay => DisplayPeriod == CurrencyPeriod.Monthly;
+
+    public bool IsAnnualDisplay => DisplayPeriod == CurrencyPeriod.Annual;
+
+    /// <summary>Appended to a periodic field's label, e.g. <c>per month</c>.</summary>
+    public string DisplayPeriodQualifier => CurrencyPeriodMath.Qualifier(DisplayPeriod);
+
+    /// <summary>Shown inside a periodic field's entry, e.g. <c>/mo</c>.</summary>
+    public string DisplayPeriodSuffix => CurrencyPeriodMath.Suffix(DisplayPeriod);
+
+    /// <summary>Whether this calculator has any recurring amounts to toggle.</summary>
+    public bool HasPeriodicFields
+    {
+        get
+        {
+            EnsurePeriodicFields();
+            return periodicFields.Count > 0;
+        }
+    }
+
+    [RelayCommand]
+    private void SetDisplayPeriod(string period)
+    {
+        if (!Enum.TryParse(period, out CurrencyPeriod requested) || !Enum.IsDefined(requested))
+        {
+            return;
+        }
+
+        EnsurePeriodicFields();
+        if (requested == displayPeriod)
+        {
+            return;
+        }
+
+        displayPeriod = requested;
+        foreach (var field in periodicFields.Values)
+        {
+            field.SetDisplayPeriod(requested);
+        }
+
+        displayPeriodPreferences.Save(CalculatorId, requested);
+
+        // Raising "everything changed" rather than naming each bound text property. A hand-kept list
+        // would silently stop refreshing a field the day one was added, which is precisely the class
+        // of miss this feature is meant to avoid; the derived view models declare their periodic
+        // fields in one place already (PeriodicFieldCatalog) and nowhere else needs to repeat it.
+        OnPropertyChanged(string.Empty);
+    }
+
+    private void EnsurePeriodicFields()
+    {
+        if (displayPeriod.HasValue)
+        {
+            return;
+        }
+
+        var period = displayPeriodPreferences.Get(CalculatorId);
+        displayPeriod = period;
+        foreach (var definition in PeriodicFieldCatalog.For(CalculatorId))
+        {
+            periodicFields[definition.Key] = new PeriodicAmountField(definition.StoredPeriod, period);
+        }
+    }
+
+    /// <summary>
+    /// The field behind a periodic input. Throws for a key this calculator did not declare, so a typo
+    /// fails at first use instead of quietly creating a field nothing toggles.
+    /// </summary>
+    private PeriodicAmountField PeriodicField(string key)
+    {
+        EnsurePeriodicFields();
+        return periodicFields.TryGetValue(key, out var field)
+            ? field
+            : throw new KeyNotFoundException(
+                $"'{key}' is not a periodic field of '{CalculatorId}'. Declare it in {nameof(PeriodicFieldCatalog)}.");
+    }
+
+    /// <summary>What a periodic entry should display, in the current display period.</summary>
+    protected string PeriodicText(string key) => PeriodicField(key).Text;
+
+    /// <summary>Accept text from a periodic entry, typed by the user or echoed by the two-way binding.</summary>
+    protected void SetPeriodicText(string key, string? value, [CallerMemberName] string? propertyName = null)
+    {
+        var field = PeriodicField(key);
+        if (string.Equals(field.Text, value, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        field.TrySetText(value);
+        OnPropertyChanged(propertyName);
+        OnDraftInputChanged();
+    }
+
+    /// <summary>Load a canonical amount into a periodic field when a draft or plan is applied.</summary>
+    protected void LoadPeriodicValue(string key, double value, [CallerMemberName] string? propertyName = null)
+    {
+        PeriodicField(key).SetStoredValue(value);
+        OnPropertyChanged(propertyName);
+    }
+
+    /// <summary>
+    /// Read a periodic field's canonical amount for a draft. Always the stored period, never what is
+    /// on screen, so switching the display cannot change a result.
+    /// </summary>
+    protected bool TryGetPeriodicValue(string key, out double value)
+    {
+        var field = PeriodicField(key);
+        value = field.StoredValue;
+        return field.HasValidText;
+    }
+
+    #endregion
 
     protected ICalculatorDefaultsService CalculatorDefaults { get; }
 

--- a/app/MyFireNumber/ViewModels/CalculatorViewModelServices.cs
+++ b/app/MyFireNumber/ViewModels/CalculatorViewModelServices.cs
@@ -14,6 +14,7 @@ public sealed class CalculatorViewModelServices(
     ICalculatorDefaultsService calculatorDefaults,
     ICorruptPayloadRepository corruptPayloadRepository,
     ICurrencyPreferencesService currencyPreferences,
+    IDisplayPeriodPreferencesService displayPeriodPreferences,
     IDraftRepository draftRepository,
     INavigationService navigation,
     IPlanRepository planRepository)
@@ -27,6 +28,8 @@ public sealed class CalculatorViewModelServices(
     public ICorruptPayloadRepository CorruptPayloadRepository { get; } = corruptPayloadRepository;
 
     public ICurrencyPreferencesService CurrencyPreferences { get; } = currencyPreferences;
+
+    public IDisplayPeriodPreferencesService DisplayPeriodPreferences { get; } = displayPeriodPreferences;
 
     public IDraftRepository DraftRepository { get; } = draftRepository;
 

--- a/app/MyFireNumber/ViewModels/CoastFireViewModel.cs
+++ b/app/MyFireNumber/ViewModels/CoastFireViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using SkiaSharp;
 using System.Globalization;
@@ -9,6 +10,22 @@ namespace MyFireNumber.ViewModels;
 public sealed partial class CoastFireViewModel : CalculatorViewModelBase<CoastFireDraft>
 {
     private readonly ICoastFireExportService exportService;
+
+    // Recurring amounts. These delegate to Core periodic fields instead of holding their own text, so
+    // the canonical amount is the single source of truth and the monthly/annual toggle only changes
+    // how it is rendered.
+
+    public string AnnualContributionText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualContribution);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualContribution, value);
+    }
+
+    public string AnnualExpensesText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualExpenses);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualExpenses, value);
+    }
 
     public CoastFireViewModel(
         CalculatorViewModelServices services,
@@ -26,12 +43,6 @@ public sealed partial class CoastFireViewModel : CalculatorViewModelBase<CoastFi
 
     [ObservableProperty]
     private string currentSavingsText = string.Empty;
-
-    [ObservableProperty]
-    private string annualContributionText = string.Empty;
-
-    [ObservableProperty]
-    private string annualExpensesText = string.Empty;
 
     [ObservableProperty]
     private string expectedReturnText = string.Empty;
@@ -75,8 +86,6 @@ public sealed partial class CoastFireViewModel : CalculatorViewModelBase<CoastFi
     partial void OnCurrentAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnRetirementAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnCurrentSavingsTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualContributionTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualExpensesTextChanged(string value) => OnDraftInputChanged();
     partial void OnExpectedReturnTextChanged(string value) => OnDraftInputChanged();
     partial void OnInflationRateTextChanged(string value) => OnDraftInputChanged();
     partial void OnWithdrawalRateTextChanged(string value) => OnDraftInputChanged();
@@ -86,8 +95,8 @@ public sealed partial class CoastFireViewModel : CalculatorViewModelBase<CoastFi
         CurrentAgeText = draft.CurrentAge.ToString(CultureInfo.CurrentCulture);
         RetirementAgeText = draft.RetirementAge.ToString(CultureInfo.CurrentCulture);
         CurrentSavingsText = FormatNumber(draft.CurrentSavings);
-        AnnualContributionText = FormatNumber(draft.AnnualContribution);
-        AnnualExpensesText = FormatNumber(draft.AnnualExpenses);
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualContribution, draft.AnnualContribution, nameof(AnnualContributionText));
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, draft.AnnualExpenses, nameof(AnnualExpensesText));
         ExpectedReturnText = FormatNumber(draft.ExpectedReturn * 100);
         InflationRateText = FormatNumber(draft.InflationRate * 100);
         WithdrawalRateText = FormatNumber(draft.WithdrawalRate * 100);
@@ -109,8 +118,8 @@ public sealed partial class CoastFireViewModel : CalculatorViewModelBase<CoastFi
         }
 
         if (!TryParseNonNegative(CurrentSavingsText, out var currentSavings)
-            || !TryParseNonNegative(AnnualContributionText, out var annualContribution)
-            || !TryParseNonNegative(AnnualExpensesText, out var annualExpenses))
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualContribution, out var annualContribution)
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, out var annualExpenses))
         {
             ValidationMessage = "Enter zero or a positive amount for each dollar value.";
             return false;

--- a/app/MyFireNumber/ViewModels/FireNumberViewModelBase.cs
+++ b/app/MyFireNumber/ViewModels/FireNumberViewModelBase.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using SkiaSharp;
 using System.Globalization;
@@ -28,14 +29,26 @@ public abstract partial class FireNumberViewModelBase<TDraft> : CalculatorViewMo
     [ObservableProperty]
     private string currentSavingsText = string.Empty;
 
-    [ObservableProperty]
-    private string annualContributionText = string.Empty;
+    // Recurring amounts. These delegate to Core periodic fields instead of holding their own text, so
+    // the canonical amount is the single source of truth and the monthly/annual toggle only changes
+    // how it is rendered.
+    public string AnnualContributionText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualContribution);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualContribution, value);
+    }
 
-    [ObservableProperty]
-    private string annualIncomeText = string.Empty;
+    public string AnnualIncomeText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualIncome);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualIncome, value);
+    }
 
-    [ObservableProperty]
-    private string annualExpensesText = string.Empty;
+    public string AnnualExpensesText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualExpenses);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualExpenses, value);
+    }
 
     [ObservableProperty]
     private string expectedReturnText = string.Empty;
@@ -113,9 +126,6 @@ public abstract partial class FireNumberViewModelBase<TDraft> : CalculatorViewMo
     partial void OnCurrentAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnRetirementAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnCurrentSavingsTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualContributionTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualIncomeTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualExpensesTextChanged(string value) => OnDraftInputChanged();
     partial void OnExpectedReturnTextChanged(string value) => OnDraftInputChanged();
     partial void OnInflationRateTextChanged(string value) => OnDraftInputChanged();
     partial void OnWithdrawalRateTextChanged(string value) => OnDraftInputChanged();
@@ -154,9 +164,9 @@ public abstract partial class FireNumberViewModelBase<TDraft> : CalculatorViewMo
         CurrentAgeText = standard.CurrentAge.ToString(CultureInfo.CurrentCulture);
         RetirementAgeText = standard.RetirementAge.ToString(CultureInfo.CurrentCulture);
         CurrentSavingsText = FormatNumber(standard.CurrentSavings);
-        AnnualContributionText = FormatNumber(standard.AnnualContribution);
-        AnnualIncomeText = FormatNumber(standard.AnnualIncome);
-        AnnualExpensesText = FormatNumber(standard.AnnualExpenses);
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualContribution, standard.AnnualContribution, nameof(AnnualContributionText));
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualIncome, standard.AnnualIncome, nameof(AnnualIncomeText));
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, standard.AnnualExpenses, nameof(AnnualExpensesText));
         ExpectedReturnText = FormatNumber(standard.ExpectedReturn * 100);
         InflationRateText = FormatNumber(standard.InflationRate * 100);
         WithdrawalRateText = FormatNumber(standard.WithdrawalRate * 100);
@@ -217,9 +227,9 @@ public abstract partial class FireNumberViewModelBase<TDraft> : CalculatorViewMo
         }
 
         if (!TryParseNonNegative(CurrentSavingsText, out var currentSavings)
-            || !TryParseNonNegative(AnnualContributionText, out var annualContribution)
-            || !TryParseNonNegative(AnnualIncomeText, out var annualIncome)
-            || !TryParseNonNegative(AnnualExpensesText, out var annualExpenses))
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualContribution, out var annualContribution)
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualIncome, out var annualIncome)
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, out var annualExpenses))
         {
             ValidationMessage = "Enter zero or a positive amount for each dollar value.";
             return false;

--- a/app/MyFireNumber/ViewModels/HealthcareGapViewModel.cs
+++ b/app/MyFireNumber/ViewModels/HealthcareGapViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using SkiaSharp;
 using System.Globalization;
@@ -9,6 +10,28 @@ namespace MyFireNumber.ViewModels;
 public sealed partial class HealthcareGapViewModel : CalculatorViewModelBase<HealthcareGapDraft>
 {
     private readonly IHealthcareGapExportService exportService;
+
+    // Recurring amounts. These delegate to Core periodic fields instead of holding their own text, so
+    // the canonical amount is the single source of truth and the monthly/annual toggle only changes
+    // how it is rendered.
+
+    public string MonthlyPremiumText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.HealthcareMonthlyPremium);
+        set => SetPeriodicText(PeriodicFieldCatalog.HealthcareMonthlyPremium, value);
+    }
+
+    public string AnnualDeductibleText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.HealthcareAnnualDeductible);
+        set => SetPeriodicText(PeriodicFieldCatalog.HealthcareAnnualDeductible, value);
+    }
+
+    public string AnnualOutOfPocketText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.HealthcareAnnualOutOfPocket);
+        set => SetPeriodicText(PeriodicFieldCatalog.HealthcareAnnualOutOfPocket, value);
+    }
 
     public HealthcareGapViewModel(
         CalculatorViewModelServices services,
@@ -26,15 +49,6 @@ public sealed partial class HealthcareGapViewModel : CalculatorViewModelBase<Hea
 
     [ObservableProperty]
     private string medicareAgeText = string.Empty;
-
-    [ObservableProperty]
-    private string monthlyPremiumText = string.Empty;
-
-    [ObservableProperty]
-    private string annualDeductibleText = string.Empty;
-
-    [ObservableProperty]
-    private string annualOutOfPocketText = string.Empty;
 
     [ObservableProperty]
     private string inflationRateText = string.Empty;
@@ -69,9 +83,6 @@ public sealed partial class HealthcareGapViewModel : CalculatorViewModelBase<Hea
     partial void OnHealthcareCurrentAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnEarlyRetirementAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnMedicareAgeTextChanged(string value) => OnDraftInputChanged();
-    partial void OnMonthlyPremiumTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualDeductibleTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualOutOfPocketTextChanged(string value) => OnDraftInputChanged();
     partial void OnInflationRateTextChanged(string value) => OnDraftInputChanged();
 
     protected override void ApplyDraft(HealthcareGapDraft draft)
@@ -79,9 +90,9 @@ public sealed partial class HealthcareGapViewModel : CalculatorViewModelBase<Hea
         HealthcareCurrentAgeText = draft.CurrentAge.ToString(CultureInfo.CurrentCulture);
         EarlyRetirementAgeText = draft.EarlyRetirementAge.ToString(CultureInfo.CurrentCulture);
         MedicareAgeText = draft.MedicareAge.ToString(CultureInfo.CurrentCulture);
-        MonthlyPremiumText = FormatNumber(draft.MonthlyPremium);
-        AnnualDeductibleText = FormatNumber(draft.AnnualDeductible);
-        AnnualOutOfPocketText = FormatNumber(draft.AnnualOutOfPocket);
+        LoadPeriodicValue(PeriodicFieldCatalog.HealthcareMonthlyPremium, draft.MonthlyPremium, nameof(MonthlyPremiumText));
+        LoadPeriodicValue(PeriodicFieldCatalog.HealthcareAnnualDeductible, draft.AnnualDeductible, nameof(AnnualDeductibleText));
+        LoadPeriodicValue(PeriodicFieldCatalog.HealthcareAnnualOutOfPocket, draft.AnnualOutOfPocket, nameof(AnnualOutOfPocketText));
         InflationRateText = FormatNumber(draft.InflationRate * 100);
     }
 
@@ -110,9 +121,9 @@ public sealed partial class HealthcareGapViewModel : CalculatorViewModelBase<Hea
             return false;
         }
 
-        if (!TryParseNonNegative(MonthlyPremiumText, out var monthlyPremium)
-            || !TryParseNonNegative(AnnualDeductibleText, out var annualDeductible)
-            || !TryParseNonNegative(AnnualOutOfPocketText, out var annualOutOfPocket))
+        if (!TryGetPeriodicValue(PeriodicFieldCatalog.HealthcareMonthlyPremium, out var monthlyPremium)
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.HealthcareAnnualDeductible, out var annualDeductible)
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.HealthcareAnnualOutOfPocket, out var annualOutOfPocket))
         {
             ValidationMessage = "Enter zero or a positive amount for each healthcare cost.";
             return false;

--- a/app/MyFireNumber/ViewModels/RetirementCashFlowViewModel.cs
+++ b/app/MyFireNumber/ViewModels/RetirementCashFlowViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LiveChartsCore;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using SkiaSharp;
 using System.Collections.ObjectModel;
@@ -26,6 +27,15 @@ public sealed partial class RetirementCashFlowViewModel : CalculatorViewModelBas
 
     private readonly IDeferredCompensationExportService exportService;
 
+    // Recurring amount. Delegates to a Core periodic field instead of holding its own text, so the
+    // canonical amount is the single source of truth and the monthly/annual toggle only changes how
+    // it is rendered.
+    public string RetirementExpensesText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualExpenses);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualExpenses, value);
+    }
+
     public RetirementCashFlowViewModel(
         CalculatorViewModelServices services,
         IDeferredCompensationExportService exportService)
@@ -46,7 +56,6 @@ public sealed partial class RetirementCashFlowViewModel : CalculatorViewModelBas
     [ObservableProperty] private string retirementCurrentAgeText = "45";
     [ObservableProperty] private string retirementSemiAgeText = "55";
     [ObservableProperty] private string retirementPlanThroughAgeText = "90";
-    [ObservableProperty] private string retirementExpensesText = "80000";
     [ObservableProperty] private string retirementInflationText = "3";
     [ObservableProperty] private string retirementCurrentBalanceText = string.Empty;
     [ObservableProperty] private string retirementBalanceAtSemiText = string.Empty;
@@ -88,7 +97,6 @@ public sealed partial class RetirementCashFlowViewModel : CalculatorViewModelBas
     partial void OnRetirementCurrentAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnRetirementSemiAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnRetirementPlanThroughAgeTextChanged(string value) => OnDraftInputChanged();
-    partial void OnRetirementExpensesTextChanged(string value) => OnDraftInputChanged();
     partial void OnRetirementInflationTextChanged(string value) => OnDraftInputChanged();
     partial void OnWithdrawOnlyAfterRetirementChanged(bool value) => OnDraftInputChanged();
     partial void OnReinvestRetirementSurplusChanged(bool value) => OnDraftInputChanged();
@@ -176,7 +184,7 @@ public sealed partial class RetirementCashFlowViewModel : CalculatorViewModelBas
         RetirementCurrentAgeText = draft.CurrentAge.ToString(CultureInfo.CurrentCulture);
         RetirementSemiAgeText = draft.SemiRetirementAge.ToString(CultureInfo.CurrentCulture);
         RetirementPlanThroughAgeText = draft.PlanThroughAge.ToString(CultureInfo.CurrentCulture);
-        RetirementExpensesText = draft.AnnualExpenses.ToString("0.##", CultureInfo.CurrentCulture);
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, draft.AnnualExpenses, nameof(RetirementExpensesText));
         RetirementInflationText = (draft.InflationRate * 100).ToString("0.##", CultureInfo.CurrentCulture);
         WithdrawOnlyAfterRetirement = draft.WithdrawOnlyAfterRetirement;
         ReinvestRetirementSurplus = draft.ReinvestSurplus;
@@ -206,7 +214,7 @@ public sealed partial class RetirementCashFlowViewModel : CalculatorViewModelBas
             return false;
         }
 
-        if (!TryParseNonNegative(RetirementExpensesText, out var annualExpenses))
+        if (!TryGetPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, out var annualExpenses))
         {
             ValidationMessage = "Scenario: Annual retirement spending in today's dollars must be a number of zero or more.";
             return false;

--- a/app/MyFireNumber/ViewModels/ReverseFireViewModel.cs
+++ b/app/MyFireNumber/ViewModels/ReverseFireViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using SkiaSharp;
 using System.Globalization;
@@ -9,6 +10,16 @@ namespace MyFireNumber.ViewModels;
 public sealed partial class ReverseFireViewModel : CalculatorViewModelBase<ReverseFireDraft>
 {
     private readonly IReverseFireExportService exportService;
+
+    // Recurring amounts. These delegate to Core periodic fields instead of holding their own text, so
+    // the canonical amount is the single source of truth and the monthly/annual toggle only changes
+    // how it is rendered.
+
+    public string AnnualExpensesText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualExpenses);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualExpenses, value);
+    }
 
     public ReverseFireViewModel(
         CalculatorViewModelServices services,
@@ -26,9 +37,6 @@ public sealed partial class ReverseFireViewModel : CalculatorViewModelBase<Rever
 
     [ObservableProperty]
     private string currentSavingsText = string.Empty;
-
-    [ObservableProperty]
-    private string annualExpensesText = string.Empty;
 
     [ObservableProperty]
     private string expectedReturnText = string.Empty;
@@ -72,7 +80,6 @@ public sealed partial class ReverseFireViewModel : CalculatorViewModelBase<Rever
     partial void OnCurrentAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnRetirementAgeTextChanged(string value) => OnDraftInputChanged();
     partial void OnCurrentSavingsTextChanged(string value) => OnDraftInputChanged();
-    partial void OnAnnualExpensesTextChanged(string value) => OnDraftInputChanged();
     partial void OnExpectedReturnTextChanged(string value) => OnDraftInputChanged();
     partial void OnInflationRateTextChanged(string value) => OnDraftInputChanged();
     partial void OnWithdrawalRateTextChanged(string value) => OnDraftInputChanged();
@@ -82,7 +89,7 @@ public sealed partial class ReverseFireViewModel : CalculatorViewModelBase<Rever
         CurrentAgeText = draft.CurrentAge.ToString(CultureInfo.CurrentCulture);
         RetirementAgeText = draft.TargetRetirementAge.ToString(CultureInfo.CurrentCulture);
         CurrentSavingsText = FormatNumber(draft.CurrentSavings);
-        AnnualExpensesText = FormatNumber(draft.AnnualExpenses);
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, draft.AnnualExpenses, nameof(AnnualExpensesText));
         ExpectedReturnText = FormatNumber(draft.ExpectedReturn * 100);
         InflationRateText = FormatNumber(draft.InflationRate * 100);
         WithdrawalRateText = FormatNumber(draft.WithdrawalRate * 100);
@@ -108,7 +115,7 @@ public sealed partial class ReverseFireViewModel : CalculatorViewModelBase<Rever
         }
 
         if (!TryParseNonNegative(CurrentSavingsText, out var currentSavings)
-            || !TryParseNonNegative(AnnualExpensesText, out var annualExpenses))
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualExpenses, out var annualExpenses))
         {
             ValidationMessage = "Enter zero or a positive amount for each dollar value.";
             return false;

--- a/app/MyFireNumber/ViewModels/SavingsInvestmentViewModel.cs
+++ b/app/MyFireNumber/ViewModels/SavingsInvestmentViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using SkiaSharp;
 using System.Globalization;
@@ -10,6 +11,16 @@ namespace MyFireNumber.ViewModels;
 public sealed partial class SavingsInvestmentViewModel : CalculatorViewModelBase<SavingsInvestmentDraft>
 {
     private readonly ISavingsInvestmentExportService exportService;
+
+    // Recurring amounts. These delegate to Core periodic fields instead of holding their own text, so
+    // the canonical amount is the single source of truth and the monthly/annual toggle only changes
+    // how it is rendered.
+
+    public string InvestmentAnnualIncomeText
+    {
+        get => PeriodicText(PeriodicFieldCatalog.AnnualIncome);
+        set => SetPeriodicText(PeriodicFieldCatalog.AnnualIncome, value);
+    }
 
     public SavingsInvestmentViewModel(
         CalculatorViewModelServices services,
@@ -30,9 +41,6 @@ public sealed partial class SavingsInvestmentViewModel : CalculatorViewModelBase
 
     [ObservableProperty]
     private string investmentContributionText = string.Empty;
-
-    [ObservableProperty]
-    private string investmentAnnualIncomeText = string.Empty;
 
     [ObservableProperty]
     private string expectedReturnText = string.Empty;
@@ -94,7 +102,6 @@ public sealed partial class SavingsInvestmentViewModel : CalculatorViewModelBase
     partial void OnYearsInvestingTextChanged(string value) => OnDraftInputChanged();
     partial void OnStartingAmountTextChanged(string value) => OnDraftInputChanged();
     partial void OnInvestmentContributionTextChanged(string value) => OnDraftInputChanged();
-    partial void OnInvestmentAnnualIncomeTextChanged(string value) => OnDraftInputChanged();
     partial void OnExpectedReturnTextChanged(string value) => OnDraftInputChanged();
     partial void OnInflationRateTextChanged(string value) => OnDraftInputChanged();
     partial void OnContributionFrequencyChanged(ContributionFrequency value) => OnDraftInputChanged();
@@ -115,7 +122,7 @@ public sealed partial class SavingsInvestmentViewModel : CalculatorViewModelBase
         YearsInvestingText = draft.YearsInvesting.ToString(CultureInfo.CurrentCulture);
         ExpectedReturnText = FormatNumber(draft.ExpectedReturn * 100);
         InflationRateText = FormatNumber(draft.InflationRate * 100);
-        InvestmentAnnualIncomeText = FormatNumber(draft.AnnualIncome);
+        LoadPeriodicValue(PeriodicFieldCatalog.AnnualIncome, draft.AnnualIncome, nameof(InvestmentAnnualIncomeText));
         CurrentAgeText = draft.CurrentAge.ToString(CultureInfo.CurrentCulture);
     }
 
@@ -136,7 +143,7 @@ public sealed partial class SavingsInvestmentViewModel : CalculatorViewModelBase
 
         if (!TryParseNonNegative(StartingAmountText, out var startingAmount)
             || !TryParseNonNegative(InvestmentContributionText, out var contributionAmount)
-            || !TryParseNonNegative(InvestmentAnnualIncomeText, out var annualIncome))
+            || !TryGetPeriodicValue(PeriodicFieldCatalog.AnnualIncome, out var annualIncome))
         {
             ValidationMessage = "Enter zero or a positive amount for each dollar value.";
             return false;

--- a/app/MyFireNumber/Views/BaristaFirePage.xaml
+++ b/app/MyFireNumber/Views/BaristaFirePage.xaml
@@ -31,12 +31,13 @@
             <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
                 <VerticalStackLayout Spacing="14">
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Your starting point" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Barista FIRE values to their defaults." /></Grid>
+                    <controls:PeriodToggleView />
                     <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Current savings" HelpText="Invested assets available for this goal, in dollars." Placeholder="100000" Text="{Binding CurrentSavingsText}" />
-                        <controls:NumericInputView Grid.Row="1" Header="Annual retirement expenses" HelpText="Expected annual spending, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" />
-                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="Annual after-tax part-time take-home income" HelpText="Expected annual take-home pay after taxes while in the Barista FIRE phase, in dollars." Placeholder="20000" Text="{Binding PartTimeAnnualIncomeText}" />
-                        <controls:NumericInputView Grid.Row="2" Grid.ColumnSpan="2" Header="Annual contribution" HelpText="How much you expect to invest each year before changing work." Placeholder="24000" Text="{Binding AnnualContributionText}" />
+                        <controls:NumericInputView Grid.Row="1" Header="Retirement expenses" HelpText="Expected spending, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
+                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="After-tax part-time take-home income" HelpText="Expected take-home pay after taxes while in the Barista FIRE phase, in dollars." Placeholder="20000" Text="{Binding PartTimeAnnualIncomeText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
+                        <controls:NumericInputView Grid.Row="2" Grid.ColumnSpan="2" Header="Contribution" HelpText="How much you expect to invest before changing work." Placeholder="24000" Text="{Binding AnnualContributionText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
                         <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">

--- a/app/MyFireNumber/Views/CoastFirePage.xaml
+++ b/app/MyFireNumber/Views/CoastFirePage.xaml
@@ -36,12 +36,13 @@
                         <Label Text="Your starting point" Style="{StaticResource CalculatorSectionHeading}" />
                         <Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Coast FIRE values to their defaults." />
                     </Grid>
+                    <controls:PeriodToggleView />
                     <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Retirement age" HelpText="The age when your portfolio should be ready to fund retirement." Placeholder="55" Text="{Binding RetirementAgeText}" />
                         <controls:NumericInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Current savings" HelpText="Invested assets available for this goal, in dollars." Placeholder="100000" Text="{Binding CurrentSavingsText}" />
-                        <controls:NumericInputView Grid.Row="2" Header="Annual contribution" HelpText="How much you expect to invest each year, in dollars." Placeholder="24000" Text="{Binding AnnualContributionText}" />
-                        <controls:NumericInputView Grid.Row="2" Grid.Column="1" Header="Annual retirement expenses" HelpText="Expected annual spending after retirement, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" />
+                        <controls:NumericInputView Grid.Row="2" Header="Contribution" HelpText="How much you expect to invest, in dollars." Placeholder="24000" Text="{Binding AnnualContributionText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
+                        <controls:NumericInputView Grid.Row="2" Grid.Column="1" Header="Retirement expenses" HelpText="Expected spending after retirement, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
                         <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">

--- a/app/MyFireNumber/Views/Controls/NumericInputView.xaml
+++ b/app/MyFireNumber/Views/Controls/NumericInputView.xaml
@@ -1,20 +1,30 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:MyFireNumber.Views.Controls"
              x:Class="MyFireNumber.Views.Controls.NumericInputView"
              x:Name="Root">
     <Grid RowDefinitions="Auto,Auto"
           RowSpacing="4">
-        <local:FieldHelpView xmlns:local="clr-namespace:MyFireNumber.Views.Controls"
-                             Header="{Binding Header, Source={x:Reference Root}}"
+        <local:FieldHelpView Header="{Binding DisplayHeader, Source={x:Reference Root}}"
                              HelpText="{Binding HelpText, Source={x:Reference Root}}" />
-        <Entry Grid.Row="1"
-               Text="{Binding Text, Source={x:Reference Root}, Mode=TwoWay}"
-               Placeholder="{Binding Placeholder, Source={x:Reference Root}}"
-               Keyboard="Numeric"
-               Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
-               TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
-               PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
-               SemanticProperties.Description="{Binding HelpText, Source={x:Reference Root}}" />
+        <Grid Grid.Row="1"
+              ColumnDefinitions="*,Auto"
+              ColumnSpacing="6">
+            <Entry Text="{Binding Text, Source={x:Reference Root}, Mode=TwoWay}"
+                   Placeholder="{Binding Placeholder, Source={x:Reference Root}}"
+                   Keyboard="Numeric"
+                   Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                   TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
+                   PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
+                   SemanticProperties.Description="{Binding HelpText, Source={x:Reference Root}}" />
+            <Label Grid.Column="1"
+                   Text="{Binding PeriodSuffix, Source={x:Reference Root}}"
+                   IsVisible="{Binding HasPeriodSuffix, Source={x:Reference Root}}"
+                   VerticalTextAlignment="Center"
+                   FontAttributes="Bold"
+                   TextColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
+                   SemanticProperties.Description="{Binding PeriodSuffixDescription, Source={x:Reference Root}}" />
+        </Grid>
     </Grid>
 </ContentView>

--- a/app/MyFireNumber/Views/Controls/NumericInputView.xaml.cs
+++ b/app/MyFireNumber/Views/Controls/NumericInputView.xaml.cs
@@ -2,11 +2,23 @@ namespace MyFireNumber.Views.Controls;
 
 public partial class NumericInputView : ContentView
 {
-    public static readonly BindableProperty HeaderProperty = BindableProperty.Create(nameof(Header), typeof(string), typeof(NumericInputView), string.Empty);
+    public static readonly BindableProperty HeaderProperty = BindableProperty.Create(
+        nameof(Header), typeof(string), typeof(NumericInputView), string.Empty, propertyChanged: OnHeaderPartChanged);
 
     public static readonly BindableProperty HelpTextProperty = BindableProperty.Create(nameof(HelpText), typeof(string), typeof(NumericInputView), string.Empty);
 
     public static readonly BindableProperty PlaceholderProperty = BindableProperty.Create(nameof(Placeholder), typeof(string), typeof(NumericInputView), string.Empty);
+
+    /// <summary>
+    /// Appended to the label when this field holds a recurring amount, e.g. <c>per month</c>. Bound to
+    /// the view model's display period so the label always says which period the number is in.
+    /// </summary>
+    public static readonly BindableProperty PeriodQualifierProperty = BindableProperty.Create(
+        nameof(PeriodQualifier), typeof(string), typeof(NumericInputView), string.Empty, propertyChanged: OnHeaderPartChanged);
+
+    /// <summary>Short marker shown beside the entry, e.g. <c>/mo</c>.</summary>
+    public static readonly BindableProperty PeriodSuffixProperty = BindableProperty.Create(
+        nameof(PeriodSuffix), typeof(string), typeof(NumericInputView), string.Empty, propertyChanged: OnPeriodSuffixChanged);
 
     public static readonly BindableProperty TextProperty = BindableProperty.Create(
         nameof(Text),
@@ -38,9 +50,45 @@ public partial class NumericInputView : ContentView
         set => SetValue(PlaceholderProperty, value);
     }
 
+    public string PeriodQualifier
+    {
+        get => (string)GetValue(PeriodQualifierProperty);
+        set => SetValue(PeriodQualifierProperty, value);
+    }
+
+    public string PeriodSuffix
+    {
+        get => (string)GetValue(PeriodSuffixProperty);
+        set => SetValue(PeriodSuffixProperty, value);
+    }
+
     public string Text
     {
         get => (string)GetValue(TextProperty);
         set => SetValue(TextProperty, value);
+    }
+
+    /// <summary>The label actually rendered, e.g. <c>Contribution (per month)</c>.</summary>
+    public string DisplayHeader => string.IsNullOrWhiteSpace(PeriodQualifier)
+        ? Header
+        : $"{Header} ({PeriodQualifier})";
+
+    public bool HasPeriodSuffix => !string.IsNullOrWhiteSpace(PeriodSuffix);
+
+    /// <summary>Screen readers should hear the period, not the "/mo" punctuation.</summary>
+    public string PeriodSuffixDescription => string.IsNullOrWhiteSpace(PeriodQualifier)
+        ? string.Empty
+        : $"Amount is {PeriodQualifier}";
+
+    private static void OnHeaderPartChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        var view = (NumericInputView)bindable;
+        view.OnPropertyChanged(nameof(DisplayHeader));
+        view.OnPropertyChanged(nameof(PeriodSuffixDescription));
+    }
+
+    private static void OnPeriodSuffixChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        ((NumericInputView)bindable).OnPropertyChanged(nameof(HasPeriodSuffix));
     }
 }

--- a/app/MyFireNumber/Views/Controls/PeriodToggleView.xaml
+++ b/app/MyFireNumber/Views/Controls/PeriodToggleView.xaml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:MyFireNumber.Views.Controls"
+             x:Class="MyFireNumber.Views.Controls.PeriodToggleView"
+             x:Name="Root"
+             IsVisible="{Binding HasPeriodicFields}">
+    <VerticalStackLayout Spacing="6">
+        <controls:FieldHelpView Header="Show recurring amounts as"
+                                HelpText="Switches how recurring dollar amounts are displayed. This does not change any result — the same amount is used either way." />
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+            <Button Text="Monthly"
+                    Command="{Binding SetDisplayPeriodCommand}"
+                    CommandParameter="Monthly"
+                    Background="{StaticResource Secondary}"
+                    TextColor="{StaticResource PrimaryDarkText}"
+                    SemanticProperties.Description="Show recurring amounts per month. Results do not change.">
+                <Button.Triggers>
+                    <DataTrigger TargetType="Button" Binding="{Binding IsMonthlyDisplay}" Value="True">
+                        <Setter Property="Background" Value="{StaticResource Primary}" />
+                        <Setter Property="TextColor" Value="{StaticResource White}" />
+                    </DataTrigger>
+                </Button.Triggers>
+            </Button>
+            <Button Grid.Column="1"
+                    Text="Annual"
+                    Command="{Binding SetDisplayPeriodCommand}"
+                    CommandParameter="Annual"
+                    Background="{StaticResource Secondary}"
+                    TextColor="{StaticResource PrimaryDarkText}"
+                    SemanticProperties.Description="Show recurring amounts per year. Results do not change.">
+                <Button.Triggers>
+                    <DataTrigger TargetType="Button" Binding="{Binding IsAnnualDisplay}" Value="True">
+                        <Setter Property="Background" Value="{StaticResource Primary}" />
+                        <Setter Property="TextColor" Value="{StaticResource White}" />
+                    </DataTrigger>
+                </Button.Triggers>
+            </Button>
+        </Grid>
+    </VerticalStackLayout>
+</ContentView>

--- a/app/MyFireNumber/Views/Controls/PeriodToggleView.xaml.cs
+++ b/app/MyFireNumber/Views/Controls/PeriodToggleView.xaml.cs
@@ -1,0 +1,17 @@
+namespace MyFireNumber.Views.Controls;
+
+/// <summary>
+/// Switches whether a calculator's recurring dollar amounts are shown per month or per year.
+/// </summary>
+/// <remarks>
+/// Display only. The calculator keeps using the same canonical amount whichever way it is shown, which
+/// is what separates this from the contribution frequency toggle on the Savings &amp; Investment page —
+/// that one selects between two different formulas. Both appear on that page together.
+/// </remarks>
+public partial class PeriodToggleView : ContentView
+{
+    public PeriodToggleView()
+    {
+        InitializeComponent();
+    }
+}

--- a/app/MyFireNumber/Views/FireNumberPage.xaml
+++ b/app/MyFireNumber/Views/FireNumberPage.xaml
@@ -88,6 +88,7 @@
                                 FontSize="12"
                                 SemanticProperties.Description="Reset this calculator to its defaults." />
                     </Grid>
+                    <controls:PeriodToggleView />
                     <VerticalStackLayout IsVisible="{Binding IsStandardFire}" Spacing="4">
                         <controls:FieldHelpView Header="Quick preset"
                                                 HelpText="A preset replaces all assumptions with a common starting point. You can still edit every value below." />
@@ -112,22 +113,22 @@
                                                    Placeholder="100000"
                                                    Text="{Binding CurrentSavingsText}" />
                         <controls:NumericInputView Grid.Row="1"
-                                                   Header="Annual contribution"
-                                                   HelpText="How much you add to investments each year, in dollars."
+                                                   Header="Contribution"
+                                                   HelpText="How much you add to investments, in dollars."
                                                    Placeholder="24000"
-                                                   Text="{Binding AnnualContributionText}" />
+                                                   Text="{Binding AnnualContributionText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                         <controls:NumericInputView Grid.Row="1"
                                                    Grid.Column="1"
-                                                   Header="Annual after-tax take-home income"
-                                                   HelpText="Annual income after taxes, used to calculate your savings rate."
+                                                   Header="After-tax take-home income"
+                                                   HelpText="Income after taxes, used to calculate your savings rate."
                                                    Placeholder="72000"
-                                                   Text="{Binding AnnualIncomeText}" />
+                                                   Text="{Binding AnnualIncomeText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                         <controls:NumericInputView Grid.Row="2"
                                                    Grid.ColumnSpan="2"
-                                                   Header="Annual retirement expenses"
-                                                   HelpText="Estimated annual spending after leaving full-time work, in today’s dollars."
+                                                   Header="Retirement expenses"
+                                                   HelpText="Estimated spending after leaving full-time work, in today’s dollars."
                                                    Placeholder="48000"
-                                                   Text="{Binding AnnualExpensesText}" />
+                                                   Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
                         <VerticalStackLayout Margin="0,12,0,0" Spacing="12">

--- a/app/MyFireNumber/Views/HealthcareGapPage.xaml
+++ b/app/MyFireNumber/Views/HealthcareGapPage.xaml
@@ -25,22 +25,23 @@
 
             <controls:CalculatorInfoView Title="What is the healthcare gap?"
                                          Summary="Estimate health insurance costs between early retirement and Medicare eligibility."
-                                         Details="Leaving employer coverage before Medicare can create a major retirement expense. This estimate includes premiums, deductibles, out-of-pocket costs, and medical inflation. Premiums are entered monthly; deductibles and out-of-pocket costs are entered annually. It does not estimate ACA premium tax credits, which depend on household size and the federal poverty level."
+                                         Details="Leaving employer coverage before Medicare can create a major retirement expense. This estimate includes premiums, deductibles, out-of-pocket costs, and medical inflation. It does not estimate ACA premium tax credits, which depend on household size and the federal poverty level."
                                          IconGlyph="&#xf0f9;" />
 
             <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
                 <VerticalStackLayout Spacing="14">
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Coverage basics" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Healthcare Gap values to their defaults." /></Grid>
+                    <controls:PeriodToggleView />
                     <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding HealthcareCurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Retire at age" HelpText="The age when employer health coverage ends." Placeholder="55" Text="{Binding EarlyRetirementAgeText}" />
-                        <controls:NumericInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Monthly health insurance premium" HelpText="Expected monthly health insurance premium, in dollars." Placeholder="600" Text="{Binding MonthlyPremiumText}" />
+                        <controls:NumericInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Health insurance premium" HelpText="Expected health insurance premium, in dollars." Placeholder="600" Text="{Binding MonthlyPremiumText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
                         <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
                             <controls:NumericInputView Header="Medicare age" HelpText="The expected age when Medicare coverage begins." Placeholder="65" Text="{Binding MedicareAgeText}" />
-                            <controls:NumericInputView Grid.Column="1" Header="Annual deductible" HelpText="Expected annual deductible, in dollars." Placeholder="2500" Text="{Binding AnnualDeductibleText}" />
-                            <controls:NumericInputView Grid.Row="1" Header="Annual out-of-pocket costs" HelpText="Expected annual medical costs beyond premiums and deductibles, in dollars." Placeholder="2000" Text="{Binding AnnualOutOfPocketText}" />
+                            <controls:NumericInputView Grid.Column="1" Header="Deductible" HelpText="Expected deductible, in dollars." Placeholder="2500" Text="{Binding AnnualDeductibleText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
+                            <controls:NumericInputView Grid.Row="1" Header="Out-of-pocket costs" HelpText="Expected medical costs beyond premiums and deductibles, in dollars." Placeholder="2000" Text="{Binding AnnualOutOfPocketText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                             <controls:PercentageInputView Grid.Row="1" Grid.Column="1" Header="Medical inflation (%)" HelpText="Expected annual increase in medical costs." Placeholder="3" Minimum="0" Maximum="10" Text="{Binding InflationRateText}" />
                         </Grid>
                     </controls:AdvancedAssumptionsExpander>

--- a/app/MyFireNumber/Views/RetirementCashFlowPage.xaml
+++ b/app/MyFireNumber/Views/RetirementCashFlowPage.xaml
@@ -43,11 +43,12 @@
                 <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
                     <VerticalStackLayout Spacing="12">
                         <Label Text="Scenario" Style="{StaticResource CalculatorSectionHeading}" />
+                        <controls:PeriodToggleView />
                         <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
                             <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="45" Text="{Binding RetirementCurrentAgeText}" />
                             <controls:NumericInputView Grid.Column="1" Header="Semi-retirement age" HelpText="The age when your plan changes from full-time work." Placeholder="55" Text="{Binding RetirementSemiAgeText}" />
                         </Grid>
-                        <controls:NumericInputView Header="Annual retirement expenses" HelpText="Expected annual retirement spending, in today’s dollars." Placeholder="80000" Text="{Binding RetirementExpensesText}" />
+                        <controls:NumericInputView Header="Retirement expenses" HelpText="Expected retirement spending, in today’s dollars." Placeholder="80000" Text="{Binding RetirementExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                         <controls:AdvancedAssumptionsExpander>
                             <VerticalStackLayout Margin="0,12,0,0" Spacing="12">
                                 <Grid ColumnDefinitions="*,*" ColumnSpacing="12">

--- a/app/MyFireNumber/Views/ReverseFirePage.xaml
+++ b/app/MyFireNumber/Views/ReverseFirePage.xaml
@@ -31,11 +31,12 @@
             <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
                 <VerticalStackLayout Spacing="14">
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Your FIRE goal" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Reverse FIRE values to their defaults." /></Grid>
+                    <controls:PeriodToggleView />
                     <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Target FIRE age" HelpText="The age at which you want to be financially independent." Placeholder="55" Text="{Binding RetirementAgeText}" />
                         <controls:NumericInputView Grid.Row="1" Header="Current savings" HelpText="Invested assets available for this goal, in dollars." Placeholder="100000" Text="{Binding CurrentSavingsText}" />
-                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="Annual retirement expenses" HelpText="Expected annual spending after retirement, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" />
+                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="Retirement expenses" HelpText="Expected spending after retirement, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
                         <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">

--- a/app/MyFireNumber/Views/SavingsInvestmentPage.xaml
+++ b/app/MyFireNumber/Views/SavingsInvestmentPage.xaml
@@ -31,11 +31,12 @@
             <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
                 <VerticalStackLayout Spacing="14">
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Your investment details" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Savings and Investment Rate values to their defaults." /></Grid>
+                    <controls:PeriodToggleView />
                     <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Years investing" HelpText="How long contributions and growth should be modeled." Placeholder="30" Text="{Binding YearsInvestingText}" />
                         <controls:NumericInputView Grid.Row="1" Header="Starting amount" HelpText="Current invested balance, in dollars." Placeholder="100000" Text="{Binding StartingAmountText}" />
-                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="Annual after-tax take-home income" HelpText="Yearly income after taxes, used to calculate the savings rate, in dollars." Placeholder="72000" Text="{Binding InvestmentAnnualIncomeText}" />
+                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="After-tax take-home income" HelpText="Income after taxes, used to calculate the savings rate, in dollars." Placeholder="72000" Text="{Binding InvestmentAnnualIncomeText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <VerticalStackLayout Spacing="6">
                         <controls:FieldHelpView Header="Contribution frequency" HelpText="Choose whether the contribution amount represents a monthly or yearly amount." />

--- a/shared/parity/README.md
+++ b/shared/parity/README.md
@@ -103,3 +103,50 @@ so a missing one throws, rather than defaulting and quietly testing a different 
 
 Editing this file triggers both CI jobs in `.github/workflows/tests.yml`; the path filters are there
 so a fixture change cannot land without re-running both suites.
+
+---
+
+# `periodic-fields.json`
+
+A second artifact in this directory, pinning a **policy** rather than a set of numbers: which currency
+inputs are recurring amounts, and which period each one is canonically stored in.
+
+- Web reads it from `web/src/utils/__tests__/periodicFieldInventory.test.ts`.
+- MAUI reads it from `app/MyFireNumber.Tests/Presentation/SharedPeriodicFieldInventoryTests.cs`.
+
+## Why a policy belongs here when conversion arithmetic does not
+
+The monthly/annual toggle is display-only: a recurring amount is stored in one canonical period, every
+calculation runs on the canonical value, and the other period is produced at the display edge. So
+there is no cross-platform *number* to pin — and a case asserting `50000 / 12 = 4166.67` would be the
+screenshot test this README forbids, because that identity is the implementation restated rather than
+an independent oracle. Conversion behaviour is pinned per platform instead, against a
+lossless-round-trip invariant the implementation can actually fail.
+
+What *is* shared, and what review alone was previously holding, is the inventory. Almost every field is
+canonically annual, but the healthcare premium is canonically monthly. A mechanism that assumed all
+fields were annual would read a $600 premium as $50 a month — wrong by 144x, silently, and identically
+plausible on screen. That makes the policy distinguishable from its alternative, which is the bar this
+directory sets for being worth pinning.
+
+It also covers a gap neither suite can reach on its own: `MyFireNumber.Tests` cannot reference the MAUI
+single-project, so no unit test can prove a XAML `Entry` is bound to a period-aware field. A field made
+periodic on one platform and forgotten on the other is invisible to both suites unless something
+outside both of them holds the list.
+
+## Shape
+
+Every shipped calculator appears, including those with **no** periodic fields, which declare an empty
+list rather than being omitted — absence is indistinguishable from an oversight. `webPage` names the
+`.tsx` the web scan reads, since MAUI's three FIRE variants share one page while web gives each its own.
+
+Both consumers additionally assert the inventory is not silently empty, so an artifact that failed to
+load cannot make an empty list agree with an empty list and report success.
+
+## Adding a field
+
+1. Add it to the calculator's `fields`, with the period the value is actually stored in.
+2. Web: pass `periodic` (and `storedPeriod="monthly"` when it is not annual) to that `CurrencyInput`.
+3. MAUI: declare it in `PeriodicFieldCatalog`, route the view model's text property through
+   `PeriodicText`/`SetPeriodicText`, and bind `PeriodQualifier`/`PeriodSuffix` on the page.
+4. Run `npm test` in `web/` **and** `dotnet test app/MyFireNumber.Tests`. Both must pass.

--- a/shared/parity/periodic-fields.json
+++ b/shared/parity/periodic-fields.json
@@ -1,0 +1,95 @@
+{
+  "policy": "Which currency inputs are recurring amounts, and which period each one is stored in.",
+  "why": [
+    "A recurring amount is stored in exactly one canonical period and every calculation runs on that canonical value; showing it in the other period divides or multiplies by 12 at the display edge only.",
+    "Almost every field is canonically annual, but the healthcare premium is canonically monthly. A mechanism that assumed all fields were annual would read a $600 premium as $50 a month and a $7,200 one as $600 -- wrong by 144x, silently, on both platforms.",
+    "That is why this file lists a per-field storedPeriod rather than a flat list of field names: the policy has to be distinguishable from its plausible alternative to be worth pinning.",
+    "No conversion arithmetic is pinned here. '50000 / 12 = 4166.67' is not an independent oracle, it is the implementation restated, which is the screenshot test this directory's README forbids. Behaviour is pinned in each platform's own suite instead."
+  ],
+  "storedPeriodValues": ["annual", "monthly"],
+  "calculators": [
+    {
+      "id": "standard-fire",
+      "webPage": "StandardFIRE.tsx",
+      "fields": [
+        { "key": "annualContribution", "storedPeriod": "annual" },
+        { "key": "annualIncome", "storedPeriod": "annual" },
+        { "key": "annualExpenses", "storedPeriod": "annual" }
+      ]
+    },
+    {
+      "id": "lean-fire",
+      "webPage": "LeanFIRE.tsx",
+      "fields": [
+        { "key": "annualContribution", "storedPeriod": "annual" },
+        { "key": "annualIncome", "storedPeriod": "annual" },
+        { "key": "annualExpenses", "storedPeriod": "annual" }
+      ]
+    },
+    {
+      "id": "fat-fire",
+      "webPage": "FatFIRE.tsx",
+      "fields": [
+        { "key": "annualContribution", "storedPeriod": "annual" },
+        { "key": "annualIncome", "storedPeriod": "annual" },
+        { "key": "annualExpenses", "storedPeriod": "annual" }
+      ]
+    },
+    {
+      "id": "coast-fire",
+      "webPage": "CoastFIRE.tsx",
+      "fields": [
+        { "key": "annualContribution", "storedPeriod": "annual" },
+        { "key": "annualExpenses", "storedPeriod": "annual" }
+      ]
+    },
+    {
+      "id": "barista-fire",
+      "webPage": "BaristaFIRE.tsx",
+      "fields": [
+        { "key": "annualContribution", "storedPeriod": "annual" },
+        { "key": "annualExpenses", "storedPeriod": "annual" },
+        { "key": "partTimeIncome", "storedPeriod": "annual" }
+      ]
+    },
+    {
+      "id": "reverse-fire",
+      "webPage": "ReverseFIRE.tsx",
+      "fields": [{ "key": "annualExpenses", "storedPeriod": "annual" }]
+    },
+    {
+      "id": "savings-rate",
+      "webPage": "SavingsRate.tsx",
+      "note": "savingsContribution is deliberately absent. Its monthly/yearly control is an input frequency that selects between two different formulas, not a display period, so it must not be routed through this mechanism.",
+      "fields": [{ "key": "annualIncome", "storedPeriod": "annual" }]
+    },
+    {
+      "id": "healthcare-gap",
+      "webPage": "HealthcareGap.tsx",
+      "note": "A 'monthly deductible' is semantically odd, since a deductible is an annual cap. Web makes it periodic anyway and this is display-only arithmetic, so both platforms mirror it deliberately: silent divergence between the platforms would be worse than a slightly odd unit.",
+      "fields": [
+        { "key": "healthcareMonthlyPremium", "storedPeriod": "monthly" },
+        { "key": "healthcareAnnualDeductible", "storedPeriod": "annual" },
+        { "key": "healthcareAnnualOutOfPocket", "storedPeriod": "annual" }
+      ]
+    },
+    {
+      "id": "retirement-cash-flow",
+      "webPage": "DeferredCompensation.tsx",
+      "note": "Named retirement-cash-flow on MAUI and DeferredCompensation on web. Per-account contributions are not periodic on either platform.",
+      "fields": [{ "key": "annualExpenses", "storedPeriod": "annual" }]
+    },
+    {
+      "id": "withdrawal-rate",
+      "webPage": "WithdrawalRate.tsx",
+      "note": "Declared with no periodic fields rather than omitted. Absence would be indistinguishable from an oversight, and the monthly withdrawal it displays is a derived result, which neither platform makes switchable.",
+      "fields": []
+    },
+    {
+      "id": "debt-payoff",
+      "webPage": "DebtPayoff.tsx",
+      "note": "Declared with no periodic fields rather than omitted. Its budget and payment inputs are genuinely monthly because the amortization steps monthly, so they are fixed units and not a display choice.",
+      "fields": []
+    }
+  ]
+}

--- a/web/src/utils/__tests__/periodicFieldInventory.test.ts
+++ b/web/src/utils/__tests__/periodicFieldInventory.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+
+import inventory from '../../../../shared/parity/periodic-fields.json'
+
+import { PAGE_SOURCES, blankOutCommentsAndStrings, pageFileName } from './pageSources'
+
+/**
+ * Pins the web pages to `shared/parity/periodic-fields.json`, the same file
+ * `app/MyFireNumber.Tests/Presentation/SharedPeriodicFieldInventoryTests.cs` reads.
+ *
+ * Adds no runtime code and changes no behaviour. It exists because "web and MAUI agree about which
+ * amounts are recurring" was otherwise enforced by review alone, and the MAUI side cannot check its
+ * own XAML from a unit test at all — its test project cannot reference the MAUI single-project. A
+ * field made periodic on one platform and forgotten on the other is invisible to both suites unless
+ * something outside both of them holds the list.
+ *
+ * The scan reuses `blankOutCommentsAndStrings` and `PAGE_SOURCES` from `pageSources.ts` rather than
+ * parsing pages a second way. That module was extracted for exactly this in #74, and #73 records why:
+ * a second parser is a second set of blind spots, and the two drift.
+ */
+
+interface SharedField {
+  key: string
+  storedPeriod: string
+}
+
+interface SharedCalculator {
+  id: string
+  webPage: string
+  fields: SharedField[]
+}
+
+const CALCULATORS = inventory.calculators as SharedCalculator[]
+
+/**
+ * The `<CurrencyInput …/>` elements on one page, as raw source text.
+ *
+ * Throws when an element is unterminated rather than returning the ones found so far. A scan that
+ * quietly returns a shorter list is the failure this whole file is trying to prevent: it would still
+ * report success, over fields nobody checked.
+ */
+function currencyInputElements(fileName: string, source: string): Array<{ blanked: string; raw: string }> {
+  const blanked = blankOutCommentsAndStrings(source)
+  const elements: Array<{ blanked: string; raw: string }> = []
+  const opening = '<CurrencyInput'
+
+  let from = 0
+  for (;;) {
+    const start = blanked.indexOf(opening, from)
+    if (start === -1) break
+
+    let depth = 0
+    let end = -1
+    for (let i = start; i < blanked.length; i += 1) {
+      const char = blanked[i]
+      if (char === '{') depth += 1
+      else if (char === '}') depth -= 1
+      else if (depth === 0 && char === '/' && blanked[i + 1] === '>') {
+        end = i + 2
+        break
+      }
+    }
+
+    if (end === -1) {
+      throw new Error(
+        `${fileName}: a <CurrencyInput> starting at offset ${start} is never closed. ` +
+          'Refusing to report a partial field list.',
+      )
+    }
+
+    elements.push({ blanked: blanked.slice(start, end), raw: source.slice(start, end) })
+    from = end
+  }
+
+  return elements
+}
+
+/** The periodic fields one page declares, as `key:storedPeriod`, sorted. */
+function scanPeriodicFields(fileName: string, source: string): string[] {
+  const found: string[] = []
+
+  for (const element of currencyInputElements(fileName, source)) {
+    // `periodic` is a bare boolean prop; `storedPeriod` must not match it.
+    if (!/\bperiodic\b/.test(element.blanked)) continue
+
+    const key = /value=\{params\.(\w+)\}/.exec(element.blanked)?.[1]
+    if (!key) {
+      throw new Error(
+        `${fileName}: a periodic <CurrencyInput> has no value={params.…} binding, so its field name ` +
+          `cannot be determined. Element: ${element.raw.slice(0, 120)}`,
+      )
+    }
+
+    // The prop's value is a string literal, so it survives only in the unblanked source.
+    const storedPeriod = /storedPeriod="(\w+)"/.exec(element.raw)?.[1] ?? 'annual'
+    found.push(`${key}:${storedPeriod}`)
+  }
+
+  return found.sort()
+}
+
+function sourceFor(webPage: string): string {
+  const path = Object.keys(PAGE_SOURCES).find(candidate => pageFileName(candidate) === webPage)
+  if (!path) throw new Error(`No page source for '${webPage}' named in periodic-fields.json.`)
+  return PAGE_SOURCES[path]
+}
+
+describe('shared periodic field inventory', () => {
+  it.each(CALCULATORS.map(calculator => [calculator.webPage, calculator] as const))(
+    '%s declares the shared periodic fields in the shared periods',
+    (webPage, calculator) => {
+      const expected = calculator.fields.map(field => `${field.key}:${field.storedPeriod}`).sort()
+
+      expect(scanPeriodicFields(webPage, sourceFor(webPage))).toEqual(expected)
+    },
+  )
+
+  it('names every page that uses the period mechanism', () => {
+    // Enumerated from the pages themselves, not from a count. A tenth page gaining a periodic field
+    // fails here instead of passing quietly, which `expect(pages.length).toBe(9)` would not do.
+    const usesMechanism = Object.entries(PAGE_SOURCES)
+      .filter(([, source]) => /\bperiodic\b|CurrencyPeriodProvider/.test(blankOutCommentsAndStrings(source)))
+      .map(([path]) => pageFileName(path))
+      .sort()
+
+    const named = CALCULATORS.map(calculator => calculator.webPage).sort()
+
+    expect(named).toEqual(expect.arrayContaining(usesMechanism))
+  })
+
+  it('is not silently empty', () => {
+    // Guards the guard. If the artifact failed to load, or the scanner matched nothing, every
+    // comparison above would be an empty array equalling an empty array — indistinguishable from
+    // success. These are the two facts that give the comparisons their meaning.
+    expect(CALCULATORS.flatMap(calculator => calculator.fields).length).toBeGreaterThan(0)
+    expect(
+      CALCULATORS.flatMap(calculator => calculator.fields).filter(field => field.storedPeriod === 'monthly'),
+    ).not.toHaveLength(0)
+  })
+
+  it('reads fields past a comment or a string holding an unbalanced brace', () => {
+    // The ways the scan could give up early and silently report a shorter list.
+    const hostile = [
+      'export default function Hostile() {',
+      '  return (',
+      '    <CurrencyPeriodProvider>',
+      "      <CurrencyInput label='spend {A' value={params.annualExpenses} periodic />",
+      '      {/* <CurrencyInput value={params.ignoredByComment} periodic /> */}',
+      '      <CurrencyInput label="premium" value={params.healthcareMonthlyPremium} periodic storedPeriod="monthly" />',
+      '    </CurrencyPeriodProvider>',
+      '  )',
+      '}',
+    ].join('\n')
+
+    expect(scanPeriodicFields('Hostile.tsx', hostile)).toEqual([
+      'annualExpenses:annual',
+      'healthcareMonthlyPremium:monthly',
+    ])
+  })
+
+  it('throws rather than truncating when an element is never closed', () => {
+    const truncated = '<CurrencyInput value={params.annualExpenses} periodic'
+
+    expect(() => scanPeriodicFields('Truncated.tsx', truncated)).toThrow(/never closed/)
+  })
+})


### PR DESCRIPTION
Brings the MAUI app to parity with the web app's monthly/annual **display** toggle, and pins the field inventory across both platforms so they cannot drift apart again.

Closes the last item from the cross-platform calculator audit.

## What this is — and what it deliberately is not

There are two different "period" concepts in this codebase and conflating them would be a bug:

1. **Semantic frequency that changes the math** — web `savingsFrequency`, MAUI `ContributionFrequency`. Already exists on both platforms. **Untouched here.**
2. **Presentation-only display period** — `currencyPeriod.ts` + `PeriodToggle` on web. Absent from MAUI. **This is what was added.**

Scope is defined by a reviewer-checkable rule: *a MAUI field is in scope iff the web page has a `periodic` field there.* That resolves to **7 MAUI pages / 14 fields** against web's 9 calculators / 20 fields — MAUI has no Lean or Fat page, they are variants inside `FireNumberPage`.

Result labels were explicitly **excluded**: the web app does not toggle results, so adding toggles there would manufacture divergence rather than remove it.

## Canonical storage is per-field, not uniformly annual

`HealthcareMonthlyPremium` is stored **monthly**; everything else is annual. Treating storage as uniformly annual would have made the healthcare gap wrong by a factor of 144.

## The drift problem

Displayed figures are rounded for readability, so a naive toggle corrupts stored data just by being looked at: $50,000/yr displays as $4,166.67/mo, and $4,166.67 × 12 is **$50,000.04**. `ResolveEditedAmount` returns the stored value untouched when the typed amount matches the display to the cent, so the round trip is lossless.

## Round-half-up, matching JavaScript

```
value    JS Math.round    C# default (banker's)    C# AwayFromZero
  0.5          1                   0                     1
  2.5          3                   2                     3
  4.5          5                   4                     5
 -0.5         -0                  -0                    -1
 -1.5         -1                  -2                    -2
```

**Neither C# mode matches JS.** The default diverges on *positive* midpoints — every even boundary, which is exactly where currency lives. Pairing C# `AwayFromZero` with JS `Math.round` is what shipped as #63, so this repo has already paid for getting it wrong once. The midpoint table is pinned in **both** directions.

Implemented by comparing the fraction rather than as `Math.Floor(x + 0.5)`: the naive form disagrees with JS at `0.49999999999999994`, where the addition itself rounds up to exactly 1. Pinned by test.

`RoundHalfUp(-0.5)` returns **positive** zero here (`Math.Floor(-0.5)` is `-1.0`, and IEEE-754 addition of exact opposites yields `+0.0`), one step safer than the JS original, which would render as the string `"-0"` in an entry. Pinned with `double.IsNegative` because `-0.0 == 0.0` makes `Assert.Equal` blind to it.

## Why the round-trip tests are not vacuous

The obvious test — toggle N times, assert the stored value is unchanged — **passes with the drift guard deleted**. Drift only exists because the `TwoWay` binding echoes the rounded string back into the setter, so a test that does not simulate the echo proves nothing.

Verified by breaking it:

| sabotage | round-trip tests |
|---|---|
| Drift guard removed, echo simulated | **11 failures** |
| Drift guard removed, **echo also removed** | **all 15 pass** |

`The_binding_echo_is_what_gives_the_round_trip_tests_teeth` computes what the unguarded path would have stored, so the echo is proven load-bearing rather than assumed.

The negative rows are defensive only — `TrySetText` rejects `typed < 0` before converting — and that *precondition* is pinned by its own test, so removing the guard fails loudly instead of quietly making the negative rows live.

## Design constraints

- All conversion logic lives in **`MyFireNumber.Core`**, because `MyFireNumber.Tests.csproj` references only Core and Storage. View-model logic would have been untestable.
- No `PayloadVersion` bump; no draft-shape change. Saved plans and exports are untouched by construction.
- `shared/parity/periodic-fields.json` pins the field inventory, asserted from both platforms. The web-side scan reuses `blankOutCommentsAndStrings` / `PAGE_SOURCES` from `pageSources.ts` rather than standing up a second parser, and carries **no hardcoded count** — pages are discovered, so a tenth page cannot be silently missed.

## Sabotage log — actual failure output

Every guard below was proven to fire by breaking production code, capturing the real failure, and reverting.

| # | sabotage | observed failure |
|---|---|---|
| A | `ResolveEditedAmount` converts unconditionally | 11 failures, e.g. `Expected: 4677104761256804352 / Actual: 4677104766754362491` |
| B | A **still applied**, echo removed from the test helper | `Passed! - Failed: 0, Passed: 15` — the meta-verification |
| C | Healthcare premium declared `Annual` | `Expected: "600" / Actual: "50"` (the 144× signature) |
| D | `Enum.IsDefined` guard disabled | `Assert.Throws() Failure: No exception was thrown / Expected: typeof(System.ArgumentOutOfRangeException)` |
| E-1 | `Math.Round` (banker's) | `0.5 Expected 1 Actual 0`, `2.5 Expected 3 Actual 2`, `4.5 Expected 5 Actual 4`, `-1.5 Expected -1 Actual -2` |
| E-2 | `MidpointRounding.AwayFromZero` | `-0.5 Expected 0 Actual -1`, `-2.5 Expected -2 Actual -3`, `-1.5 Expected -1 Actual -2` |
| G | 12th calculator added to `CalculatorCatalog` | set-equality test names the missing id (no count assertion) |
| H | `periodic` removed from CoastFIRE's expenses input | `expected [ 'annualContribution:annual' ] to deeply equal [ 'annualContribution:annual', …(1) ]` |
| I | `healthcareAnnualOutOfPocket` dropped from the MAUI catalog | `Expected: [… "healthcareAnnualOutOfPocket:annual", "healthcareMonthlyPremium:monthly"] / Actual: ["healthcareAnnualDeductible:annual", "healthcareMonthlyPremium:monthly"]` |
| J | `periodic` **added** to WithdrawalRate (reverse direction) | `expected [ 'portfolioValue:annual' ] to deeply equal []` |
| K | Helper made to faithfully reproduce JS's `-0` | `-0.5 rounded to negative zero, which formats as "-0".` |
| L | `\|\| typed < 0` removed from `TrySetText` | `Assert.False() Failure / Expected: False / Actual: True` |

Sabotage C is worth calling out: the first attempt only reddened a string-list test, which would have left the real 144× failure mode uncovered. A test that builds the field **from the catalog** was added so the sabotage fails on the arithmetic, not on a list.

## Residual gaps — stated, not papered over

- **No unit test can prove a XAML `Entry` is bound to a period-aware field.** `MyFireNumber.Tests` cannot reference the MAUI app project, so any test claiming to cover the wiring would be exactly the vacuous guard this audit has hit repeatedly. The wiring is covered by the cross-platform inventory pin and by manual runtime validation, not by unit tests.
- **Runtime UI validation is manual on this PR.** Automated DevFlow verification was not run; note that `MauiProgram.cs` compiles the DevFlow agent out on iOS (`#if MAUI_DEVFLOW && !IOS`), a pre-existing deliberate exclusion, so Android is the only automated path.

## Reported, not fixed — kept out to keep this one reviewable unit

- **`web/src/utils/currencyPeriod.ts` has no dedicated tests.** The reference implementation this ports from is itself unpinned. The practical consequence: **if the C# port and the web original ever disagree, web's suite cannot adjudicate which one is correct.** This PR pins the behaviour on the C# side; closing the hole on the web side is its own issue.
- **Web makes HealthcareGap's *deductible* and *out-of-pocket* periodic.** A "monthly deductible" is semantically odd — a deductible is an annual cap. It is display-only and therefore arithmetically harmless, and diverging from web would break the parity this PR exists to establish, so it is **mirrored deliberately**. Recorded here so the oddity reads as a decision rather than an oversight.
- **`CalculatorCatalogTests.AllWebCalculators_HaveStableNativeDefinitions` asserts `Expected: 11`** — a hardcoded count, the precise pattern this PR's own tests avoid. Surfaced by sabotage G. Pre-existing; not changed here.

No calculation defect was found, and none of the math is changed.

## Validation

| | before | after |
|---|---|---|
| .NET | 202 | **291** |
| Web | 814 / 14 files | **829 / 15 files** |

`npm run build` clean. Web changes are **test-only** — no web production file is modified.

Rebased onto `7f42959` (#75); `shared/parity/` hunks merged without conflict.