### PR TITLE
Fix MAUI mobile spacing, header wrapping, contrast, and first-paint flow

### DIFF
--- a/app/MyFireNumber/App.xaml.cs
+++ b/app/MyFireNumber/App.xaml.cs
@@ -1,19 +1,20 @@
-﻿using MyFireNumber.Services;
+﻿using Microsoft.Extensions.DependencyInjection;
+using MyFireNumber.Services;
 
 namespace MyFireNumber;
 
 public partial class App : Application
 {
-	private readonly AppShell appShell;
+	private readonly IServiceProvider services;
 
 	public App(
-		AppShell appShell,
+		IServiceProvider services,
 		IThemeService themeService,
 		IAppBehaviorPreferencesService behaviorPreferencesService,
 		ITemporaryExportCleanupService temporaryExportCleanupService)
 	{
 		InitializeComponent();
-		this.appShell = appShell;
+		this.services = services;
 		temporaryExportCleanupService.RemoveStaleFiles();
 		themeService.Apply(behaviorPreferencesService.Current.HighContrast
 			? ThemePreference.Dark
@@ -22,6 +23,10 @@ public partial class App : Application
 
 	protected override Window CreateWindow(IActivationState? activationState)
 	{
-		return new Window(appShell);
+		// Resolve AppShell here rather than injecting it into the constructor. Constructor
+		// injection forced DI to build AppShell -- and with it the four tab pages -- before
+		// InitializeComponent() merged Colors.xaml and Styles.xaml into Application.Resources,
+		// so any {StaticResource} in those pages threw "StaticResource not found" at startup.
+		return new Window(services.GetRequiredService<AppShell>());
 	}
 }

--- a/app/MyFireNumber/Resources/Styles/Colors.xaml
+++ b/app/MyFireNumber/Resources/Styles/Colors.xaml
@@ -27,6 +27,14 @@
     <Color x:Key="Gray900">#212121</Color>
     <Color x:Key="Gray950">#141414</Color>
 
+    <!--
+    Placeholder text. The grays above fail WCAG AA badly on this app's field
+    backgrounds (Gray200 on the light field surface is 1.55:1), so placeholders
+    use these instead. Light 5.0:1, dark 10.2:1 against the field backgrounds.
+    -->
+    <Color x:Key="PlaceholderLight">#587068</Color>
+    <Color x:Key="PlaceholderDark">#B9D1C2</Color>
+
     <SolidColorBrush x:Key="PrimaryBrush" Color="{StaticResource Primary}"/>
     <SolidColorBrush x:Key="SecondaryBrush" Color="{StaticResource Secondary}"/>
     <SolidColorBrush x:Key="TertiaryBrush" Color="{StaticResource Tertiary}"/>

--- a/app/MyFireNumber/Resources/Styles/Styles.xaml
+++ b/app/MyFireNumber/Resources/Styles/Styles.xaml
@@ -3,6 +3,23 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
 
+    <!--
+    Spacing scale. Use these instead of literal Padding/Spacing numbers so the
+    vertical rhythm stays consistent across pages and cannot drift page by page.
+    Fine-grained label stacking (2-4) may still use literals; page and card level
+    spacing should always come from here.
+    -->
+    <x:Double x:Key="SpaceXs">4</x:Double>
+    <x:Double x:Key="SpaceSm">8</x:Double>
+    <x:Double x:Key="SpaceMd">12</x:Double>
+    <x:Double x:Key="SpaceLg">16</x:Double>
+    <x:Double x:Key="SpaceXl">24</x:Double>
+
+    <Thickness x:Key="PagePadding">20,20,20,24</Thickness>
+    <Thickness x:Key="PagePaddingCompact">20,16,20,16</Thickness>
+    <Thickness x:Key="CardPadding">16</Thickness>
+    <Thickness x:Key="CardPaddingCompact">12</Thickness>
+
     <Style TargetType="ActivityIndicator">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
     </Style>
@@ -92,7 +109,7 @@
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14" />
-        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
         <Setter Property="MinimumHeightRequest" Value="44"/>
         <Setter Property="MinimumWidthRequest" Value="44"/>
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -114,7 +131,7 @@
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
         <Setter Property="FontSize" Value="14" />
-        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray500}}" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
         <Setter Property="MinimumHeightRequest" Value="44"/>
         <Setter Property="MinimumWidthRequest" Value="44"/>
         <Setter Property="VisualStateManager.VisualStateGroups">
@@ -252,8 +269,8 @@
 
     <Style TargetType="SearchBar">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
-        <Setter Property="CancelButtonColor" Value="{StaticResource Gray500}" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
+        <Setter Property="CancelButtonColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
         <Setter Property="FontSize" Value="14" />
@@ -276,7 +293,7 @@
 
     <Style TargetType="SearchHandler">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
-        <Setter Property="PlaceholderColor" Value="{StaticResource Gray500}" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular" />
         <Setter Property="FontSize" Value="14" />
@@ -322,18 +339,66 @@
         </Setter>
     </Style>
 
+    <!--
+    Info affordance beside a field label. Explicitly sized because these sit in
+    half-width input grid cells (~150pt on a phone), where the platform default
+    button width leaves the label almost no room. 32pt clears the WCAG 2.2 AA
+    target-size minimum of 24pt.
+    -->
     <Style x:Key="FieldHelpInfoButton" TargetType="Button">
         <Setter Property="Background" Value="Transparent" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
         <Setter Property="FontFamily" Value="FontAwesomeSolid" />
-        <Setter Property="FontSize" Value="16" />
-        <Setter Property="Padding" Value="8" />
+        <Setter Property="FontSize" Value="15" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BorderWidth" Value="0" />
+        <Setter Property="CornerRadius" Value="16" />
+        <Setter Property="WidthRequest" Value="32" />
+        <Setter Property="HeightRequest" Value="32" />
+        <Setter Property="MinimumWidthRequest" Value="0" />
+        <Setter Property="MinimumHeightRequest" Value="0" />
+        <Setter Property="VerticalOptions" Value="Start" />
     </Style>
 
+    <!--
+    Short, static section headings only. Deliberately has NO MaxLines cap: the
+    longest heading in the app is 36 characters, which wraps to at most two lines,
+    and a cap would silently truncate it under iOS Dynamic Type or a large Android
+    fontScale. Hiding a heading is worse than wrapping one. Long dynamic result
+    sentences belong on CalculatorStatusHeadline, not here.
+    -->
     <Style x:Key="CalculatorSectionHeading" TargetType="Label">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark={StaticResource White}}" />
         <Setter Property="FontAttributes" Value="Bold" />
         <Setter Property="FontSize" Value="20" />
+        <Setter Property="LineBreakMode" Value="WordWrap" />
+        <Setter Property="LineHeight" Value="1.2" />
+    </Style>
+
+    <!--
+    Dynamic result sentences ("You're already Coast FIRE!", "To FIRE by age 55 you
+    need to save $X per month."). These are full sentences, so they wrap freely and
+    are never truncated - the sentence is the result. Smaller and semibold rather
+    than 20pt bold so a long one reads as a statement instead of a wall of heading.
+    -->
+    <Style x:Key="CalculatorStatusHeadline" TargetType="Label">
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource PrimaryDarkText}, Dark={StaticResource White}}" />
+        <Setter Property="FontFamily" Value="OpenSansSemibold" />
+        <Setter Property="FontSize" Value="17" />
+        <Setter Property="LineBreakMode" Value="WordWrap" />
+        <Setter Property="LineHeight" Value="1.25" />
+    </Style>
+
+    <!--
+    Field labels inside two-column input grids. No MaxLines cap: NumericInputView
+    and PercentageInputView pin their entry to the bottom row, so a label that wraps
+    to two lines no longer knocks its neighbour's entry out of alignment. Capping
+    here would only hide text without buying any tidiness.
+    -->
+    <Style x:Key="CalculatorFieldHeading" TargetType="Label">
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="LineBreakMode" Value="WordWrap" />
+        <Setter Property="LineHeight" Value="1.15" />
     </Style>
 
     <Style x:Key="CalculatorSupportingText" TargetType="Label">

--- a/app/MyFireNumber/Views/BaristaFirePage.xaml
+++ b/app/MyFireNumber/Views/BaristaFirePage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:BaristaFireViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,7 +20,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" HorizontalOptions="Center" SemanticProperties.Description="Restoring your local calculator draft." />
             <Border IsVisible="{Binding HasValidationMessage}" Padding="14" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" Stroke="{AppThemeBinding Light=#C97727, Dark=#F2B56D}" StrokeShape="RoundRectangle 8"><Label Text="{Binding ValidationMessage}" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" LineHeight="1.3" /></Border>
 
@@ -28,19 +29,19 @@
                                          Details="Barista FIRE uses flexible earned income to cover part of your spending while investments cover the rest."
                                          IconGlyph="&#xf0f4;" />
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="14">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Your starting point" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Barista FIRE values to their defaults." /></Grid>
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}"><Label Text="Your starting point" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Barista FIRE values to their defaults." /></Grid>
                     <controls:PeriodToggleView />
-                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Current savings" HelpText="Invested assets available for this goal, in dollars." Placeholder="100000" Text="{Binding CurrentSavingsText}" />
                         <controls:NumericInputView Grid.Row="1" Header="Retirement expenses" HelpText="Expected spending, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
