### PR TITLE
Fix MAUIG2045 reflection bindings and replace the catalog count assertion

### DIFF
--- a/app/MyFireNumber.Tests/Calculations/CalculatorCatalogTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/CalculatorCatalogTests.cs
@@ -1,26 +1,99 @@
+using System.Text.RegularExpressions;
+
 using MyFireNumber.Core.Calculators;
 
 namespace MyFireNumber.Tests.Calculations;
 
+/// <summary>
+/// Pins every shipped calculator to a native definition — a Shell route registered under the
+/// calculator's ID and pointing at a page type — discovered from <c>app/MyFireNumber/AppShell.xaml.cs</c>.
+///
+/// <para><b>Why the expected set is discovered rather than listed.</b> This test used to open with
+/// <c>Assert.Equal(11, catalog.All.Count)</c>. A cardinality check cannot do the job the test's name
+/// claims. Adding a twelfth calculator failed it as "expected 11, got 12", which reads as
+/// <i>the test needs updating</i>, so the natural fix was to bump the literal — a rubber stamp that
+/// checked nothing about the new calculator. Worse, it could not see a swap at all: drop one
+/// calculator, add another, and the count is still 11 and still green with the catalog materially
+/// changed. An assertion that is satisfied by editing a number is not a guard.</para>
+///
+/// <para><b>Why the route table is the oracle.</b> <c>MyFireNumber.Tests</c> cannot reference the MAUI
+/// single-project, so the route table is read as text rather than invoked — the same shape as
+/// <see cref="Presentation.SharedPeriodicFieldInventoryTests"/> reading <c>shared/parity</c>. It is the
+/// right oracle because it is the only place a catalog entry becomes reachable natively: a calculator
+/// listed in the catalog with no registered route is a dead tile in the app. Nothing here is
+/// enumerated, so a calculator added to one side and forgotten on the other fails on its own.</para>
+///
+/// <para><b>What this deliberately does not assert.</b> The reverse direction — that every registered
+/// route is a calculator — is not checkable, because <c>quiz</c>, <c>welcome</c>, the onboarding
+/// routes and <c>retirement-annual-details</c> are legitimately routes without catalog entries, and
+/// nothing in the registration distinguishes them.</para>
+/// </summary>
 public class CalculatorCatalogTests
 {
-    [Fact]
-    public void AllWebCalculators_HaveStableNativeDefinitions()
-    {
-        ICalculatorCatalog catalog = new CalculatorCatalog();
+    private static readonly ICalculatorCatalog Catalog = new CalculatorCatalog();
+    private static readonly IReadOnlyDictionary<string, string> NativeRoutes = LoadNativeRoutes();
 
-        Assert.Equal(11, catalog.All.Count);
-        Assert.Equal(catalog.All.Count, catalog.All.Select(definition => definition.Id).Distinct().Count());
-        Assert.All(catalog.All, definition => Assert.Equal($"calculator/{definition.Id}", definition.Route));
-        Assert.All(catalog.All, definition => Assert.False(string.IsNullOrWhiteSpace(definition.IconGlyph)));
-        Assert.All(catalog.All, definition => Assert.InRange(definition.Summary.Length, 40, 120));
+    [Fact]
+    public void Every_shipped_calculator_has_a_native_page_route()
+    {
+        foreach (var definition in Catalog.All)
+        {
+            Assert.True(
+                NativeRoutes.ContainsKey(definition.Id),
+                $"Calculator '{definition.Id}' is in the catalog but no Shell route is registered for it in " +
+                "app/MyFireNumber/AppShell.xaml.cs, so it is unreachable in the native app. Add " +
+                $"Routing.RegisterRoute(\"{definition.Id}\", typeof(SomePage)); alongside the others.");
+        }
+    }
+
+    [Fact]
+    public void Every_shipped_calculator_definition_is_well_formed()
+    {
+        Assert.Equal(Catalog.All.Count, Catalog.All.Select(definition => definition.Id).Distinct(StringComparer.Ordinal).Count());
+        Assert.All(Catalog.All, definition => Assert.Equal($"calculator/{definition.Id}", definition.Route));
+        Assert.All(Catalog.All, definition => Assert.False(string.IsNullOrWhiteSpace(definition.Title)));
+        Assert.All(Catalog.All, definition => Assert.False(string.IsNullOrWhiteSpace(definition.IconGlyph)));
+        Assert.All(Catalog.All, definition => Assert.InRange(definition.Summary.Length, 40, 120));
+        Assert.All(Catalog.All, definition => Assert.Same(definition, Catalog.GetRequired(definition.Id)));
+    }
+
+    [Fact]
+    public void Neither_the_catalog_nor_the_discovered_route_table_is_silently_empty()
+    {
+        // Guards the guard. Every assertion above is a "for each" over one of these two sets, and a
+        // "for each" over an empty set passes. Emptying the catalog, or a regex that silently stopped
+        // matching after the route table was reformatted, would turn this file green while checking
+        // nothing. Both facts are therefore asserted directly, each pinned by a named member so a
+        // non-empty set of the wrong things cannot stand in.
+        Assert.NotEmpty(Catalog.All);
+        Assert.NotEmpty(NativeRoutes);
+        Assert.Contains(Catalog.All, definition => definition.Id == "standard-fire");
+        Assert.Equal("FireNumberPage", NativeRoutes["standard-fire"]);
     }
 
     [Fact]
     public void GetRequired_RejectsUnknownCalculatorIds()
     {
-        ICalculatorCatalog catalog = new CalculatorCatalog();
+        Assert.Throws<KeyNotFoundException>(() => Catalog.GetRequired("not-a-calculator"));
+    }
 
-        Assert.Throws<KeyNotFoundException>(() => catalog.GetRequired("not-a-calculator"));
+    private static IReadOnlyDictionary<string, string> LoadNativeRoutes()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "NativeRoutes", "AppShell.xaml.cs");
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"Native route table not found at '{path}'. It is copied from app/MyFireNumber by MyFireNumber.Tests.csproj.",
+                path);
+        }
+
+        var registrations = Regex.Matches(
+            File.ReadAllText(path),
+            """Routing\.RegisterRoute\s*\(\s*"(?<route>[^"]+)"\s*,\s*typeof\(\s*(?<page>[\w.]+)\s*\)\s*\)""");
+
+        return registrations.ToDictionary(
+            registration => registration.Groups["route"].Value,
+            registration => registration.Groups["page"].Value.Split('.')[^1],
+            StringComparer.Ordinal);
     }
 }

