### PR TITLE
Remove the dead CalculatorDefinition.Route member

### DIFF
--- a/app/MyFireNumber.Core/Calculators/CalculatorCatalog.cs
+++ b/app/MyFireNumber.Core/Calculators/CalculatorCatalog.cs
@@ -1,6 +1,6 @@
 namespace MyFireNumber.Core.Calculators;
 
-public sealed record CalculatorDefinition(string Id, string Title, string Summary, string Route, string IconGlyph);
+public sealed record CalculatorDefinition(string Id, string Title, string Summary, string IconGlyph);
 
 public interface ICalculatorCatalog
 {
@@ -13,17 +13,17 @@ public sealed class CalculatorCatalog : ICalculatorCatalog
 {
     private static readonly IReadOnlyList<CalculatorDefinition> Definitions =
     [
-        new("standard-fire", "Standard FIRE", "Calculate your full financial independence target with the classic 25x expenses rule.", "calculator/standard-fire", "\uf06d"),
-        new("coast-fire", "Coast FIRE", "Find what you need invested now so compound growth can carry you to retirement.", "calculator/coast-fire", "\uf5ca"),
-        new("lean-fire", "Lean FIRE", "Reach financial independence sooner with a lower-cost, minimalist lifestyle.", "calculator/lean-fire", "\uf4d8"),
-        new("fat-fire", "Fat FIRE", "Plan for financial independence while maintaining a comfortable lifestyle.", "calculator/fat-fire", "\uf51e"),
-        new("barista-fire", "Barista FIRE", "Blend part-time income with portfolio withdrawals to leave full-time work earlier.", "calculator/barista-fire", "\uf0f4"),
-        new("reverse-fire", "Reverse FIRE", "Choose a target retirement age and find the savings needed to reach it.", "calculator/reverse-fire", "\uf2f9"),
-        new("withdrawal-rate", "Withdrawal Rate", "Test how long your portfolio may last while funding retirement spending.", "calculator/withdrawal-rate", "\uf4c0"),
-        new("savings-rate", "Savings & Investment Rate", "See how recurring contributions and compound growth can build wealth over time.", "calculator/savings-rate", "\uf4c4"),
-        new("debt-payoff", "Debt Payoff", "Compare Snowball and Avalanche strategies for eliminating multiple debts.", "calculator/debt-payoff", "\uf09d"),
-        new("healthcare-gap", "Healthcare Gap", "Estimate healthcare costs between early retirement and Medicare eligibility.", "calculator/healthcare-gap", "\uf0fa"),
-        new("retirement-cash-flow", "Retirement Cash Flow", "Coordinate accounts, income, expenses, and withdrawals across retirement.", "calculator/retirement-cash-flow", "\uf1da")
+        new("standard-fire", "Standard FIRE", "Calculate your full financial independence target with the classic 25x expenses rule.", "\uf06d"),
+        new("coast-fire", "Coast FIRE", "Find what you need invested now so compound growth can carry you to retirement.", "\uf5ca"),
+        new("lean-fire", "Lean FIRE", "Reach financial independence sooner with a lower-cost, minimalist lifestyle.", "\uf4d8"),
+        new("fat-fire", "Fat FIRE", "Plan for financial independence while maintaining a comfortable lifestyle.", "\uf51e"),
+        new("barista-fire", "Barista FIRE", "Blend part-time income with portfolio withdrawals to leave full-time work earlier.", "\uf0f4"),
+        new("reverse-fire", "Reverse FIRE", "Choose a target retirement age and find the savings needed to reach it.", "\uf2f9"),
+        new("withdrawal-rate", "Withdrawal Rate", "Test how long your portfolio may last while funding retirement spending.", "\uf4c0"),
+        new("savings-rate", "Savings & Investment Rate", "See how recurring contributions and compound growth can build wealth over time.", "\uf4c4"),
+        new("debt-payoff", "Debt Payoff", "Compare Snowball and Avalanche strategies for eliminating multiple debts.", "\uf09d"),
+        new("healthcare-gap", "Healthcare Gap", "Estimate healthcare costs between early retirement and Medicare eligibility.", "\uf0fa"),
+        new("retirement-cash-flow", "Retirement Cash Flow", "Coordinate accounts, income, expenses, and withdrawals across retirement.", "\uf1da")
     ];
 
     public IReadOnlyList<CalculatorDefinition> All => Definitions;

--- a/app/MyFireNumber.Tests/Calculations/CalculatorCatalogTests.cs
+++ b/app/MyFireNumber.Tests/Calculations/CalculatorCatalogTests.cs
@@ -50,7 +50,6 @@ public class CalculatorCatalogTests
     public void Every_shipped_calculator_definition_is_well_formed()
     {
         Assert.Equal(Catalog.All.Count, Catalog.All.Select(definition => definition.Id).Distinct(StringComparer.Ordinal).Count());
-        Assert.All(Catalog.All, definition => Assert.Equal($"calculator/{definition.Id}", definition.Route));
         Assert.All(Catalog.All, definition => Assert.False(string.IsNullOrWhiteSpace(definition.Title)));
         Assert.All(Catalog.All, definition => Assert.False(string.IsNullOrWhiteSpace(definition.IconGlyph)));
         Assert.All(Catalog.All, definition => Assert.InRange(definition.Summary.Length, 40, 120));


### PR DESCRIPTION
Fixes #88.

`CalculatorDefinition.Route` was populated for all 11 calculators as `"calculator/{id}"` and read by nothing. Native navigation goes through `CalculatorRoutes.Build(id)`, which returns the bare calculator ID plus a query string, and `AppShell.xaml.cs` registers the bare IDs — so the `calculator/`-prefixed form matched no registered Shell route. The field read as live wiring and routed nowhere.

## The field was not merely unused — it was actively misleading

While validating a different test during the audit that produced #88, a catalog mutation via `sed 's/"barista-fire"/"chubby-fire"/'` changed the `Id` but **not** the `Route`, because the route literal `"calculator/barista-fire"` does not contain `"barista-fire"` as a quoted token. The suite then failed on a spurious `Route`/`Id` mismatch rather than on the property actually under test. For a while that made a test that was not working look like one that was. A dead field that redirects sabotage probes onto itself is worse than an unused one.

The sole reader was a self-referential assertion — a value checked against its own construction rule, with no consumer on either side:

```csharp
Assert.All(Catalog.All, definition => Assert.Equal($"calculator/{definition.Id}", definition.Route));
```

## Evidence the member was genuinely unreferenced

Searched the whole repo (`app/`, `web/`, `.github/`, `docs/`) across `.cs`, `.xaml`, `.ts/.tsx/.js/.jsx`, `.json`, `.yml`, `.md`, `.csproj`, `.slnx`, excluding `node_modules/`, `bin/`, `obj/`, `dist/`.

**Positive control — the same search shape run against members known to be live:**

| Member | `.Member` access | `{Binding Member}` | `nameof` / `"Member"` |
|---|---|---|---|
| `Id` | 104 | 0 | 0 |
| `Title` | 14 | 27 | 2 |
| `Summary` | 4 | 3 | 1 |
| `IconGlyph` | 5 | 4 | 1 |
| **`Route`** | **1** | **0** | **0** |

The searches return hits for every live member, including XAML bindings a plain C# symbol search would miss — so a zero for `Route` is a real absence, not a malformed probe. The single `.Route` hit was the self-referential assertion being deleted here.

The only other `Route` occurrences in the repo are unrelated: `Route = route` in `AppShell.xaml.cs` sets MAUI's own `ShellContent.Route` / `Tab.Route`, and two prose mentions in `docs/GITHUB_PAGES_SPA_ROUTING.md`.

Also confirmed: no other `new CalculatorDefinition(...)` construction, no `with` expression touching `Route`, and no positional deconstruction anywhere — so removing a positional record parameter breaks no call site.

**Not a breaking external API change.** `MyFireNumber.Core` is a plain `net10.0` classlib with no `IsPackable`/`PackageId`, and no `dotnet pack` or `nuget push` in any workflow. Its only consumers are the in-repo `MyFireNumber`, `MyFireNumber.Storage`, and `MyFireNumber.Tests` projects.

## The oracle with teeth is intact and verified

The reachability test from #85 is untouched. It parses `Routing.RegisterRoute` out of `AppShell.xaml.cs` and asserts catalog ⊆ registered routes, with a non-vacuity guard. Verified by local sabotage, then restored:

- **All 17 route registrations deleted** → 2 failures: `Every_shipped_calculator_has_a_native_page_route` and the vacuity guard `Neither_the_catalog_nor_the_discovered_route_table_is_silently_empty`.
- **Only `barista-fire`'s registration deleted** (a case the vacuity guard cannot catch) → 1 failure, naming the exact calculator: *"Calculator 'barista-fire' is in the catalog but no Shell route is registered for it… so it is unreachable in the native app."*

`git diff` against `AppShell.xaml.cs` is empty — the sabotage is fully reverted.

## Validation

- `dotnet test app/MyFireNumber.Tests/` — **293 passed, 0 failed**, before and after.
- The count is unchanged rather than down one: xUnit counts `[Fact]` methods, not assertions, and the removed `Assert.All` was one of six statements inside `Every_shipped_calculator_definition_is_well_formed`, which survives with its other five.
- `dotnet build app/MyFireNumber/MyFireNumber.csproj -f net10.0-maccatalyst` — **0 warnings, 0 errors**, with `MauiXamlInflator=SourceGen`, so compiled-binding analysis would have flagged any XAML reference to `Route`.

Zero changes to formulas, defaults, or calculation behaviour; `web/` untouched.