-                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="After-tax part-time take-home income" HelpText="Expected take-home pay after taxes while in the Barista FIRE phase, in dollars." Placeholder="20000" Text="{Binding PartTimeAnnualIncomeText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
+                        <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="Part-time take-home" HelpText="Expected take-home pay after taxes while in the Barista FIRE phase, in dollars." Placeholder="20000" Text="{Binding PartTimeAnnualIncomeText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                         <controls:NumericInputView Grid.Row="2" Grid.ColumnSpan="2" Header="Contribution" HelpText="How much you expect to invest before changing work." Placeholder="24000" Text="{Binding AnnualContributionText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
-                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                             <controls:PercentageInputView Header="Expected return (%)" HelpText="Expected average annual investment return before inflation." Placeholder="7" Minimum="0" Maximum="15" Text="{Binding ExpectedReturnText}" />
                             <controls:PercentageInputView Grid.Column="1" Header="Inflation (%)" HelpText="Expected annual increase in the cost of living." Placeholder="3" Minimum="0" Maximum="10" Text="{Binding InflationRateText}" />
                             <controls:PercentageInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Withdrawal rate (%)" HelpText="First-year percentage withdrawn from the portfolio. This is an assumption, not a promise." Placeholder="4" Minimum="2" Maximum="6" Text="{Binding WithdrawalRateText}" />
@@ -49,25 +50,25 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Your Barista FIRE outlook" Style="{StaticResource CalculatorSectionHeading}" />
-                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Barista FIRE number" FontSize="12" /><Label Text="{Binding BaristaNumberText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Full FIRE number" FontSize="12" /><Label Text="{Binding FullFireNumberText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.ColumnSpan="2" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Years to Barista FIRE" FontSize="12" /><Label Text="{Binding BaristaYearsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Barista FIRE number" FontSize="12" /><Label Text="{Binding BaristaNumberText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Full FIRE number" FontSize="12" /><Label Text="{Binding FullFireNumberText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.ColumnSpan="2" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Years to Barista FIRE" FontSize="12" /><Label Text="{Binding BaristaYearsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
                 <Label Text="{Binding BaristaReductionText}" FontAttributes="Bold" />
                 <Label Text="{Binding BaristaProgressDescription}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Barista FIRE projection" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" />
                 <Label Text="{Binding BaristaProjectionSummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}" Placeholder="My Barista FIRE Plan" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" SemanticProperties.Description="Name for this saved Barista FIRE plan" />
                     <Button Text="{Binding SavePlanActionText}" Command="{Binding SavePlanCommand}" SemanticProperties.Description="{Binding SavePlanActionDescription}" />

--- a/app/MyFireNumber/Views/CalculatorsPage.xaml
+++ b/app/MyFireNumber/Views/CalculatorsPage.xaml
@@ -7,15 +7,16 @@
              x:Class="MyFireNumber.Views.CalculatorsPage"
              x:DataType="viewModels:CalculatorCatalogViewModel"
              Title="Calculators"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="Container">
 
-    <Grid Padding="20,16">
+    <Grid Padding="{StaticResource PagePaddingCompact}">
         <CollectionView ItemsSource="{Binding FilteredCalculatorGroups}"
                         IsGrouped="True"
                         SelectionMode="None">
             <CollectionView.Header>
-                <VerticalStackLayout Spacing="14" Margin="0,0,0,14">
-                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}" Margin="0,0,0,14">
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                         <Label Text="&#xf1ec;"
                                FontFamily="FontAwesomeSolid"
                                VerticalTextAlignment="Center"
@@ -45,7 +46,7 @@
             <CollectionView.GroupHeaderTemplate>
                 <DataTemplate x:DataType="viewModels:CalculatorGroup">
                     <Grid ColumnDefinitions="Auto,*"
-                          ColumnSpacing="8"
+                          ColumnSpacing="{StaticResource SpaceSm}"
                           Padding="4,12,4,10">
                         <Label Text="{Binding IconGlyph}"
                                FontFamily="FontAwesomeSolid"
@@ -65,7 +66,7 @@
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="catalog:CalculatorDefinition">
                     <Border Margin="0,0,0,10"
-                            Padding="16"
+                            Padding="{StaticResource CardPadding}"
                             Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                             Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                             StrokeShape="RoundRectangle 12"
@@ -74,7 +75,7 @@
                             <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:CalculatorCatalogViewModel}}, Path=OpenCalculatorCommand}"
                                                   CommandParameter="{Binding .}" />
                         </Border.GestureRecognizers>
-                        <Grid ColumnDefinitions="44,*,Auto" ColumnSpacing="12">
+                        <Grid ColumnDefinitions="44,*,Auto" ColumnSpacing="{StaticResource SpaceMd}">
                             <Border WidthRequest="44"
                                     HeightRequest="44"
                                     Padding="0"
@@ -110,7 +111,7 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
             <CollectionView.EmptyView>
-                  <VerticalStackLayout VerticalOptions="Center" Spacing="8">
+                  <VerticalStackLayout VerticalOptions="Center" Spacing="{StaticResource SpaceSm}">
                       <Label Text="&#xf002;"
                               FontFamily="FontAwesomeSolid"
                               VerticalTextAlignment="Center"

--- a/app/MyFireNumber/Views/CoastFirePage.xaml
+++ b/app/MyFireNumber/Views/CoastFirePage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:CoastFireViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,7 +20,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" HorizontalOptions="Center" SemanticProperties.Description="Restoring your local calculator draft." />
             <Border IsVisible="{Binding HasValidationMessage}" Padding="14" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" Stroke="{AppThemeBinding Light=#C97727, Dark=#F2B56D}" StrokeShape="RoundRectangle 8">
                 <Label Text="{Binding ValidationMessage}" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" LineHeight="1.3" />
@@ -30,14 +31,14 @@
                                          Details="Coast FIRE means current investments could grow to a full FIRE number without more contributions. You still need income for today’s expenses."
                                          IconGlyph="&#xf0eb;" />
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="14">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                         <Label Text="Your starting point" Style="{StaticResource CalculatorSectionHeading}" />
                         <Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Coast FIRE values to their defaults." />
                     </Grid>
                     <controls:PeriodToggleView />
-                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Retirement age" HelpText="The age when your portfolio should be ready to fund retirement." Placeholder="55" Text="{Binding RetirementAgeText}" />
                         <controls:NumericInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Current savings" HelpText="Invested assets available for this goal, in dollars." Placeholder="100000" Text="{Binding CurrentSavingsText}" />
@@ -45,7 +46,7 @@
                         <controls:NumericInputView Grid.Row="2" Grid.Column="1" Header="Retirement expenses" HelpText="Expected spending after retirement, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
-                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                             <controls:PercentageInputView Header="Expected return (%)" HelpText="Expected average annual investment return before inflation." Placeholder="7" Minimum="0" Maximum="15" Text="{Binding ExpectedReturnText}" />
                             <controls:PercentageInputView Grid.Column="1" Header="Inflation (%)" HelpText="Expected annual increase in the cost of living." Placeholder="3" Minimum="0" Maximum="10" Text="{Binding InflationRateText}" />
                             <controls:PercentageInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Safe withdrawal rate (%)" HelpText="First-year percentage withdrawn from the portfolio. This is an assumption, not a promise." Placeholder="4" Minimum="2" Maximum="6" Text="{Binding WithdrawalRateText}" />
@@ -54,24 +55,25 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
-                <Label Text="{Binding CoastStatusText}" Style="{StaticResource CalculatorSectionHeading}" />
-                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#EAF2FF, Dark=#1D3040}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Coast FIRE number" FontSize="12" /><Label Text="{Binding CoastNumberText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Full FIRE number" FontSize="12" /><Label Text="{Binding FullFireNumberText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.ColumnSpan="2" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Time to Coast FIRE" FontSize="12" /><Label Text="{Binding YearsToCoastText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                <Label Text="Your Coast FIRE outlook" Style="{StaticResource CalculatorSectionHeading}" />
+                <Label Text="{Binding CoastStatusText}" Style="{StaticResource CalculatorStatusHeadline}" SemanticProperties.Description="{Binding CoastStatusText}" />
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#EAF2FF, Dark=#1D3040}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Coast FIRE number" FontSize="12" /><Label Text="{Binding CoastNumberText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Full FIRE number" FontSize="12" /><Label Text="{Binding FullFireNumberText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.ColumnSpan="2" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Time to Coast FIRE" FontSize="12" /><Label Text="{Binding YearsToCoastText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
                 <Label Text="{Binding CoastProgressDescription}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Coast vs. continue contributing" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" />
                 <Label Text="{Binding CoastProjectionSummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}" Placeholder="My Coast FIRE Plan" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" SemanticProperties.Description="Name for this saved Coast FIRE plan" />
                     <Button Text="{Binding SavePlanActionText}" Command="{Binding SavePlanCommand}" SemanticProperties.Description="{Binding SavePlanActionDescription}" />

--- a/app/MyFireNumber/Views/Controls/AdvancedAssumptionsExpander.cs
+++ b/app/MyFireNumber/Views/Controls/AdvancedAssumptionsExpander.cs
@@ -4,6 +4,7 @@ public sealed class AdvancedAssumptionsExpander : VerticalStackLayout
 {
     private readonly Button toggleButton;
     private bool isExpanded;
+    private bool hasAppliedInitialState;
 
     public static readonly BindableProperty TitleProperty = BindableProperty.Create(
         nameof(Title),
@@ -23,7 +24,39 @@ public sealed class AdvancedAssumptionsExpander : VerticalStackLayout
         SemanticProperties.SetDescription(toggleButton, "Show advanced assumptions");
         toggleButton.Clicked += OnToggleClicked;
         Children.Add(toggleButton);
-        Loaded += (_, _) => SetExpanded(false);
+    }
+
+    /// <summary>
+    /// Collapse as children are added rather than waiting for <c>Loaded</c>. Collapsing in
+    /// <c>Loaded</c> meant the advanced fields were measured and drawn expanded first, so the
+    /// input card visibly jumped shorter on every page open.
+    /// </summary>
+    protected override void OnChildAdded(Element child)
+    {
+        base.OnChildAdded(child);
+
+        if (!ReferenceEquals(child, toggleButton) && child is VisualElement visualElement)
+        {
+            visualElement.IsVisible = isExpanded;
+        }
+    }
+
+    /// <summary>
+    /// Safety net in case a child is ever added without going through <see cref="OnChildAdded"/>.
+    /// Runs once: Shell reuses cached pages, so collapsing on every <c>Loaded</c> would throw away
+    /// the user's expanded section each time they returned to a calculator.
+    /// </summary>
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+
+        if (Handler is null || hasAppliedInitialState)
+        {
+            return;
+        }
+
+        hasAppliedInitialState = true;
+        SetExpanded(isExpanded);
     }
 
     public string Title

--- a/app/MyFireNumber/Views/Controls/CalculatorInfoView.xaml
+++ b/app/MyFireNumber/Views/Controls/CalculatorInfoView.xaml
@@ -3,12 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MyFireNumber.Views.Controls.CalculatorInfoView"
              x:Name="Root">
-    <Border Padding="16"
+    <Border Padding="{StaticResource CardPadding}"
             Background="{AppThemeBinding Light=#EAF4EC, Dark=#1B3B2D}"
             Stroke="{AppThemeBinding Light=#A8D4B2, Dark=#43805B}"
             StrokeShape="RoundRectangle 8">
-        <VerticalStackLayout Spacing="8">
-            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                 <Label Text="{Binding IconGlyph, Source={x:Reference Root}}"
                        FontFamily="FontAwesomeSolid"
                        VerticalTextAlignment="Center"

--- a/app/MyFireNumber/Views/Controls/EducationalDisclaimerView.xaml
+++ b/app/MyFireNumber/Views/Controls/EducationalDisclaimerView.xaml
@@ -9,7 +9,7 @@
         <Grid Grid.Row="1"
               Margin="0,8,0,0"
               ColumnDefinitions="Auto,*"
-              ColumnSpacing="7">
+              ColumnSpacing="{StaticResource SpaceSm}">
             <Label Text="&#xf071;"
                    FontFamily="FontAwesomeSolid"
                    FontSize="11"

--- a/app/MyFireNumber/Views/Controls/FieldHelpView.xaml
+++ b/app/MyFireNumber/Views/Controls/FieldHelpView.xaml
@@ -4,15 +4,15 @@
              x:Class="MyFireNumber.Views.Controls.FieldHelpView"
              x:Name="Root">
     <Grid ColumnDefinitions="*,Auto"
-          ColumnSpacing="4">
+          ColumnSpacing="{StaticResource SpaceXs}">
         <Label Text="{Binding Header, Source={x:Reference Root}}"
-               FontAttributes="Bold"
+               Style="{StaticResource CalculatorFieldHeading}"
                VerticalTextAlignment="Center"
                SemanticProperties.HeadingLevel="Level3" />
         <Button Grid.Column="1"
                 Text="&#xf05a;"
                 Style="{StaticResource FieldHelpInfoButton}"
                 Clicked="OnInfoClicked"
-                SemanticProperties.Description="Show help for this field" />
+                SemanticProperties.Description="{Binding Header, Source={x:Reference Root}, StringFormat='Show help for {0}'}" />
     </Grid>
 </ContentView>

--- a/app/MyFireNumber/Views/Controls/NumericInputView.xaml
+++ b/app/MyFireNumber/Views/Controls/NumericInputView.xaml
@@ -4,10 +4,18 @@
              xmlns:local="clr-namespace:MyFireNumber.Views.Controls"
              x:Class="MyFireNumber.Views.Controls.NumericInputView"
              x:Name="Root">
-    <Grid RowDefinitions="Auto,Auto"
-          RowSpacing="4">
+    <!--
+    Rows are "*,Auto" rather than "Auto,Auto" on purpose. Side-by-side fields in a
+    two-column input grid get the same height, so pinning the entry to the bottom
+    row keeps the entry boxes aligned even when one label wraps to two lines and
+    its neighbour does not. Without this the labels have to be capped or truncated
+    to stay tidy, which hides text the user needs.
+    -->
+    <Grid RowDefinitions="*,Auto"
+          RowSpacing="{StaticResource SpaceXs}">
         <local:FieldHelpView Header="{Binding DisplayHeader, Source={x:Reference Root}}"
-                             HelpText="{Binding HelpText, Source={x:Reference Root}}" />
+                             HelpText="{Binding HelpText, Source={x:Reference Root}}"
+                             VerticalOptions="Start" />
         <Grid Grid.Row="1"
               ColumnDefinitions="*,Auto"
               ColumnSpacing="6">

--- a/app/MyFireNumber/Views/Controls/PercentageInputView.xaml
+++ b/app/MyFireNumber/Views/Controls/PercentageInputView.xaml
@@ -7,10 +7,12 @@
     <ContentView.Resources>
         <local:NumericTextConverter x:Key="NumericTextConverter" />
     </ContentView.Resources>
-    <Grid RowDefinitions="Auto,Auto,Auto"
-          RowSpacing="4">
+    <!-- See NumericInputView for why the label row is "*" and not "Auto". -->
+    <Grid RowDefinitions="*,Auto,Auto"
+          RowSpacing="{StaticResource SpaceXs}">
         <local:FieldHelpView Header="{Binding Header, Source={x:Reference Root}}"
-                             HelpText="{Binding HelpText, Source={x:Reference Root}}" />
+                             HelpText="{Binding HelpText, Source={x:Reference Root}}"
+                             VerticalOptions="Start" />
         <Entry Grid.Row="1"
                Text="{Binding Text, Source={x:Reference Root}, Mode=TwoWay}"
                Placeholder="{Binding Placeholder, Source={x:Reference Root}}"

--- a/app/MyFireNumber/Views/Controls/PeriodToggleView.xaml
+++ b/app/MyFireNumber/Views/Controls/PeriodToggleView.xaml
@@ -8,7 +8,7 @@
     <VerticalStackLayout Spacing="6">
         <controls:FieldHelpView Header="Show recurring amounts as"
                                 HelpText="Switches how recurring dollar amounts are displayed. This does not change any result — the same amount is used either way." />
-        <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
             <Button Text="Monthly"
                     Command="{Binding SetDisplayPeriodCommand}"
                     CommandParameter="Monthly"

--- a/app/MyFireNumber/Views/DebtPayoffPage.xaml
+++ b/app/MyFireNumber/Views/DebtPayoffPage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:DebtPayoffViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,7 +20,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" HorizontalOptions="Center" SemanticProperties.Description="Restoring your local calculator draft." />
             <Border IsVisible="{Binding HasValidationMessage}" Padding="14" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" Stroke="{AppThemeBinding Light=#C97727, Dark=#F2B56D}" StrokeShape="RoundRectangle 8"><Label Text="{Binding ValidationMessage}" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" LineHeight="1.3" /></Border>
 
@@ -28,23 +29,23 @@
                                          Details="Snowball prioritizes the smallest balance for early milestones. Avalanche prioritizes the highest rate and can reduce total interest."
                                          IconGlyph="&#xf09d;" />
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="12">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                         <Label Text="Your debts" Style="{StaticResource CalculatorSectionHeading}" />
                         <Button Grid.Column="1" Text="Add debt" Command="{Binding AddDebtCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Add another debt to this payoff plan." />
                     </Grid>
                     <controls:FieldHelpView Header="Debt details" HelpText="For each debt, enter its balance, annual interest rate, and required minimum payment." />
-                    <VerticalStackLayout BindableLayout.ItemsSource="{Binding DebtItems}" Spacing="10">
+                    <VerticalStackLayout BindableLayout.ItemsSource="{Binding DebtItems}" Spacing="{StaticResource SpaceSm}">
                         <BindableLayout.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:DebtEditorItem">
-                                <Border Padding="12" Background="{AppThemeBinding Light=#FFF9F3, Dark=#2B2019}" Stroke="{AppThemeBinding Light=#F1D5BB, Dark=#634631}" StrokeShape="RoundRectangle 8">
-                                    <VerticalStackLayout Spacing="8">
-                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFF9F3, Dark=#2B2019}" Stroke="{AppThemeBinding Light=#F1D5BB, Dark=#634631}" StrokeShape="RoundRectangle 8">
+                                    <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                                             <Entry Text="{Binding Name}" Placeholder="Debt name" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" SemanticProperties.Description="Debt name" />
                                             <Button Grid.Column="1" Text="Remove" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveDebtCommand}" CommandParameter="{Binding .}" Background="{AppThemeBinding Light=#FCE5E1, Dark=#4A2B2A}" TextColor="{AppThemeBinding Light=#7C352E, Dark=#FFB9B1}" FontSize="12" SemanticProperties.Description="Remove this debt from the payoff plan." />
                                         </Grid>
-                                        <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
+                                        <Grid ColumnDefinitions="*,*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                             <VerticalStackLayout Spacing="3"><Label Text="Balance" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding BalanceText}" Keyboard="Numeric" Placeholder="5000" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" SemanticProperties.Description="Current debt balance in dollars." /></VerticalStackLayout>
                                             <VerticalStackLayout Grid.Column="1" Spacing="3"><Label Text="Rate (%)" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding RateText}" Keyboard="Numeric" Placeholder="19.99" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" SemanticProperties.Description="Annual interest rate percentage." /></VerticalStackLayout>
                                             <VerticalStackLayout Grid.Column="2" Spacing="3"><Label Text="Minimum" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding MinimumPaymentText}" Keyboard="Numeric" Placeholder="150" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" SemanticProperties.Description="Minimum monthly payment in dollars." /></VerticalStackLayout>
@@ -55,16 +56,16 @@
                         </BindableLayout.ItemTemplate>
                     </VerticalStackLayout>
                     <controls:AdvancedAssumptionsExpander Title="Advanced payment strategy">
-                        <VerticalStackLayout Margin="0,12,0,0" Spacing="12">
-                            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                        <VerticalStackLayout Margin="0,12,0,0" Spacing="{StaticResource SpaceMd}">
+                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                 <Button Text="Fixed budget" Command="{Binding SetDebtPayoffModeCommand}" CommandParameter="fixed" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" SemanticProperties.Description="Use a fixed total monthly debt budget."><Button.Triggers><DataTrigger TargetType="Button" Binding="{Binding IsFixedDebtPayoff}" Value="True"><Setter Property="Background" Value="{StaticResource Primary}" /><Setter Property="TextColor" Value="{StaticResource White}" /></DataTrigger></Button.Triggers></Button>
                                 <Button Grid.Column="1" Text="Target timeline" Command="{Binding SetDebtPayoffModeCommand}" CommandParameter="target" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" SemanticProperties.Description="Calculate the payment required for a target payoff timeline."><Button.Triggers><DataTrigger TargetType="Button" Binding="{Binding IsTargetDebtPayoff}" Value="True"><Setter Property="Background" Value="{StaticResource Primary}" /><Setter Property="TextColor" Value="{StaticResource White}" /></DataTrigger></Button.Triggers></Button>
                             </Grid>
-                            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                 <Button Text="Snowball" Command="{Binding SetDebtStrategyCommand}" CommandParameter="snowball" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" SemanticProperties.Description="Pay the smallest debt first." />
                                 <Button Grid.Column="1" Text="Avalanche" Command="{Binding SetDebtStrategyCommand}" CommandParameter="avalanche" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" SemanticProperties.Description="Pay the highest interest rate first." />
                             </Grid>
-                            <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceMd}">
                                 <controls:NumericInputView IsVisible="{Binding IsFixedDebtPayoff}" Header="Monthly debt budget" HelpText="Total amount available for debt payments each month, in dollars." Placeholder="1000" Text="{Binding DebtMonthlyBudgetText}" />
                                 <controls:NumericInputView IsVisible="{Binding IsTargetDebtPayoff}" Header="Target months" HelpText="Months in which you aim to eliminate all debt." Placeholder="36" Text="{Binding DebtTargetMonthsText}" />
                                 <controls:NumericInputView Grid.Column="1" Header="Extra monthly payment" HelpText="Additional monthly amount paid beyond minimums, in dollars." Placeholder="0" Text="{Binding DebtExtraPaymentText}" />
@@ -74,29 +75,29 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Your payoff outlook" Style="{StaticResource CalculatorSectionHeading}" />
-                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#FFF1E7, Dark=#493225}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total debt" FontSize="12" /><Label Text="{Binding DebtTotalText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Minimum payments" FontSize="12" /><Label Text="{Binding DebtMinimumPaymentsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Payoff time" FontSize="12" /><Label Text="{Binding DebtPayoffTimeText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total interest" FontSize="12" /><Label Text="{Binding DebtInterestText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="2" Grid.ColumnSpan="2" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly payment" FontSize="12" /><Label Text="{Binding DebtPaymentText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFF1E7, Dark=#493225}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total debt" FontSize="12" /><Label Text="{Binding DebtTotalText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Minimum payments" FontSize="12" /><Label Text="{Binding DebtMinimumPaymentsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Payoff time" FontSize="12" /><Label Text="{Binding DebtPayoffTimeText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total interest" FontSize="12" /><Label Text="{Binding DebtInterestText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="2" Grid.ColumnSpan="2" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly payment" FontSize="12" /><Label Text="{Binding DebtPaymentText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
                 <Label Text="{Binding DebtStrategySummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Debt balance projection" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" />
                 <Label Text="Principal and interest paid" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding DebtBreakdownSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding DebtBreakdownDescription}" />
                 <Label Text="{Binding DebtBreakdownSummary}" Style="{StaticResource CalculatorSupportingText}" />
-                <Grid ColumnDefinitions="*,*" ColumnSpacing="10"><VerticalStackLayout Spacing="2"><Label Text="Snowball" FontAttributes="Bold" /><Label Text="{Binding DebtSnowballComparisonText}" Style="{StaticResource CalculatorSupportingText}" /></VerticalStackLayout><VerticalStackLayout Grid.Column="1" Spacing="2"><Label Text="Avalanche" FontAttributes="Bold" /><Label Text="{Binding DebtAvalancheComparisonText}" Style="{StaticResource CalculatorSupportingText}" /></VerticalStackLayout></Grid>
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}"><VerticalStackLayout Spacing="2"><Label Text="Snowball" FontAttributes="Bold" /><Label Text="{Binding DebtSnowballComparisonText}" Style="{StaticResource CalculatorSupportingText}" /></VerticalStackLayout><VerticalStackLayout Grid.Column="1" Spacing="2"><Label Text="Avalanche" FontAttributes="Bold" /><Label Text="{Binding DebtAvalancheComparisonText}" Style="{StaticResource CalculatorSupportingText}" /></VerticalStackLayout></Grid>
             </VerticalStackLayout>
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}" Placeholder="My Debt Payoff Plan" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" SemanticProperties.Description="Name for this saved Debt Payoff plan" />
                     <Button Text="{Binding SavePlanActionText}" Command="{Binding SavePlanCommand}" SemanticProperties.Description="{Binding SavePlanActionDescription}" />