--- a/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
+++ b/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
@@ -27,6 +27,10 @@
     <!-- Same file the web Vitest suite reads, so both platforms are pinned to one set of numbers. -->
     <None Include="..\..\shared\parity\fire-parity-cases.json" Link="SharedParity\fire-parity-cases.json" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\..\shared\parity\periodic-fields.json" Link="SharedParity\periodic-fields.json" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Read as text, never compiled: this project cannot reference the MAUI single-project, but the
+         Shell route table is the only place a calculator becomes reachable natively, so it is the
+         oracle CalculatorCatalogTests discovers its expected set from. -->
+    <None Include="..\MyFireNumber\AppShell.xaml.cs" Link="NativeRoutes\AppShell.xaml.cs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/app/MyFireNumber/ViewModels/IFireNumberViewModel.cs
+++ b/app/MyFireNumber/ViewModels/IFireNumberViewModel.cs
@@ -97,6 +97,13 @@ public interface IFireNumberViewModel : ICalculatorViewModel
 
     string SavePlanActionDescription { get; }
 
+    // Declared here, not just on CalculatorViewModelBase, because FireNumberPage.xaml is typed
+    // against this interface. A base-class-only member is invisible to the compiled binding and
+    // silently degrades to a reflection binding, which trimming is free to remove in Release.
+    string DisplayPeriodQualifier { get; }
+
+    string DisplayPeriodSuffix { get; }
+
     IReadOnlyList<StandardFirePreset> StandardFirePresets { get; }
 
     StandardFirePreset? SelectedPreset { get; set; }