--- a/app/MyFireNumber/Views/DefaultsOnboardingPage.xaml
+++ b/app/MyFireNumber/Views/DefaultsOnboardingPage.xaml
@@ -8,7 +8,8 @@
              Title="About you"
              Shell.NavBarIsVisible="True"
              Shell.TabBarIsVisible="False"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Skip"
                      Command="{Binding SkipCommand}"
@@ -17,7 +18,7 @@
 
     <Grid>
         <ScrollView>
-            <VerticalStackLayout Padding="24,20,24,32" Spacing="18">
+            <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
                 <VerticalStackLayout Spacing="6">
                     <Label Text="Tell us about today"
                            FontSize="28"
@@ -30,11 +31,11 @@
                            TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
                 </VerticalStackLayout>
 
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="22">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceXl}">
                         <VerticalStackLayout Spacing="6">
                             <Grid ColumnDefinitions="*,Auto">
                                 <Label Text="Current age"

--- a/app/MyFireNumber/Views/FireNumberPage.xaml
+++ b/app/MyFireNumber/Views/FireNumberPage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:IFireNumberViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,8 +20,8 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32"
-                             Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}"
+                             Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}"
                                IsVisible="{Binding IsLoading}"
                                HorizontalOptions="Center"
@@ -35,7 +36,7 @@
                        LineHeight="1.3" />
             </Border>
 
-            <VerticalStackLayout Spacing="12">
+            <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                 <controls:CalculatorInfoView IsVisible="{Binding IsStandardFire}"
                                              Title="What is Standard FIRE?"
                                              Summary="Calculate the portfolio needed for full financial independence using the classic 25x expenses rule."
@@ -52,7 +53,7 @@
                                              Details="Fat FIRE pairs a larger portfolio target with more flexibility for lifestyle choices and unexpected costs."
                                              IconGlyph="&#xf219;" />
                 <Border IsVisible="{Binding IsLeanFire}"
-                        Padding="12"
+                        Padding="{StaticResource CardPaddingCompact}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 8">
@@ -62,7 +63,7 @@
                     </VerticalStackLayout>
                 </Border>
                 <Border IsVisible="{Binding IsFatFire}"
-                        Padding="12"
+                        Padding="{StaticResource CardPaddingCompact}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 8">
@@ -73,12 +74,12 @@
                 </Border>
             </VerticalStackLayout>
 
-            <Border Padding="16"
+            <Border Padding="{StaticResource CardPadding}"
                     Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                     Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                     StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="14">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                         <Label Text="Your starting point" Style="{StaticResource CalculatorSectionHeading}" />
                         <Button Grid.Column="1"
                                 Text="Reset"
@@ -101,8 +102,8 @@
                     </VerticalStackLayout>
                     <Grid ColumnDefinitions="*,*"
                           RowDefinitions="Auto,Auto,Auto"
-                          ColumnSpacing="12"
-                          RowSpacing="12">
+                          ColumnSpacing="{StaticResource SpaceMd}"
+                          RowSpacing="{StaticResource SpaceMd}">
                         <controls:NumericInputView Header="Current age"
                                                    HelpText="Your age today, in years."
                                                    Placeholder="30"
@@ -119,7 +120,7 @@
                                                    Text="{Binding AnnualContributionText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                         <controls:NumericInputView Grid.Row="1"
                                                    Grid.Column="1"
-                                                   Header="After-tax take-home income"
+                                                   Header="Take-home income"
                                                    HelpText="Income after taxes, used to calculate your savings rate."
                                                    Placeholder="72000"
                                                    Text="{Binding AnnualIncomeText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
@@ -131,15 +132,15 @@
                                                    Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
-                        <VerticalStackLayout Margin="0,12,0,0" Spacing="12">
+                        <VerticalStackLayout Margin="0,12,0,0" Spacing="{StaticResource SpaceMd}">
                             <controls:NumericInputView Header="Retirement age"
                                                        HelpText="The age you would like to reach financial independence."
                                                        Placeholder="55"
                                                        Text="{Binding RetirementAgeText}" />
                             <Grid ColumnDefinitions="*,*"
                                   RowDefinitions="Auto,Auto"
-                                  ColumnSpacing="12"
-                                  RowSpacing="12">
+                                  ColumnSpacing="{StaticResource SpaceMd}"
+                                  RowSpacing="{StaticResource SpaceMd}">
                                 <controls:PercentageInputView Header="Expected return (%)"
                                                               HelpText="Expected average annual investment return before inflation."
                                                               Placeholder="7"
@@ -167,17 +168,17 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="{Binding OutlookTitle}" Style="{StaticResource CalculatorSectionHeading}" />
                 <Grid ColumnDefinitions="*,*"
                       RowDefinitions="Auto,Auto,Auto"
-                      ColumnSpacing="10"
-                      RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="{Binding FireNumberLabel}" FontSize="12" /><Label Text="{Binding FireNumberText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="{Binding YearsToFireLabel}" FontSize="12" /><Label Text="{Binding YearsToFireText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="FIRE age" FontSize="12" /><Label Text="{Binding FireAgeText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Savings rate" FontSize="12" /><Label Text="{Binding SavingsRateText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="2" Grid.ColumnSpan="2" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly contribution" FontSize="12" /><Label Text="{Binding MonthlyContributionText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                      ColumnSpacing="{StaticResource SpaceSm}"
+                      RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="{Binding FireNumberLabel}" FontSize="12" /><Label Text="{Binding FireNumberText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="{Binding YearsToFireLabel}" FontSize="12" /><Label Text="{Binding YearsToFireText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="FIRE age" FontSize="12" /><Label Text="{Binding FireAgeText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Savings rate" FontSize="12" /><Label Text="{Binding SavingsRateText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="2" Grid.ColumnSpan="2" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly contribution" FontSize="12" /><Label Text="{Binding MonthlyContributionText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
                 <VerticalStackLayout Spacing="2">
                     <Label Text="Target-age check"
@@ -191,7 +192,7 @@
                 <Label Text="{Binding ProjectionSummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="{Binding ProjectionTitle}" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}"
                                     XAxes="{Binding ProjectionXAxes}"
@@ -201,11 +202,11 @@
                 <Label Text="{Binding ProjectionSummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <Border Padding="16"
+            <Border Padding="{StaticResource CardPadding}"
                     Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                     Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                     StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}"
                            Placeholder="{Binding PlanNamePlaceholder}"

--- a/app/MyFireNumber/Views/HealthcareGapPage.xaml
+++ b/app/MyFireNumber/Views/HealthcareGapPage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:HealthcareGapViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,7 +20,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" HorizontalOptions="Center" SemanticProperties.Description="Restoring your local calculator draft." />
             <Border IsVisible="{Binding HasValidationMessage}" Padding="14" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" Stroke="{AppThemeBinding Light=#C97727, Dark=#F2B56D}" StrokeShape="RoundRectangle 8"><Label Text="{Binding ValidationMessage}" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" LineHeight="1.3" /></Border>
 
@@ -28,17 +29,17 @@
                                          Details="Leaving employer coverage before Medicare can create a major retirement expense. This estimate includes premiums, deductibles, out-of-pocket costs, and medical inflation. It does not estimate ACA premium tax credits, which depend on household size and the federal poverty level."
                                          IconGlyph="&#xf0f9;" />
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="14">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Coverage basics" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Healthcare Gap values to their defaults." /></Grid>
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}"><Label Text="Coverage basics" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Healthcare Gap values to their defaults." /></Grid>
                     <controls:PeriodToggleView />
-                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding HealthcareCurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Retire at age" HelpText="The age when employer health coverage ends." Placeholder="55" Text="{Binding EarlyRetirementAgeText}" />
                         <controls:NumericInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Health insurance premium" HelpText="Expected health insurance premium, in dollars." Placeholder="600" Text="{Binding MonthlyPremiumText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
-                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                             <controls:NumericInputView Header="Medicare age" HelpText="The expected age when Medicare coverage begins." Placeholder="65" Text="{Binding MedicareAgeText}" />
                             <controls:NumericInputView Grid.Column="1" Header="Deductible" HelpText="Expected deductible, in dollars." Placeholder="2500" Text="{Binding AnnualDeductibleText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                             <controls:NumericInputView Grid.Row="1" Header="Out-of-pocket costs" HelpText="Expected medical costs beyond premiums and deductibles, in dollars." Placeholder="2000" Text="{Binding AnnualOutOfPocketText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
@@ -48,24 +49,24 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Your pre-Medicare healthcare outlook" Style="{StaticResource CalculatorSectionHeading}" />
-                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#FDEEEB, Dark=#4A2B2A}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Coverage gap" FontSize="12" /><Label Text="{Binding HealthcareGapYearsText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="First-year cost" FontSize="12" /><Label Text="{Binding HealthcareAnnualCostText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total projected cost" FontSize="12" /><Label Text="{Binding HealthcareTotalCostText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Average annual cost" FontSize="12" /><Label Text="{Binding HealthcareAverageAnnualCostText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FDEEEB, Dark=#4A2B2A}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Coverage gap" FontSize="12" /><Label Text="{Binding HealthcareGapYearsText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="First-year cost" FontSize="12" /><Label Text="{Binding HealthcareAnnualCostText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total projected cost" FontSize="12" /><Label Text="{Binding HealthcareTotalCostText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Average annual cost" FontSize="12" /><Label Text="{Binding HealthcareAverageAnnualCostText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Annual healthcare cost projection" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" />
                 <Label Text="{Binding HealthcareProjectionSummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}" Placeholder="My Healthcare Gap Plan" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" SemanticProperties.Description="Name for this saved Healthcare Gap plan" />
                     <Button Text="{Binding SavePlanActionText}" Command="{Binding SavePlanCommand}" SemanticProperties.Description="{Binding SavePlanActionDescription}" />

--- a/app/MyFireNumber/Views/HomePage.xaml
+++ b/app/MyFireNumber/Views/HomePage.xaml
@@ -7,19 +7,20 @@
              x:Class="MyFireNumber.Views.HomePage"
              x:DataType="viewModels:HomeViewModel"
              Title="Home"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="Container">
 
     <Grid>
         <ScrollView>
-            <VerticalStackLayout Padding="24,24,24,32" Spacing="24">
-                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+            <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceXl}">
+                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceMd}">
                     <Label Text="&#xf201;"
                               FontFamily="FontAwesomeSolid"
                               VerticalTextAlignment="Center"
                            TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
                            FontSize="28"
                            SemanticProperties.Description="Financial progress" />
-                    <VerticalStackLayout Grid.Column="1" Spacing="8">
+                    <VerticalStackLayout Grid.Column="1" Spacing="{StaticResource SpaceSm}">
                     <Label Text="MY FIRE NUMBER"
                            TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
                            FontAttributes="Bold"
@@ -40,11 +41,11 @@
 
                 <Border IsVisible="{Binding HasRecentCalculators}"
                        Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
-                       Padding="18"
+                       Padding="{StaticResource CardPadding}"
                        Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                        StrokeShape="RoundRectangle 12">
-                   <VerticalStackLayout Spacing="12">
-                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                   <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                            <Label Text="&#xf1da;"
                                   FontFamily="FontAwesomeSolid"
                                   VerticalTextAlignment="Center"
@@ -56,10 +57,10 @@
                                   FontAttributes="Bold"
                                   FontSize="20" />
                        </Grid>
-                       <VerticalStackLayout BindableLayout.ItemsSource="{Binding RecentCalculators}" Spacing="8">
+                       <VerticalStackLayout BindableLayout.ItemsSource="{Binding RecentCalculators}" Spacing="{StaticResource SpaceSm}">
                            <BindableLayout.ItemTemplate>
                                <DataTemplate x:DataType="catalog:CalculatorDefinition">
-                                   <Border Padding="12"
+                                   <Border Padding="{StaticResource CardPaddingCompact}"
                                            Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
                                            StrokeThickness="0"
                                            StrokeShape="RoundRectangle 10"
@@ -68,7 +69,7 @@
                                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:HomeViewModel}}, Path=OpenCalculatorCommand}"
                                                                  CommandParameter="{Binding .}" />
                                        </Border.GestureRecognizers>
-                                       <Grid ColumnDefinitions="32,*,Auto" ColumnSpacing="10">
+                                       <Grid ColumnDefinitions="32,*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                                            <Label Text="{Binding IconGlyph}"
                                                   FontFamily="FontAwesomeSolid"
                                                   FontSize="16"
@@ -97,11 +98,11 @@
 
                 <Border IsVisible="{Binding HasRecentPlans}"
                        Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
-                       Padding="18"
+                       Padding="{StaticResource CardPadding}"
                        Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                        StrokeShape="RoundRectangle 12">
-                   <VerticalStackLayout Spacing="12">
-                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                   <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                            <Label Text="&#xf15c;"
                                   FontFamily="FontAwesomeSolid"
                                   VerticalTextAlignment="Center"
@@ -113,10 +114,10 @@
                                   FontAttributes="Bold"
                                   FontSize="20" />
                        </Grid>
-                       <VerticalStackLayout BindableLayout.ItemsSource="{Binding RecentPlans}" Spacing="8">
+                       <VerticalStackLayout BindableLayout.ItemsSource="{Binding RecentPlans}" Spacing="{StaticResource SpaceSm}">
                            <BindableLayout.ItemTemplate>
                                <DataTemplate x:DataType="viewModels:RecentPlanItem">
-                                   <Border Padding="12"
+                                   <Border Padding="{StaticResource CardPaddingCompact}"
                                            Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
                                            StrokeThickness="0"
                                            StrokeShape="RoundRectangle 10"
@@ -125,7 +126,7 @@
                                            <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:HomeViewModel}}, Path=OpenPlanCommand}"
                                                                  CommandParameter="{Binding .}" />
                                        </Border.GestureRecognizers>
-                                       <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                       <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                                            <VerticalStackLayout Spacing="2">
                                                <Label Text="{Binding Name}"
                                                       TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
@@ -150,17 +151,17 @@
 
                 <Border IsVisible="{Binding ShowRecommendedBooks}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
-                        Padding="18"
+                        Padding="{StaticResource CardPadding}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                   <VerticalStackLayout Spacing="12">
-                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                   <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                            <Label Text="&#xf02d;"
                                   FontFamily="FontAwesomeSolid"
                                   VerticalTextAlignment="Center"
                                   TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
                                   SemanticProperties.Description="Recommended books" />
-                           <VerticalStackLayout Grid.Column="1" Spacing="1">
+                           <VerticalStackLayout Grid.Column="1" Spacing="{StaticResource SpaceXs}">
                                <Label Text="Recommended FIRE books"
                                       TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
                                       FontAttributes="Bold"
@@ -204,7 +205,7 @@
                                                       FontSize="11"
                                                       LineBreakMode="TailTruncation"
                                                       MaxLines="2" />
-                                               <Grid Margin="0,4,0,0" ColumnDefinitions="*,Auto" ColumnSpacing="4">
+                                               <Grid Margin="0,4,0,0" ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceXs}">
                                                    <Label Text="View on Amazon"
                                                           TextColor="{AppThemeBinding Light=#326B57, Dark=#9ACCB3}"
                                                           FontAttributes="Bold"
@@ -222,7 +223,7 @@
                                </DataTemplate>
                            </BindableLayout.ItemTemplate>
                        </FlexLayout>
-                       <Border Padding="12"
+                       <Border Padding="{StaticResource CardPaddingCompact}"
                                Background="{AppThemeBinding Light=#EDF2EE, Dark=#15211C}"
                                Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                                StrokeShape="RoundRectangle 10">
@@ -242,11 +243,11 @@
 
                 <Border IsVisible="{Binding ShowGettingStarted}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
-                        Padding="18"
+                        Padding="{StaticResource CardPadding}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 8">
-                    <VerticalStackLayout Spacing="14">
-                           <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                           <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf1ec;"
                                 FontFamily="FontAwesomeSolid"
                                 VerticalTextAlignment="Center"
@@ -268,7 +269,7 @@
                                 <TapGestureRecognizer Command="{Binding OpenCalculatorCommand}"
                                                       CommandParameter="{Binding RecommendedCalculator}" />
                             </Border.GestureRecognizers>
-                            <Grid ColumnDefinitions="44,*,Auto" ColumnSpacing="12">
+                            <Grid ColumnDefinitions="44,*,Auto" ColumnSpacing="{StaticResource SpaceMd}">
                                 <Label Text="{Binding RecommendedCalculator.IconGlyph}"
                                        FontFamily="FontAwesomeSolid"
                                        FontSize="20"
@@ -302,7 +303,7 @@
                                LineHeight="1.3" />
                         <VerticalStackLayout IsVisible="{Binding ShowFeaturedCalculators}"
                                              BindableLayout.ItemsSource="{Binding FeaturedCalculators}"
-                                             Spacing="10">
+                                             Spacing="{StaticResource SpaceSm}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="catalog:CalculatorDefinition">
                                     <Border Padding="10,8"
@@ -313,7 +314,7 @@
                                             <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:HomeViewModel}}, Path=OpenCalculatorCommand}"
                                                                   CommandParameter="{Binding .}" />
                                         </Border.GestureRecognizers>
-                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceMd}">
                                             <VerticalStackLayout Spacing="2">
                                                 <Label Text="{Binding Title}"
                                                        TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
@@ -333,7 +334,7 @@
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>
                         </VerticalStackLayout>
-                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Button Text="Retake quiz"
                                     Command="{Binding RetakeQuizCommand}"
                                     Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}"

--- a/app/MyFireNumber/Views/OnboardingChoicePage.xaml
+++ b/app/MyFireNumber/Views/OnboardingChoicePage.xaml
@@ -7,10 +7,11 @@
              x:DataType="viewModels:OnboardingChoiceViewModel"
              Title="Choose a starting point"
              Shell.TabBarIsVisible="False"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="Container">
     <Grid>
         <ScrollView>
-            <VerticalStackLayout Padding="24,20,24,32" Spacing="18">
+            <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
                 <VerticalStackLayout Spacing="6">
                     <Label Text="Choose your starting point"
                            FontSize="28"
@@ -23,11 +24,11 @@
                            TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
                 </VerticalStackLayout>
 
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="12">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Label Text="Take the FIRE Quiz"
                                FontSize="20"
                                FontAttributes="Bold"

--- a/app/MyFireNumber/Views/PlansPage.xaml
+++ b/app/MyFireNumber/Views/PlansPage.xaml
@@ -5,11 +5,12 @@
              x:Class="MyFireNumber.Views.PlansPage"
              x:DataType="viewModels:PlansViewModel"
              Title="Plans"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="Container">
 
-    <Grid Padding="20,16" RowDefinitions="Auto,*" RowSpacing="14">
-        <VerticalStackLayout Spacing="14">
-            <Grid ColumnDefinitions="32,*" ColumnSpacing="10">
+    <Grid Padding="{StaticResource PagePaddingCompact}" RowDefinitions="Auto,*" RowSpacing="{StaticResource SpaceMd}">
+        <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+            <Grid ColumnDefinitions="32,*" ColumnSpacing="{StaticResource SpaceSm}">
                         <Label Text="&#xf15c;"
                                FontFamily="FontAwesomeSolid"
                                WidthRequest="32"
@@ -37,7 +38,7 @@
                        TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
                        PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
                        SemanticProperties.Description="Search saved plans by name." />
-            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                 <Label Text="Sort"
                        VerticalTextAlignment="Center"
                        TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
@@ -136,12 +137,12 @@
                                </SwipeItemView>
                            </SwipeItems>
                        </SwipeView.RightItems>
-                       <Border Padding="16"
+                       <Border Padding="{StaticResource CardPadding}"
                                Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                                Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                                StrokeShape="RoundRectangle 12"
                                SemanticProperties.Description="{Binding Name, StringFormat='Saved plan {0}.'}">
-                           <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                           <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceMd}">
                                <Grid.GestureRecognizers>
                                    <TapGestureRecognizer Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:PlansViewModel}}, Path=OpenPlanCommand}"
                                                          CommandParameter="{Binding .}" />
@@ -171,7 +172,7 @@
                 </DataTemplate>
             </CollectionView.ItemTemplate>
             <CollectionView.EmptyView>
-                <VerticalStackLayout VerticalOptions="Center" Spacing="10">
+                <VerticalStackLayout VerticalOptions="Center" Spacing="{StaticResource SpaceSm}">
                     <Label Text="&#xf15c;"
                            FontFamily="FontAwesomeSolid"
                            HorizontalTextAlignment="Center"

--- a/app/MyFireNumber/Views/QuizPage.xaml
+++ b/app/MyFireNumber/Views/QuizPage.xaml
@@ -8,7 +8,8 @@
              Title="FIRE Quiz"
              Shell.NavBarIsVisible="True"
              Shell.TabBarIsVisible="False"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Skip"
                      Command="{Binding SkipCommand}"
@@ -17,8 +18,8 @@
 
     <Grid>
         <ScrollView>
-            <VerticalStackLayout Padding="24,20,24,32" Spacing="18">
-                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+            <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
+                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceMd}">
                     <Label Text="&#xf059;"
                            FontFamily="FontAwesomeSolid"
                            VerticalTextAlignment="Center"
@@ -38,7 +39,7 @@
                     </VerticalStackLayout>
                 </Grid>
 
-                <VerticalStackLayout IsVisible="{Binding IsQuestionVisible}" Spacing="18">
+                <VerticalStackLayout IsVisible="{Binding IsQuestionVisible}" Spacing="{StaticResource SpaceLg}">
                     <VerticalStackLayout Spacing="6">
                         <Label Text="{Binding QuestionProgressText}"
                                FontSize="13"
@@ -49,11 +50,11 @@
                                      SemanticProperties.Description="{Binding QuestionProgressText}" />
                     </VerticalStackLayout>
 
-                    <Border Padding="18"
+                    <Border Padding="{StaticResource CardPadding}"
                             Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                             Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                             StrokeShape="RoundRectangle 12">
-                        <VerticalStackLayout Spacing="14">
+                        <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                             <VerticalStackLayout Spacing="4">
                                 <Label Text="{Binding QuestionTitle}"
                                        FontAttributes="Bold"
@@ -66,7 +67,7 @@
                             </VerticalStackLayout>
 
                             <VerticalStackLayout BindableLayout.ItemsSource="{Binding Choices}"
-                                                 Spacing="8">
+                                                 Spacing="{StaticResource SpaceSm}">
                                 <BindableLayout.ItemTemplate>
                                     <DataTemplate x:DataType="viewModels:QuizChoice">
                                         <Grid MinimumHeightRequest="72">
@@ -129,7 +130,7 @@
                         </VerticalStackLayout>
                     </Border>
 
-                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                    <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                         <Button Text="Previous"
                                 Command="{Binding PreviousCommand}"
                                 IsEnabled="{Binding CanGoBack}"
@@ -145,8 +146,8 @@
                     </Grid>
                 </VerticalStackLayout>
 
-                <VerticalStackLayout IsVisible="{Binding IsRecommendationVisible}" Spacing="20">
-                    <VerticalStackLayout Spacing="5">
+                <VerticalStackLayout IsVisible="{Binding IsRecommendationVisible}" Spacing="{StaticResource SpaceLg}">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceXs}">
                         <Label Text="Your best FIRE starting point"
                                FontAttributes="Bold"
                                FontSize="26"
@@ -162,7 +163,7 @@
                             Stroke="{AppThemeBinding Light=#A8D4B2, Dark=#43805B}"
                             StrokeThickness="2"
                             StrokeShape="RoundRectangle 12">
-                        <VerticalStackLayout Spacing="12">
+                        <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                             <Label Text="{Binding PrimaryRecommendation.IconGlyph}"
                                    FontFamily="FontAwesomeSolid"
                                    FontSize="32"