### PR DESCRIPTION
Fixes the two open `app/` audit issues. Bindings and test structure only — no calculation, formula, or default is touched, and `web/` is untouched.

Closes #83
Closes #79

---

## #83 — MAUIG2045 reflection bindings

`FireNumberPage.xaml` declares `x:DataType="viewModels:IFireNumberViewModel"`, but `DisplayPeriodQualifier` and `DisplayPeriodSuffix` (added by #77) existed only on the concrete `CalculatorViewModelBase`. The compiled binding could not resolve them against the interface, so six bindings degraded to reflection — which trimming is free to remove in a Release build, giving a binding that works in Debug and renders empty in Release with a green build.

Fix is additive: both properties are now declared on `IFireNumberViewModel`. The base class already implements them, so no implementation changed.

### Before / after

Release is the configuration that matters here, since that is where trimming applies. Release builds both `maccatalyst-x64` and `maccatalyst-arm64`, so the source generator runs twice and each of the 6 bindings is reported twice.

```
$ dotnet build app/MyFireNumber/MyFireNumber.csproj -f net10.0-maccatalyst -c Release -v n

BEFORE:  12 Warning(s), 0 Error(s)     # all 12 are MAUIG2045
AFTER:    0 Warning(s), 0 Error(s)
```

```
$ grep -oE "warning [A-Z]+[0-9]+" release-before.log | sort | uniq -c
  24 warning MAUIG2045                  # 12 unique, each listed inline + in the summary

$ grep -c "MAUIG2045" release-after.log
0
```

Debug shows the same thing at single-RID scale — **6 → 0**:

```
$ dotnet build app/MyFireNumber/MyFireNumber.csproj -f net10.0-maccatalyst -v n
BEFORE:  6 Warning(s)     AFTER:  0 Warning(s)
```

The count goes to zero rather than down, and every warning was in one file, so there is no second instance of the pattern hiding behind these:

```
$ grep "MAUIG2045" build-before.log | grep -oE "[A-Za-z]+\.xaml" | sort | uniq -c
  12 FireNumberPage.xaml
```

I checked the issue's follow-up question — whether any *other* page binds a base-class member through an interface `x:DataType`. It does not repeat: `FireNumberPage` is the only page in `app/MyFireNumber/Views/` typed against an interface. Every other calculator page is typed against its concrete view model, which inherits `CalculatorViewModelBase` and therefore resolves these two properties at compile time. That is confirmed by the build reaching 0 warnings, not just by the grep.

## #79 — the hardcoded count

`Assert.Equal(11, catalog.All.Count)` was replaced with an assertion of the property the test is named for: every entry in `catalog.All` has a native definition — a Shell route registered under its ID and pointing at a page type.

The expected set is **discovered**, not enumerated. `MyFireNumber.Tests` cannot reference the MAUI single-project, so `AppShell.xaml.cs` is copied to the test output and its `Routing.RegisterRoute(...)` calls are parsed — the same shape as the existing `SharedPeriodicFieldInventoryTests`, which reads `shared/parity/periodic-fields.json` rather than listing calculators. The route table is the right oracle because it is the only place a catalog entry becomes reachable natively: a catalog entry with no registered route is a dead tile in the app.

No count literal remains. Non-vacuity is asserted directly instead: both sets non-empty, `standard-fire` present in the catalog by name, and `standard-fire` → `FireNumberPage` in the discovered route table.

### Proof it detects a swap

Swapped `coast-fire` → `chubby-fire` (id and route) in `CalculatorCatalog`, leaving the count at 11.

**Old test — passes, catalog materially changed:**

```
$ dotnet test app/MyFireNumber.Tests/ --filter "FullyQualifiedName~CalculatorCatalogTests"
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2
```

**New test — fails, with a message that says what to do:**

```
$ dotnet test app/MyFireNumber.Tests/ --filter "FullyQualifiedName~CalculatorCatalogTests"
  Failed CalculatorCatalogTests.Every_shipped_calculator_has_a_native_page_route [4 ms]
  Error Message:
   Calculator 'chubby-fire' is in the catalog but no Shell route is registered
   for it in app/MyFireNumber/AppShell.xaml.cs, so it is unreachable in the
   native app. Add Routing.RegisterRoute("chubby-fire", typeof(SomePage));
   alongside the others.

Failed!  - Failed: 1, Passed: 3, Skipped: 0, Total: 4
```

Sabotage reverted; `git status` was clean before committing.

### Proof the guard cannot go vacuous

A discovered set is only as good as the discovery, so I validated the detector against a known-negative rather than trusting a green run. Deleting the route registrations from `AppShell.xaml.cs` — simulating them moving elsewhere — fails loudly instead of silently checking nothing:

```
  Failed CalculatorCatalogTests.Neither_the_catalog_nor_the_discovered_route_table_is_silently_empty
  Error Message:
   Assert.NotEmpty() Failure: Collection was empty

Failed!  - Failed: 2, Passed: 2, Skipped: 0, Total: 4
```

The same guard fired when I reformatted the registrations so the regex stopped matching. I then made the regex whitespace-tolerant (`RegisterRoute\s*\(`) so a formatting change does not masquerade as a defect, and re-ran the deletion case above against the tolerant version.

## Test count

**291 → 293.** No test was lost. The old file's two tests became four: the single overloaded `AllWebCalculators_HaveStableNativeDefinitions` split into `Every_shipped_calculator_has_a_native_page_route` (the new oracle), `Every_shipped_calculator_definition_is_well_formed` (the per-entry structural assertions it already made, kept and extended with a title check and a `GetRequired`/`All` agreement check), and `Neither_the_catalog_nor_the_discovered_route_table_is_silently_empty` (new). `GetRequired_RejectsUnknownCalculatorIds` is unchanged.

```
BEFORE: Passed!  - Failed: 0, Passed: 291, Skipped: 0, Total: 291
AFTER:  Passed!  - Failed: 0, Passed: 293, Skipped: 0, Total: 293
```

## Found, not fixed

**`CalculatorDefinition.Route` is dead.** Nothing reads it. Native navigation goes through `CalculatorRoutes.Build(id)`, which returns the bare ID plus query string; `"calculator/{id}"` is never used to navigate anywhere:

```
$ grep -rn "\.Route\b" app/MyFireNumber app/MyFireNumber.Core --include=*.cs --include=*.xaml | grep -v AppShell
(no results — validated against a known-positive: the same grep for "Route" returns
 CalculatorRoutes.Build call sites, so the empty result is real, not a broken pattern)
```

So `Assert.All(..., Assert.Equal($"calculator/{definition.Id}", definition.Route))` is an assertion of a value against its own construction rule, with no consumer — a milder version of the self-referential shape #79 is about. I kept it (it is at least cheap and correct) rather than deleting a public record member, because removing it changes the `MyFireNumber.Core` public API and is outside "bindings and test structure only." Worth a separate issue if you want it gone.

**Reverse-direction coverage is not possible.** The new test asserts catalog ⊆ registered routes, not equality. `quiz`, `welcome`, the onboarding routes and `retirement-annual-details` are legitimately routes without catalog entries, and nothing in the registration distinguishes a calculator route from a navigation route. This is stated explicitly in the test's doc comment so the gap is not mistaken for coverage.

## Verification summary

| Check | Command | Result |
|---|---|---|
| MAUIG2045, Release | `dotnet build … -c Release -f net10.0-maccatalyst` | 12 → **0** |
| MAUIG2045, Debug | `dotnet build … -f net10.0-maccatalyst` | 6 → **0** |
| Tests | `dotnet test app/MyFireNumber.Tests/` | 291 → **293**, 0 failed |
| Swap detected | filtered run under sabotage | old **passed**, new **failed** |
| Guard non-vacuous | route table removed | `Assert.NotEmpty()` **failed** as intended |