@@ -198,7 +199,7 @@
                         </VerticalStackLayout>
                     </Border>
 
-                    <VerticalStackLayout Spacing="10">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                         <Label Text="Two paths worth comparing"
                                FontAttributes="Bold"
                                FontSize="20"
@@ -207,14 +208,14 @@
                                TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
                                LineHeight="1.3" />
                         <VerticalStackLayout BindableLayout.ItemsSource="{Binding AlternativeRecommendations}"
-                                             Spacing="10">
+                                             Spacing="{StaticResource SpaceSm}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:QuizRecommendationOption">
-                                    <Border Padding="16"
+                                    <Border Padding="{StaticResource CardPadding}"
                                             Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                                             Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                                             StrokeShape="RoundRectangle 10">
-                                        <VerticalStackLayout Spacing="8">
+                                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                                             <Label Text="{Binding Title}"
                                                    FontAttributes="Bold"
                                                    FontSize="18"

--- a/app/MyFireNumber/Views/RetirementAnnualDetailsPage.xaml
+++ b/app/MyFireNumber/Views/RetirementAnnualDetailsPage.xaml
@@ -7,8 +7,9 @@
              Title="Annual Cash Flow"
              Shell.NavBarIsVisible="True"
              Shell.TabBarIsVisible="False"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
-    <Grid Padding="20,16,20,0" RowDefinitions="Auto,*" RowSpacing="14">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="All">
+    <Grid Padding="{StaticResource PagePaddingCompact}" RowDefinitions="Auto,*" RowSpacing="{StaticResource SpaceMd}">
         <VerticalStackLayout Spacing="4">
             <Label Text="Annual cash-flow details"
                    FontAttributes="Bold"
@@ -28,7 +29,7 @@
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="viewModels:RetirementAnnualDetailItem">
                     <Border Margin="0,0,0,10"
-                            Padding="16"
+                            Padding="{StaticResource CardPadding}"
                             Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                             Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                             StrokeShape="RoundRectangle 12"
@@ -36,8 +37,8 @@
                         <Border.GestureRecognizers>
                             <TapGestureRecognizer Command="{Binding ToggleCommand}" />
                         </Border.GestureRecognizers>
-                        <Grid RowDefinitions="Auto,Auto" RowSpacing="12">
-                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                        <Grid RowDefinitions="Auto,Auto" RowSpacing="{StaticResource SpaceMd}">
+                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceMd}">
                                 <VerticalStackLayout Spacing="3">
                                     <Label Text="{Binding Title}"
                                            FontAttributes="Bold"
@@ -57,8 +58,8 @@
 
                             <VerticalStackLayout Grid.Row="1"
                                                  IsVisible="{Binding IsExpanded}"
-                                                 Spacing="12">
-                                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
+                                                 Spacing="{StaticResource SpaceMd}">
+                                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
                                     <Border Padding="10" StrokeThickness="0" Background="{AppThemeBinding Light=#EAF4EC, Dark=#29483B}" StrokeShape="RoundRectangle 8">
                                         <VerticalStackLayout Spacing="2"><Label Text="Income" FontSize="12" /><Label Text="{Binding IncomeText}" FontAttributes="Bold" /></VerticalStackLayout>
                                     </Border>

--- a/app/MyFireNumber/Views/RetirementCashFlowPage.xaml
+++ b/app/MyFireNumber/Views/RetirementCashFlowPage.xaml
@@ -9,7 +9,8 @@
              x:DataType="viewModels:RetirementCashFlowViewModel"
              Title="{Binding Title}"
              Shell.NavBarIsVisible="True"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="All">
 
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
@@ -20,7 +21,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}"
                                IsVisible="{Binding IsLoading}"
                                HorizontalOptions="Center"
@@ -40,22 +41,22 @@
                                              Summary="Coordinate accounts, deferred payouts, earned income, and expenses in one retirement timeline."
                                              Details="Retirement cash flow planning shows when money enters and leaves your plan year by year, including deferred compensation, retirement accounts, savings, part-time income, and expenses. It can reveal funding gaps that a single portfolio target may miss. It may fit people with complex, multi-account or phased-retirement plans."
                                              IconGlyph="&#xf1da;" />
-                <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                    <VerticalStackLayout Spacing="12">
+                <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Label Text="Scenario" Style="{StaticResource CalculatorSectionHeading}" />
                         <controls:PeriodToggleView />
-                        <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceMd}">
                             <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="45" Text="{Binding RetirementCurrentAgeText}" />
                             <controls:NumericInputView Grid.Column="1" Header="Semi-retirement age" HelpText="The age when your plan changes from full-time work." Placeholder="55" Text="{Binding RetirementSemiAgeText}" />
                         </Grid>
                         <controls:NumericInputView Header="Retirement expenses" HelpText="Expected retirement spending, in today’s dollars." Placeholder="80000" Text="{Binding RetirementExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                         <controls:AdvancedAssumptionsExpander>
-                            <VerticalStackLayout Margin="0,12,0,0" Spacing="12">
-                                <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+                            <VerticalStackLayout Margin="0,12,0,0" Spacing="{StaticResource SpaceMd}">
+                                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceMd}">
                                     <controls:NumericInputView Header="Plan through age" HelpText="The last age included in the cash-flow plan." Placeholder="90" Text="{Binding RetirementPlanThroughAgeText}" />
                                     <controls:PercentageInputView Grid.Column="1" Header="Inflation rate (%)" HelpText="Expected annual increase in expenses." Placeholder="3" Minimum="0" Maximum="10" Text="{Binding RetirementInflationText}" />
                                 </Grid>
-                                <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="8">
+                                <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,Auto" RowSpacing="{StaticResource SpaceSm}">
                                     <Label Text="Withdraw only after semi-retirement" VerticalTextAlignment="Center" />
                                     <Switch Grid.Column="1" IsToggled="{Binding WithdrawOnlyAfterRetirement}" SemanticProperties.Description="Withdraw from accounts only after semi-retirement" />
                                     <Label Grid.Row="1" Text="Reinvest annual surplus" VerticalTextAlignment="Center" />
@@ -67,37 +68,37 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Padding="16"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 8">
-                    <VerticalStackLayout Spacing="12">
-                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf1c0;" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#9A5C17, Dark=#F2B56D}" SemanticProperties.Description="Retirement accounts" />
-                            <Label Grid.Column="1" Text="Accounts" FontAttributes="Bold" FontSize="20" />
+                            <Label Grid.Column="1" Text="Accounts" Style="{StaticResource CalculatorSectionHeading}" />
                             <Button Grid.Column="2" Text="Add" Command="{Binding AddRetirementAccountCommand}" Background="#FFF0DD" TextColor="#7A4A1A" FontSize="12" SemanticProperties.Description="Add a retirement account.">
                                 <Button.ImageSource><FontImageSource FontFamily="FontAwesomeSolid" Glyph="&#xf067;" Color="#7A4A1A" Size="12" /></Button.ImageSource>
                             </Button>
                         </Grid>
-                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding RetirementAccounts}" Spacing="10">
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding RetirementAccounts}" Spacing="{StaticResource SpaceSm}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:RetirementAccountEditorItem">
-                                    <Border Padding="12" Background="{AppThemeBinding Light=#FFF9F3, Dark=#2B2019}" Stroke="{AppThemeBinding Light=#F1D5BB, Dark=#634631}" StrokeShape="RoundRectangle 8">
-                                        <VerticalStackLayout Spacing="8">
-                                            <Grid ColumnDefinitions="*,32,44" ColumnSpacing="8">
+                                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFF9F3, Dark=#2B2019}" Stroke="{AppThemeBinding Light=#F1D5BB, Dark=#634631}" StrokeShape="RoundRectangle 8">
+                                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                                            <Grid ColumnDefinitions="*,32,44" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <Grid.GestureRecognizers><TapGestureRecognizer Command="{Binding ToggleExpandedCommand}" /></Grid.GestureRecognizers>
                                                 <Label Text="{Binding Name}" FontAttributes="Bold" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" SemanticProperties.Description="{Binding Name, StringFormat='Expand or collapse {0} account.'}" />
                                                 <Label Grid.Column="1" Text="{Binding ExpansionGlyph}" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" TextColor="{AppThemeBinding Light=#9A5C17, Dark=#F2B56D}" />
                                                 <Button Grid.Column="2" Text="&#xf2ed;" FontFamily="FontAwesomeSolid" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveRetirementAccountCommand}" CommandParameter="{Binding .}" Background="#FCE5E1" TextColor="#7C352E" Padding="0" SemanticProperties.Description="Remove this retirement account." />
                                             </Grid>
-                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="8">
+                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="{StaticResource SpaceSm}">
                                             <Entry Text="{Binding Name, Mode=TwoWay}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="Account name" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Retirement account name" />
                                             <Picker Title="Account type" ItemsSource="{Binding AccountTypes}" SelectedItem="{Binding Type, Mode=TwoWay}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" TitleColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Retirement account type" />
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <VerticalStackLayout Spacing="3"><Label Text="Balance" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding BalanceText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="0" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Current account balance in dollars" /></VerticalStackLayout>
                                                 <VerticalStackLayout Grid.Column="1" Spacing="3"><Label Text="Annual contribution (today's dollars)" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding AnnualContributionText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="0" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Annual account contribution in dollars" /></VerticalStackLayout>
                                             </Grid>
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <VerticalStackLayout Spacing="3"><Label Text="Return (%)" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding AnnualReturnText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="5" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Expected annual account return percentage" /></VerticalStackLayout>
                                                 <VerticalStackLayout Grid.Column="1" Spacing="3"><Label Text="Available age" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding AvailableAgeText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="59" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Age when this account becomes available" /></VerticalStackLayout>
                                             </Grid>
@@ -113,42 +114,42 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Padding="16"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 8">
-                    <VerticalStackLayout Spacing="12">
-                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf0d6;" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#2F6B57, Dark=#9ACCB3}" SemanticProperties.Description="Retirement income" />
-                            <Label Grid.Column="1" Text="Income sources" FontAttributes="Bold" FontSize="20" />
+                            <Label Grid.Column="1" Text="Income sources" Style="{StaticResource CalculatorSectionHeading}" />
                             <Button Grid.Column="2" Text="Add" Command="{Binding AddRetirementIncomeCommand}" Background="#E4F0E9" TextColor="#245744" FontSize="12" SemanticProperties.Description="Add a retirement income source.">
                                 <Button.ImageSource><FontImageSource FontFamily="FontAwesomeSolid" Glyph="&#xf067;" Color="#245744" Size="12" /></Button.ImageSource>
                             </Button>
                         </Grid>
-                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding RetirementIncomeSources}" Spacing="10">
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding RetirementIncomeSources}" Spacing="{StaticResource SpaceSm}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:RetirementIncomeEditorItem">
-                                    <Border Padding="12" Background="{AppThemeBinding Light=#F4FAF6, Dark=#182A22}" Stroke="{AppThemeBinding Light=#C8DDD0, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                                        <VerticalStackLayout Spacing="8">
-                                            <Grid ColumnDefinitions="*,32,44" ColumnSpacing="8">
+                                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#F4FAF6, Dark=#182A22}" Stroke="{AppThemeBinding Light=#C8DDD0, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                                            <Grid ColumnDefinitions="*,32,44" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <Grid.GestureRecognizers><TapGestureRecognizer Command="{Binding ToggleExpandedCommand}" /></Grid.GestureRecognizers>
                                                 <Label Text="{Binding Name}" FontAttributes="Bold" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#245744, Dark=#C8E7D5}" SemanticProperties.Description="{Binding Name, StringFormat='Expand or collapse {0} income source.'}" />
                                                 <Label Grid.Column="1" Text="{Binding ExpansionGlyph}" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" TextColor="{AppThemeBinding Light=#2F6B57, Dark=#9ACCB3}" />
                                                 <Button Grid.Column="2" Text="&#xf2ed;" FontFamily="FontAwesomeSolid" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveRetirementIncomeCommand}" CommandParameter="{Binding .}" Background="#FCE5E1" TextColor="#7C352E" Padding="0" SemanticProperties.Description="Remove this retirement income source." />
                                             </Grid>
-                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="8">
+                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="{StaticResource SpaceSm}">
                                             <Entry Text="{Binding Name, Mode=TwoWay}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="Income name" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Retirement income source name" />
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <VerticalStackLayout Spacing="3"><Label Text="Annual amount" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding AnnualAmountText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="0" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Annual retirement income amount in dollars" /></VerticalStackLayout>
                                                 <VerticalStackLayout Grid.Column="1" Spacing="3"><Label Text="Growth (%)" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding AnnualGrowthText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="0" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Annual retirement income growth percentage" /></VerticalStackLayout>
                                             </Grid>
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <VerticalStackLayout Spacing="3"><Label Text="Start age" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding StartAgeText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="55" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Income start age" /></VerticalStackLayout>
                                                 <VerticalStackLayout Grid.Column="1" Spacing="3"><Label Text="End age" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding EndAgeText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="65" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Income end age" /></VerticalStackLayout>
                                             </Grid>
-                                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                                                <VerticalStackLayout IsVisible="{Binding RequiresTaxRate}" Spacing="3"><Label Text="Tax rate (%)" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding TaxRateText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="0" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Income tax rate percentage" /></VerticalStackLayout>
-                                                <HorizontalStackLayout Grid.Column="1" Spacing="8" VerticalOptions="Center"><Label Text="After tax" VerticalTextAlignment="Center" /><Switch IsToggled="{Binding IsAfterTax, Mode=TwoWay}" SemanticProperties.Description="Income amount is after tax" /></HorizontalStackLayout>
+                                                <HorizontalStackLayout Grid.Column="1" Spacing="{StaticResource SpaceSm}" VerticalOptions="Center"><Label Text="After tax" VerticalTextAlignment="Center" /><Switch IsToggled="{Binding IsAfterTax, Mode=TwoWay}" SemanticProperties.Description="Income amount is after tax" /></HorizontalStackLayout>
                                             </Grid>
                                             </VerticalStackLayout>
                                         </VerticalStackLayout>
@@ -159,33 +160,33 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Padding="16"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 8">
-                    <VerticalStackLayout Spacing="12">
-                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf53d;" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#A6473C, Dark=#FFB9B1}" SemanticProperties.Description="Additional retirement expenses" />
-                            <Label Grid.Column="1" Text="Additional expenses" FontAttributes="Bold" FontSize="20" />
+                            <Label Grid.Column="1" Text="Additional expenses" Style="{StaticResource CalculatorSectionHeading}" />
                             <Button Grid.Column="2" Text="Add" Command="{Binding AddRetirementExpenseCommand}" Background="#FCE5E1" TextColor="#7C352E" FontSize="12" SemanticProperties.Description="Add an additional retirement expense.">
                                 <Button.ImageSource><FontImageSource FontFamily="FontAwesomeSolid" Glyph="&#xf067;" Color="#7C352E" Size="12" /></Button.ImageSource>
                             </Button>
                         </Grid>
-                        <VerticalStackLayout Spacing="10">
-                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding RetirementAdditionalExpenses}" Spacing="10">
+                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding RetirementAdditionalExpenses}" Spacing="{StaticResource SpaceSm}">
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:RetirementExpenseEditorItem">
-                                    <Border Padding="12" Background="{AppThemeBinding Light=#FFF7F5, Dark=#2E201E}" Stroke="{AppThemeBinding Light=#EBCBC6, Dark=#68413C}" StrokeShape="RoundRectangle 8">
-                                        <VerticalStackLayout Spacing="8">
-                                            <Grid ColumnDefinitions="*,32,44" ColumnSpacing="8">
+                                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFF7F5, Dark=#2E201E}" Stroke="{AppThemeBinding Light=#EBCBC6, Dark=#68413C}" StrokeShape="RoundRectangle 8">
+                                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                                            <Grid ColumnDefinitions="*,32,44" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <Grid.GestureRecognizers><TapGestureRecognizer Command="{Binding ToggleExpandedCommand}" /></Grid.GestureRecognizers>
                                                 <Label Text="{Binding Name}" FontAttributes="Bold" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#7C352E, Dark=#FFB9B1}" SemanticProperties.Description="{Binding Name, StringFormat='Expand or collapse {0} additional expense.'}" />
                                                 <Label Grid.Column="1" Text="{Binding ExpansionGlyph}" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" TextColor="{AppThemeBinding Light=#A6473C, Dark=#FFB9B1}" />
                                                 <Button Grid.Column="2" Text="&#xf2ed;" FontFamily="FontAwesomeSolid" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveRetirementExpenseCommand}" CommandParameter="{Binding .}" Background="#FCE5E1" TextColor="#7C352E" Padding="0" SemanticProperties.Description="Remove this additional retirement expense." />
                                             </Grid>
-                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="8">
+                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="{StaticResource SpaceSm}">
                                             <Entry Text="{Binding Name, Mode=TwoWay}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="Expense name" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Additional retirement expense name" />
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <VerticalStackLayout Spacing="3"><Label Text="Annual amount" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding AnnualAmountText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="0" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Additional annual expense amount in dollars" /></VerticalStackLayout>
                                                 <VerticalStackLayout Grid.Column="1" Spacing="3"><Label Text="Start age" FontAttributes="Bold" FontSize="12" /><Entry Text="{Binding StartAgeText, Mode=TwoWay}" Keyboard="Numeric" Background="{AppThemeBinding Light=#FFFFFF, Dark=#15211C}" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" Placeholder="55" PlaceholderColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}" SemanticProperties.Description="Additional expense start age" /></VerticalStackLayout>
                                             </Grid>
@@ -199,18 +200,20 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="10"><Label Text="Cash-flow outlook" FontAttributes="Bold" FontSize="20" /><Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="10"><VerticalStackLayout Spacing="2"><Label Text="Current balance" FontSize="12" /><Label Text="{Binding RetirementCurrentBalanceText}" FontAttributes="Bold" FontSize="18" /><Label Text="Today's dollars" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Column="1" Spacing="2"><Label Text="At semi-retirement" FontSize="12" /><Label Text="{Binding RetirementBalanceAtSemiText}" FontAttributes="Bold" FontSize="18" /><Label Text="{Binding RetirementBalanceBasisText}" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Row="1" Spacing="2"><Label Text="Ending balance" FontSize="12" /><Label Text="{Binding RetirementEndingBalanceText}" FontAttributes="Bold" FontSize="18" /><Label Text="{Binding RetirementEndingBasisText}" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="2"><Label Text="First shortfall" FontSize="12" /><Label AutomationId="RetirementFirstShortfallLabel" Text="{Binding RetirementFirstShortfallText}" FontAttributes="Bold" FontSize="18" /><Label Text="First retirement year the reachable accounts cannot cover expenses" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Row="2" Grid.ColumnSpan="2" Spacing="2"><Label Text="Funded years" FontSize="12" /><Label Text="{Binding RetirementFundedYearsText}" FontAttributes="Bold" FontSize="16" /></VerticalStackLayout></Grid><Border IsVisible="{Binding HasRetirementPolicyExcess}" Padding="12" Background="{AppThemeBinding Light=#FFF6E5, Dark=#3A2F1B}" Stroke="{AppThemeBinding Light=#E8C889, Dark=#6B5426}" StrokeShape="RoundRectangle 8"><Label Text="{Binding RetirementPolicyExcessText}" FontSize="12" /></Border><Label Text="Income and withdrawal figures are spendable after-tax dollars using a flat estimated rate per account, not a bracket calculation. Balances shown for future ages are future dollars." FontSize="11" /><lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" /><Button AutomationId="AnnualCashFlowDetailsButton" Text="View annual cash-flow details" Command="{Binding ViewRetirementAnnualDetailsCommand}" Background="#FFF0DD" TextColor="#7A4A1A" SemanticProperties.Description="Open expandable annual retirement cash-flow details."><Button.ImageSource><FontImageSource FontFamily="FontAwesomeSolid" Glyph="&#xf03a;" Color="#7A4A1A" Size="14" /></Button.ImageSource></Button></VerticalStackLayout></Border>
-                <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                    <VerticalStackLayout Spacing="10">
-                        <Label Text="Account balances over time" FontAttributes="Bold" FontSize="20" />
-                        <VerticalStackLayout Spacing="10">
+                <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                        <Label Text="Cash-flow outlook" Style="{StaticResource CalculatorSectionHeading}" /><Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}"><VerticalStackLayout Spacing="2"><Label Text="Current balance" FontSize="12" /><Label Text="{Binding RetirementCurrentBalanceText}" FontAttributes="Bold" FontSize="18" /><Label Text="Today's dollars" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Column="1" Spacing="2"><Label Text="At semi-retirement" FontSize="12" /><Label Text="{Binding RetirementBalanceAtSemiText}" FontAttributes="Bold" FontSize="18" /><Label Text="{Binding RetirementBalanceBasisText}" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Row="1" Spacing="2"><Label Text="Ending balance" FontSize="12" /><Label Text="{Binding RetirementEndingBalanceText}" FontAttributes="Bold" FontSize="18" /><Label Text="{Binding RetirementEndingBasisText}" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Row="1" Grid.Column="1" Spacing="2"><Label Text="First shortfall" FontSize="12" /><Label AutomationId="RetirementFirstShortfallLabel" Text="{Binding RetirementFirstShortfallText}" FontAttributes="Bold" FontSize="18" /><Label Text="First retirement year the reachable accounts cannot cover expenses" FontSize="11" /></VerticalStackLayout><VerticalStackLayout Grid.Row="2" Grid.ColumnSpan="2" Spacing="2"><Label Text="Funded years" FontSize="12" /><Label Text="{Binding RetirementFundedYearsText}" FontAttributes="Bold" FontSize="16" /></VerticalStackLayout></Grid><Border IsVisible="{Binding HasRetirementPolicyExcess}" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFF6E5, Dark=#3A2F1B}" Stroke="{AppThemeBinding Light=#E8C889, Dark=#6B5426}" StrokeShape="RoundRectangle 8"><Label Text="{Binding RetirementPolicyExcessText}" FontSize="12" /></Border><Label Text="Income and withdrawal figures are spendable after-tax dollars using a flat estimated rate per account, not a bracket calculation. Balances shown for future ages are future dollars." FontSize="11" /><lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" /><Button AutomationId="AnnualCashFlowDetailsButton" Text="View annual cash-flow details" Command="{Binding ViewRetirementAnnualDetailsCommand}" Background="#FFF0DD" TextColor="#7A4A1A" SemanticProperties.Description="Open expandable annual retirement cash-flow details."><Button.ImageSource><FontImageSource FontFamily="FontAwesomeSolid" Glyph="&#xf03a;" Color="#7A4A1A" Size="14" /></Button.ImageSource></Button></VerticalStackLayout></Border>
+                <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                        <Label Text="Account balances over time" Style="{StaticResource CalculatorSectionHeading}" />
+                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                             <lvc:CartesianChart Series="{Binding RetirementBucketSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding RetirementBucketDescription}" />
                             <Label Text="{Binding RetirementBucketSummary}" TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" FontSize="13" LineHeight="1.3" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
-                <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                    <VerticalStackLayout Spacing="10">
+                <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                         <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                         <Entry Text="{Binding PlanNameText}" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" Placeholder="My Retirement Cash Flow Plan" SemanticProperties.Description="Name for this saved Retirement Cash Flow plan" />
                         <Button Text="Save and return"

--- a/app/MyFireNumber/Views/ReverseFirePage.xaml
+++ b/app/MyFireNumber/Views/ReverseFirePage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:ReverseFireViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,7 +20,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" HorizontalOptions="Center" SemanticProperties.Description="Restoring your local calculator draft." />
             <Border IsVisible="{Binding HasValidationMessage}" Padding="14" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" Stroke="{AppThemeBinding Light=#C97727, Dark=#F2B56D}" StrokeShape="RoundRectangle 8"><Label Text="{Binding ValidationMessage}" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" LineHeight="1.3" /></Border>
 
@@ -28,18 +29,18 @@
                                          Details="Reverse FIRE makes the tradeoff between a target date, the portfolio target, and the savings needed explicit."
                                          IconGlyph="&#xf2f1;" />
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="14">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Your FIRE goal" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Reverse FIRE values to their defaults." /></Grid>
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}"><Label Text="Your FIRE goal" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Reverse FIRE values to their defaults." /></Grid>
                     <controls:PeriodToggleView />
-                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Target FIRE age" HelpText="The age at which you want to be financially independent." Placeholder="55" Text="{Binding RetirementAgeText}" />
                         <controls:NumericInputView Grid.Row="1" Header="Current savings" HelpText="Invested assets available for this goal, in dollars." Placeholder="100000" Text="{Binding CurrentSavingsText}" />
                         <controls:NumericInputView Grid.Row="1" Grid.Column="1" Header="Retirement expenses" HelpText="Expected spending after retirement, in today’s dollars." Placeholder="48000" Text="{Binding AnnualExpensesText}" PeriodQualifier="{Binding DisplayPeriodQualifier}" PeriodSuffix="{Binding DisplayPeriodSuffix}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
-                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                             <controls:PercentageInputView Header="Expected return (%)" HelpText="Expected average annual investment return before inflation." Placeholder="7" Minimum="0" Maximum="15" Text="{Binding ExpectedReturnText}" />
                             <controls:PercentageInputView Grid.Column="1" Header="Inflation (%)" HelpText="Expected annual increase in the cost of living." Placeholder="3" Minimum="0" Maximum="10" Text="{Binding InflationRateText}" />
                             <controls:PercentageInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Withdrawal rate (%)" HelpText="First-year percentage withdrawn from the portfolio. This is an assumption, not a promise." Placeholder="4" Minimum="2" Maximum="6" Text="{Binding WithdrawalRateText}" />
@@ -48,24 +49,25 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
-                <Label Text="{Binding ReverseStatusText}" Style="{StaticResource CalculatorSectionHeading}" />
-                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#E8F7F7, Dark=#19393C}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly savings needed" FontSize="12" /><Label Text="{Binding ReverseRequiredMonthlySavingsText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Annual savings needed" FontSize="12" /><Label Text="{Binding ReverseRequiredAnnualSavingsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Years to FIRE" FontSize="12" /><Label Text="{Binding ReverseYearsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Current savings will grow to" FontSize="12" /><Label Text="{Binding ReverseCurrentGrowthText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                <Label Text="Your Reverse FIRE outlook" Style="{StaticResource CalculatorSectionHeading}" />
+                <Label Text="{Binding ReverseStatusText}" Style="{StaticResource CalculatorStatusHeadline}" SemanticProperties.Description="{Binding ReverseStatusText}" />
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#E8F7F7, Dark=#19393C}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly savings needed" FontSize="12" /><Label Text="{Binding ReverseRequiredMonthlySavingsText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Annual savings needed" FontSize="12" /><Label Text="{Binding ReverseRequiredAnnualSavingsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Years to FIRE" FontSize="12" /><Label Text="{Binding ReverseYearsText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Current savings will grow to" FontSize="12" /><Label Text="{Binding ReverseCurrentGrowthText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Portfolio projection" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" />
                 <Label Text="{Binding ReverseProjectionSummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}" Placeholder="My Reverse FIRE Plan" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" SemanticProperties.Description="Name for this saved Reverse FIRE plan" />
                     <Button Text="{Binding SavePlanActionText}" Command="{Binding SavePlanCommand}" SemanticProperties.Description="{Binding SavePlanActionDescription}" />

--- a/app/MyFireNumber/Views/SavingsInvestmentPage.xaml
+++ b/app/MyFireNumber/Views/SavingsInvestmentPage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:SavingsInvestmentViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,7 +20,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" HorizontalOptions="Center" SemanticProperties.Description="Restoring your local calculator draft." />
             <Border IsVisible="{Binding HasValidationMessage}" Padding="14" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" Stroke="{AppThemeBinding Light=#C97727, Dark=#F2B56D}" StrokeShape="RoundRectangle 8"><Label Text="{Binding ValidationMessage}" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" LineHeight="1.3" /></Border>
 
@@ -28,11 +29,11 @@
                                          Details="This estimate shows how a starting balance, recurring contributions, and a time horizon can affect a future portfolio."
                                          IconGlyph="&#xf0eb;" />
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="14">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Your investment details" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Savings and Investment Rate values to their defaults." /></Grid>
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}"><Label Text="Your investment details" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Savings and Investment Rate values to their defaults." /></Grid>
                     <controls:PeriodToggleView />
-                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                    <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                         <controls:NumericInputView Header="Current age" HelpText="Your age today, in years." Placeholder="30" Text="{Binding CurrentAgeText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Years investing" HelpText="How long contributions and growth should be modeled." Placeholder="30" Text="{Binding YearsInvestingText}" />
                         <controls:NumericInputView Grid.Row="1" Header="Starting amount" HelpText="Current invested balance, in dollars." Placeholder="100000" Text="{Binding StartingAmountText}" />
@@ -40,7 +41,7 @@
                     </Grid>
                     <VerticalStackLayout Spacing="6">
                         <controls:FieldHelpView Header="Contribution frequency" HelpText="Choose whether the contribution amount represents a monthly or yearly amount." />
-                        <Grid ColumnDefinitions="*,*" ColumnSpacing="8">
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Button Text="Monthly" Command="{Binding SetContributionFrequencyCommand}" CommandParameter="monthly" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" SemanticProperties.Description="Use a monthly contribution amount.">
                                 <Button.Triggers><DataTrigger TargetType="Button" Binding="{Binding IsMonthlyContribution}" Value="True"><Setter Property="Background" Value="{StaticResource Primary}" /><Setter Property="TextColor" Value="{StaticResource White}" /></DataTrigger></Button.Triggers>
                             </Button>
@@ -51,7 +52,7 @@
                     </VerticalStackLayout>
                     <controls:NumericInputView Header="{Binding ContributionAmountHeader}" HelpText="The amount you invest at the selected frequency, in dollars." Placeholder="500" Text="{Binding InvestmentContributionText}" />
                     <controls:AdvancedAssumptionsExpander>
-                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" ColumnSpacing="12">
+                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceMd}">
                             <controls:PercentageInputView Header="Expected return (%)" HelpText="Expected average annual investment return before inflation." Placeholder="7" Minimum="0" Maximum="15" Text="{Binding ExpectedReturnText}" />
                             <controls:PercentageInputView Grid.Column="1" Header="Inflation (%)" HelpText="Expected annual increase in the cost of living." Placeholder="3" Minimum="0" Maximum="10" Text="{Binding InflationRateText}" />
                         </Grid>
@@ -59,25 +60,26 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
-                <Label Text="{Binding InvestmentCategoryText}" Style="{StaticResource CalculatorSectionHeading}" />
-                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="10" RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#EEF0FA, Dark=#2A2E4C}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Savings rate" FontSize="12" /><Label Text="{Binding InvestmentSavingsRateText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Annual contribution" FontSize="12" /><Label Text="{Binding InvestmentAnnualContributionText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.ColumnSpan="2" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Projected portfolio" FontSize="12" /><Label Text="{Binding InvestmentFinalBalanceText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="2" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Today's dollars" FontSize="12" /><Label Text="{Binding InvestmentInflationAdjustedText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="2" Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total growth" FontSize="12" /><Label Text="{Binding InvestmentGrowthText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                <Label Text="Your investment outlook" Style="{StaticResource CalculatorSectionHeading}" />
+                <Label Text="{Binding InvestmentCategoryText}" Style="{StaticResource CalculatorStatusHeadline}" SemanticProperties.Description="{Binding InvestmentCategoryText}" />
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#EEF0FA, Dark=#2A2E4C}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Savings rate" FontSize="12" /><Label Text="{Binding InvestmentSavingsRateText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Annual contribution" FontSize="12" /><Label Text="{Binding InvestmentAnnualContributionText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.ColumnSpan="2" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Projected portfolio" FontSize="12" /><Label Text="{Binding InvestmentFinalBalanceText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="2" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Today's dollars" FontSize="12" /><Label Text="{Binding InvestmentInflationAdjustedText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="2" Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Total growth" FontSize="12" /><Label Text="{Binding InvestmentGrowthText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Investment growth projection" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" />
                 <Label Text="{Binding InvestmentProjectionSummary}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}" Placeholder="My Investment Plan" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" SemanticProperties.Description="Name for this saved Savings and Investment Rate plan" />
                     <Button Text="{Binding SavePlanActionText}" Command="{Binding SavePlanCommand}" SemanticProperties.Description="{Binding SavePlanActionDescription}" />

--- a/app/MyFireNumber/Views/SettingsPage.xaml
+++ b/app/MyFireNumber/Views/SettingsPage.xaml
@@ -7,12 +7,13 @@
              x:Class="MyFireNumber.Views.SettingsPage"
              x:DataType="viewModels:SettingsViewModel"
              Title="Settings"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="Container">
 
     <Grid>
         <ScrollView>
-            <VerticalStackLayout Padding="24" Spacing="18">
-                  <Grid ColumnDefinitions="Auto,*" ColumnSpacing="12">
+            <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
+                  <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceMd}">
                       <Label Text="&#xf013;"
                               FontFamily="FontAwesomeSolid"
                               VerticalTextAlignment="Center"
@@ -26,12 +27,12 @@
                           FontSize="30"
                           SemanticProperties.HeadingLevel="Level1" />
                   </Grid>
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                        Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                        Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                        StrokeShape="RoundRectangle 12">
-                   <VerticalStackLayout Spacing="12">
-                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                   <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                            <Label Text="&#xf53f;"
                                   FontFamily="FontAwesomeSolid"
                                   VerticalTextAlignment="Center"
@@ -50,7 +51,7 @@
                                Background="{AppThemeBinding Light=#EDF2EE, Dark=#15211C}"
                                StrokeThickness="0"
                                StrokeShape="RoundRectangle 12">
-                           <Grid ColumnDefinitions="*,*,*" ColumnSpacing="4">
+                           <Grid ColumnDefinitions="*,*,*" ColumnSpacing="{StaticResource SpaceXs}">
                                <Button AutomationId="SystemThemeButton"
                                        Text="&#xf108;"
                                        FontFamily="FontAwesomeSolid"
@@ -108,12 +109,12 @@
                        </Border>
                    </VerticalStackLayout>
                 </Border>
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="12">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf085;"
                                    FontFamily="FontAwesomeSolid"
                                    VerticalTextAlignment="Center"
@@ -131,7 +132,7 @@
                                 Background="{AppThemeBinding Light=#EDF2EE, Dark=#15211C}"
                                 StrokeThickness="0"
                                 StrokeShape="RoundRectangle 12">
-                            <Grid ColumnDefinitions="*,*,*" ColumnSpacing="4">
+                            <Grid ColumnDefinitions="*,*,*" ColumnSpacing="{StaticResource SpaceXs}">
                                 <Button AutomationId="LaunchHomeButton"
                                         Text="Home"
                                         Padding="6,10"
@@ -183,7 +184,7 @@
                                FontSize="12"
                                TextColor="{AppThemeBinding Light=#587068, Dark=#B9D1C2}"
                                SemanticProperties.Description="{Binding LaunchDestinationDescription}" />
-                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="12" RowSpacing="10">
+                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceSm}">
                             <Label Text="Restore latest calculator drafts" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />
                             <Switch AutomationId="RestoreDraftsSwitch" Grid.Column="1" IsToggled="{Binding RestoreDrafts}" />
                             <Label Grid.Row="1" Text="Confirm before deleting plans" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />
@@ -199,12 +200,12 @@
                         </Grid>
                     </VerticalStackLayout>
                 </Border>
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="12">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf1ec;"
                                    FontFamily="FontAwesomeSolid"
                                    VerticalTextAlignment="Center"
@@ -231,8 +232,8 @@
                                     TitleColor="{AppThemeBinding Light=#587068, Dark=#8EAA9B}"
                                     SemanticProperties.Description="Currency used to display calculator results" />
                         </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="12">
-                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="10">
+                        <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="{StaticResource SpaceSm}">
                                 <Label Text="Expected return"
                                        VerticalTextAlignment="Center"
                                        TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
@@ -256,7 +257,7 @@
                                         ThumbColor="#2F6B57"
                                         SemanticProperties.Description="Adjust default expected annual return percentage" />
                             </Grid>
-                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="10">
+                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="{StaticResource SpaceSm}">
                                 <Label Text="Inflation"
                                        VerticalTextAlignment="Center"
                                        TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
@@ -280,7 +281,7 @@
                                         ThumbColor="#2F6B57"
                                         SemanticProperties.Description="Adjust default annual inflation percentage" />
                             </Grid>
-                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="10">
+                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="{StaticResource SpaceSm}">
                                 <Label Text="Withdrawal rate"
                                        VerticalTextAlignment="Center"
                                        TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
@@ -304,7 +305,7 @@
                                         ThumbColor="#2F6B57"
                                         SemanticProperties.Description="Adjust default safe withdrawal percentage" />
                             </Grid>
-                            <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                 <VerticalStackLayout Spacing="4">
                                     <Label Text="Current age"
                                            TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
@@ -330,7 +331,7 @@
                                            SemanticProperties.Description="Default retirement age" />
                                 </VerticalStackLayout>
                             </Grid>
-                                <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                                     <VerticalStackLayout Spacing="4">
                                      <Label Text="After-tax take-home income"
                                          TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
@@ -367,11 +368,11 @@
                                FontSize="13" />
                     </VerticalStackLayout>
                 </Border>
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="10">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                         <VerticalStackLayout Spacing="4">
                             <Label Text="Home calculators"
                                    TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}"
@@ -381,7 +382,7 @@
                                    TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
                                    LineHeight="1.3" />
                         </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="10"
+                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}"
                                              BindableLayout.ItemsSource="{Binding CalculatorPreferences}">
                         <BindableLayout.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:CalculatorPreferenceItem">
@@ -430,12 +431,12 @@
                                 SemanticProperties.Description="Show all calculators and restore the default Home order after confirmation." />
                     </VerticalStackLayout>
                 </Border>
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="12">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf1c0;"
                                    FontFamily="FontAwesomeSolid"
                                    VerticalTextAlignment="Center"
@@ -450,7 +451,7 @@
                         <Label Text="Create a private backup or restore one you exported earlier. Nothing is uploaded automatically."
                                TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
                                LineHeight="1.3" />
-                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Button Text="Export backup"
                                     Command="{Binding ExportDataCommand}"
                                     Background="#2F6B57"
@@ -473,12 +474,12 @@
                         <FontImageSource FontFamily="FontAwesomeSolid" Glyph="&#xf01e;" Color="#FFFFFF" Size="14" />
                     </Button.ImageSource>
                 </Button>
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="12">
-                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Label Text="&#xf023;"
                                    FontFamily="FontAwesomeSolid"
                                    VerticalTextAlignment="Center"
@@ -493,7 +494,7 @@
                         <Label Text="Your financial inputs stay in local app storage. My Fire Number does not use analytics or transmit them. Your operating system may include app data in an encrypted device backup when backups are enabled."
                                TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}"
                                LineHeight="1.3" />
-                        <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Button Text="Terms"
                                     Command="{Binding OpenTermsCommand}"
                                     Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483A}"

--- a/app/MyFireNumber/Views/WelcomePage.xaml
+++ b/app/MyFireNumber/Views/WelcomePage.xaml
@@ -8,12 +8,13 @@
              Title="Welcome"
              Shell.NavBarIsVisible="False"
              Shell.TabBarIsVisible="False"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
-    <Grid Padding="24,32,24,24"
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="Container">
+    <Grid Padding="{StaticResource PagePadding}"
           RowDefinitions="*,Auto">
         <VerticalStackLayout Grid.Row="0"
                              VerticalOptions="Center"
-                             Spacing="24">
+                             Spacing="{StaticResource SpaceXl}">
             <Border HorizontalOptions="Center"
                     Padding="20"
                     Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}"
@@ -26,7 +27,7 @@
                        SemanticProperties.Description="A sprouting plant representing growth" />
             </Border>
 
-            <VerticalStackLayout Spacing="12">
+            <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                 <Label Text="Welcome to My Fire Number"
                        FontAttributes="Bold"
                        FontSize="34"
@@ -45,7 +46,7 @@
                     Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                     Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                     StrokeShape="RoundRectangle 16">
-                <VerticalStackLayout Spacing="14">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                     <Label Text="Make your plan your own"
                            FontAttributes="Bold"
                            FontSize="18"
@@ -54,7 +55,7 @@
                            LineHeight="1.4"
                            TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
                     <Grid ColumnDefinitions="Auto,*"
-                          ColumnSpacing="10">
+                          ColumnSpacing="{StaticResource SpaceSm}">
                         <Label Text="&#xf023;"
                                FontFamily="FontAwesomeSolid"
                                FontSize="16"
@@ -70,7 +71,7 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Grid.Row="1"
-                             Spacing="16">
+                             Spacing="{StaticResource SpaceLg}">
             <Button AutomationId="WelcomeGetStartedButton"
                     Text="Get started"
                     Command="{Binding GetStartedCommand}"

--- a/app/MyFireNumber/Views/WithdrawalRateOnboardingPage.xaml
+++ b/app/MyFireNumber/Views/WithdrawalRateOnboardingPage.xaml
@@ -8,7 +8,8 @@
              Title="Withdrawal rate"
              Shell.NavBarIsVisible="True"
              Shell.TabBarIsVisible="False"
-             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+             Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+             SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Skip"
                      Command="{Binding SkipCommand}"
@@ -17,7 +18,7 @@
 
     <Grid>
         <ScrollView>
-            <VerticalStackLayout Padding="24,20,24,32" Spacing="18">
+            <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
                 <VerticalStackLayout Spacing="6">
                     <Label Text="Choose your withdrawal rate"
                            FontSize="28"
@@ -30,11 +31,11 @@
                            TextColor="{AppThemeBinding Light=#425D54, Dark=#B9D1C2}" />
                 </VerticalStackLayout>
 
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}"
                         Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="14">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Label Text="Your comfort level"
                                FontSize="18"
                                FontAttributes="Bold"
@@ -63,11 +64,11 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Padding="18"
+                <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light=#E4F0E9, Dark=#29483B}"
                         StrokeThickness="0"
                         StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="10">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                         <Label Text="Common starting points"
                                FontAttributes="Bold"
                                TextColor="{AppThemeBinding Light=#17352C, Dark=#F2F7F3}" />

--- a/app/MyFireNumber/Views/WithdrawalRatePage.xaml
+++ b/app/MyFireNumber/Views/WithdrawalRatePage.xaml
@@ -9,7 +9,8 @@
                           x:DataType="viewModels:WithdrawalRateViewModel"
                           Title="{Binding Title}"
                           Shell.NavBarIsVisible="True"
-                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}">
+                          Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}"
+                          SafeAreaEdges="All">
     <ContentPage.ToolbarItems>
         <ToolbarItem Command="{Binding SavePlanCommand}"
                      SemanticProperties.Description="Save the current calculator values as a plan.">
@@ -19,7 +20,7 @@
         </ToolbarItem>
     </ContentPage.ToolbarItems>
     <ScrollView>
-        <VerticalStackLayout Padding="20,20,20,32" Spacing="18">
+        <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
             <ActivityIndicator IsRunning="{Binding IsLoading}" IsVisible="{Binding IsLoading}" HorizontalOptions="Center" SemanticProperties.Description="Restoring your local calculator draft." />
             <Border IsVisible="{Binding HasValidationMessage}" Padding="14" Background="{AppThemeBinding Light=#FFF4E8, Dark=#4A3323}" Stroke="{AppThemeBinding Light=#C97727, Dark=#F2B56D}" StrokeShape="RoundRectangle 8"><Label Text="{Binding ValidationMessage}" TextColor="{AppThemeBinding Light=#6B3B12, Dark=#FFE0BC}" LineHeight="1.3" /></Border>
 
@@ -28,15 +29,15 @@
                                          Details="A withdrawal rate is the first-year percentage spent from your portfolio. The 4% rule is a common starting point, not a guarantee."
                                          IconGlyph="&#xf02d;" />
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="14">
-                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8"><Label Text="Your portfolio" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Withdrawal Rate values to their defaults." /></Grid>
-                    <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}"><Label Text="Your portfolio" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Reset" Command="{Binding ResetDefaultsCommand}" Background="{StaticResource Secondary}" TextColor="{StaticResource PrimaryDarkText}" FontSize="12" SemanticProperties.Description="Reset Withdrawal Rate values to their defaults." /></Grid>
+                    <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceMd}">
                         <controls:NumericInputView Header="Portfolio value" HelpText="Current total invested portfolio, in dollars." Placeholder="1000000" Text="{Binding PortfolioValueText}" />
                         <controls:NumericInputView Grid.Column="1" Header="Retirement duration" HelpText="Number of retirement years to model." Placeholder="30" Text="{Binding RetirementYearsText}" />
                     </Grid>
                     <controls:AdvancedAssumptionsExpander>
-                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="12" RowSpacing="12">
+                        <Grid Margin="0,12,0,0" ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceMd}" RowSpacing="{StaticResource SpaceMd}">
                             <controls:PercentageInputView Header="Withdrawal rate (%)" HelpText="First-year percentage withdrawn from the portfolio. This is an assumption, not a promise." Placeholder="4" Minimum="2" Maximum="8" Text="{Binding WithdrawalRateText}" />
                             <controls:PercentageInputView Grid.Column="1" Header="Expected return (%)" HelpText="Expected average annual investment return before inflation." Placeholder="7" Minimum="0" Maximum="15" Text="{Binding ExpectedReturnText}" />
                             <controls:PercentageInputView Grid.Row="1" Grid.ColumnSpan="2" Header="Inflation (%)" HelpText="Expected annual increase in the cost of living." Placeholder="3" Minimum="0" Maximum="10" Text="{Binding InflationRateText}" />
@@ -45,24 +46,25 @@
                 </VerticalStackLayout>
             </Border>
 
-            <VerticalStackLayout Spacing="10">
-                <Label Text="{Binding WithdrawalStatusText}" Style="{StaticResource CalculatorSectionHeading}" />
-                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="10" RowSpacing="10">
-                    <Border Padding="12" Background="{AppThemeBinding Light=#EAF5FC, Dark=#1B3546}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Annual withdrawal" FontSize="12" /><Label Text="{Binding WithdrawalAnnualText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
-                    <Border Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly withdrawal" FontSize="12" /><Label Text="{Binding WithdrawalMonthlyText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Portfolio lasts" FontSize="12" /><Label Text="{Binding WithdrawalLongevityText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
-                    <Border Grid.Row="1" Grid.Column="1" Padding="12" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Share of horizon funded" FontSize="12" /><Label Text="{Binding WithdrawalHorizonFundedText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                <Label Text="Your withdrawal outlook" Style="{StaticResource CalculatorSectionHeading}" />
+                <Label Text="{Binding WithdrawalStatusText}" Style="{StaticResource CalculatorStatusHeadline}" SemanticProperties.Description="{Binding WithdrawalStatusText}" />
+                <Grid ColumnDefinitions="*,*" RowDefinitions="Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}" RowSpacing="{StaticResource SpaceSm}">
+                    <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#EAF5FC, Dark=#1B3546}" StrokeThickness="0" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Annual withdrawal" FontSize="12" /><Label Text="{Binding WithdrawalAnnualText}" FontAttributes="Bold" FontSize="22" /></VerticalStackLayout></Border>
+                    <Border Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Monthly withdrawal" FontSize="12" /><Label Text="{Binding WithdrawalMonthlyText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Portfolio lasts" FontSize="12" /><Label Text="{Binding WithdrawalLongevityText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
+                    <Border Grid.Row="1" Grid.Column="1" Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" StrokeShape="RoundRectangle 8"><VerticalStackLayout Spacing="2"><Label Text="Share of horizon funded" FontSize="12" /><Label Text="{Binding WithdrawalHorizonFundedText}" FontAttributes="Bold" FontSize="18" /></VerticalStackLayout></Border>
                 </Grid>
                 <Label Text="{Binding WithdrawalRateAnalysisText}" Style="{StaticResource CalculatorSupportingText}" />
             </VerticalStackLayout>
 
-            <VerticalStackLayout Spacing="10">
+            <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                 <Label Text="Portfolio balance over time" Style="{StaticResource CalculatorSectionHeading}" />
                 <lvc:CartesianChart Series="{Binding ProjectionSeries}" XAxes="{Binding ProjectionXAxes}" AnimationsSpeed="{Binding ChartAnimationsSpeed}" HeightRequest="300" SemanticProperties.Description="{Binding ProjectionChartDescription}" />
             </VerticalStackLayout>
 
-            <Border Padding="16" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
-                <VerticalStackLayout Spacing="10">
+            <Border Padding="{StaticResource CardPadding}" Background="{AppThemeBinding Light=#FFFFFF, Dark=#203129}" Stroke="{AppThemeBinding Light=#D7DED8, Dark=#365244}" StrokeShape="RoundRectangle 8">
+                <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
                     <Label Text="Save or export this plan" Style="{StaticResource CalculatorSectionHeading}" />
                     <Entry Text="{Binding PlanNameText}" Placeholder="My Withdrawal Plan" Background="{AppThemeBinding Light=#F5F7F2, Dark=#15211C}" SemanticProperties.Description="Name for this saved Withdrawal Rate plan" />
                     <Button Text="{Binding SavePlanActionText}" Command="{Binding SavePlanCommand}" SemanticProperties.Description="{Binding SavePlanActionDescription}" />


### PR DESCRIPTION
Presentation-only UI/UX pass over the .NET MAUI app (`app/`), covering the four things asked for: **spacing on mobile, header text wrapping, formatting, and overall flow.**

**No calculation changes.** Nothing under `Core/Calculations/**`, `shared/parity/**`, or any value-computing view-model logic was touched. No `web/` files. `dotnet test` stays at **291 passed / 0 failed** — the test project doesn't reference the MAUI app, so no XAML change can move that number.

---

## Two corrections to the framing

**1. The heading style wasn't the real wrap problem.** It's true `CalculatorSectionHeading` set no `LineBreakMode`/`MaxLines`, but the longest *static* heading is 36 chars, which wraps to 2 lines and looks fine. The headings that actually looked bad were **four dynamic result sentences bound into the 20pt bold heading style** — worst case 82 chars rendered as a wall of bold text. Those can't be truncated, because the sentence *is* the answer. So the fix is structural, not a `LineBreakMode` policy.

The genuinely ugly wrap was elsewhere: `FieldHelpView` headers inside two-column input grids get ~105pt on a 390pt phone, and `NumericInputView.DisplayHeader` appends `" (per year)"` at runtime, making labels longer than they look in XAML. Adjacent `Entry` boxes visibly misaligned.

**2. Contrast was not broadly broken.** I measured 28 pairs. Every inline hardcoded pair passes AA in both themes. The failures were in the **global styles pages forget to override**.

---

## What changed

**Safe area — the biggest mobile spacing defect.** The app had **zero** `SafeAreaEdges`/`UseSafeArea` declarations while targeting `net10.0`, where `ContentPage` now defaults to edge-to-edge on *all* platforms. Five pages have no nav bar (`AppShell.CreateTab` sets `NavBarIsVisible=false` on the four tab roots; WelcomePage sets it in XAML), so their headers sat under the status bar. Added `SafeAreaEdges` to all 19 pages — `Container` for chrome-less pages, `All` for the 13 Entry-bearing forms so they also get keyboard avoidance — and replaced the static `…,32` bottom fudges with real inset handling.

**Header wrapping — a deliberate, documented policy.**
- Four dynamic status sentences demoted to a new `CalculatorStatusHeadline` (17pt semibold, `LineHeight` 1.25) under a short static section heading.
- `CalculatorSectionHeading` gets explicit `LineBreakMode` + `LineHeight` but **deliberately no `MaxLines`**. A cap would silently truncate under Dynamic Type / `fontScale` — trading a cosmetic wrap for hidden content, which is its own bug.
- **Root-cause alignment fix instead of truncation:** `NumericInputView`/`PercentageInputView` now use `RowDefinitions="*,Auto"`, bottom-pinning the entry so adjacent entries align even when one label wraps to more lines.
- Two over-long field headers shortened; the "after tax" detail is retained in each field's help text. Label strings only.

**Contrast.** Light `Entry`/`Editor` placeholder was `Gray200` on `#F5F7F2` = **1.55:1**, used by 13 un-overridden Entry controls across 12 pages (every "Plan name" field). Dark `SearchBar` placeholder was 3.25:1. New tokens measure **4.95:1** and **10.24:1**.

**Spacing.** Named scale (`SpaceXs`…`SpaceXl`, `PagePadding`, `CardPadding`) applied at page and card level, replacing 17 distinct ad-hoc `Spacing` literals. Fine-grained label stacking (2–4pt) left alone as intentional micro-rhythm.

**Flow.** `AdvancedAssumptionsExpander` collapsed in `Loaded`, so advanced fields were measured visible first and the input card visibly jumped shorter on open — now collapses as children are added. Five hand-rolled `FontAttributes="Bold" FontSize="20"` labels on `RetirementCashFlowPage` now route through the shared heading style so the policy can't drift.

## Startup crash this uncovered

`App` took `AppShell` via constructor injection, so DI built `AppShell` — and all four tab pages — **before** `InitializeComponent()` merged `Colors.xaml`/`Styles.xaml` into `Application.Resources`. Any `{StaticResource}` in those four pages threw `StaticResource not found` at launch. This was latent on `main` only because none of those pages used one; the spacing scale was the first to. Fixed by resolving `AppShell` in `CreateWindow`. **Runtime testing caught this — the build was green.**

---

## Validation

- `dotnet test` → **291 passed, 0 failed**
- `dotnet build -f net10.0-android` → 0 errors (6 pre-existing `MAUIG2045` warnings, unchanged)
- **Verified on a Pixel 7a API 35 emulator**, light and dark: clean launch with zero exceptions; tab-page headers clear the status bar; Barista FIRE's mismatched 2-line and 3-line labels now render with both entry boxes on the same baseline and no truncation; info buttons render as compact circles (the Android Material min-width concern); expander collapsed on first paint with no flash; theme switch preserves scroll position.

## Residual gaps — not verified, stated plainly

- **iOS was not visually verified.** DevFlow is deliberately compiled out here (`#if MAUI_DEVFLOW && !IOS`), so Android is the only automated runtime path — and safe-area insets are exactly what differs most on a notched iPhone. The two claims most needing your own eyes: **top insets on the four tab pages**, and the **WelcomePage bottom action row against the home indicator**.
- The placeholder contrast fix is only visible when a field is empty; I verified it numerically rather than by emptying all 13 fields.

## Out of scope — worth filing separately

1. **1109 hardcoded hex occurrences, 73 distinct colours, 23 files.** The app's largest styling debt, with `Colors.xaml` a parallel palette pages barely use. Left alone because contrast already passes and a half-migration drifts worse than none.
2. **`MAUIG2045` reflection-binding warnings** on `FireNumberPage` — `DisplayPeriodQualifier`/`DisplayPeriodSuffix` missing from `IFireNumberViewModel` (introduced by #77). An AOT/trimming risk; trivial fix but behavioural.
3. **Unused `Shadow` style** in `Styles.xaml` — white brush in *both* themes, offset down-right. Zero usages, so dead code rather than a live bug.

---

## Measured spacing deltas (added by the coordinating session)

The "Spacing" bullet above reads as a pure rename. It isn't — the scale has no `10`, and `10` was the app's most common value. Measured from the diff across `app/MyFireNumber/Views/*.xaml`:

| old | new | delta | sites |
|---|---|---|---|
| 10 | `SpaceSm` 8 | **−2** | **55** |
| 18 | `SpaceLg` 16 | −2 | 15 |
| 14 | `SpaceMd` 12 | −2 | 14 |
| 10 | `SpaceMd` 12 | +2 | 5 |
| 22 | `SpaceXl` 24 | +2 | 1 |
| 1 | `SpaceXs` 4 | **+3** | 1 |
| 20 | `SpaceLg` 16 | **−4** | 1 |
| 5 | `SpaceXs` 4 | −1 | 1 |
| 7 | `SpaceSm` 8 | +1 | 1 |
| 16, 24 | unchanged | 0 | 3 |

336 numeric `Spacing` literals → 101 (the 2/3/4/6 micro-rhythm deliberately kept).

**Net effect: roughly 84 sites tighten by exactly 2pt**, dominated by `10 → 8` in 55 places. This is a systematic density increase across every page, not a no-op refactor. Two sites move further: `1 → 4` and `20 → 16`.

**Why this matters for review:** only Android was visually verified (see residual gaps). Density is the thing to look at on iOS alongside the safe-area insets.

## Which heading setter is a no-op

`CalculatorSectionHeading` gained two setters, and they are not equivalent:

- `LineBreakMode="WordWrap"` — **a no-op.** `Label.LineBreakMode` already defaults to `WordWrap`. It changes nothing at runtime and is there to record the decision (and the deliberate absence of `MaxLines`) where the next person will look. It should not be read as having fixed anything.
- `LineHeight="1.2"` — **a real change**, applied to all 35 headings using this style.

## Verification by the coordinating session

Independently confirmed rather than accepted: `dotnet test` → **291**, matching baseline exactly (no silent test loss); `App` on `main` did take `AppShell` by constructor injection, and all four tab pages had **exactly zero** `StaticResource` uses — so the startup crash was real and latent for precisely the stated reason; `#C8C8C8` on `#F5F7F2` recomputes to **1.5517:1**; the 1109/23-file hex figures reproduce exactly.
