### PR TITLE
Stop formatPeriodAmount rendering a signed zero (#87)

### DIFF
--- a/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
@@ -227,6 +227,74 @@ public class CurrencyPeriodMathTests
         Assert.Equal(expected, CurrencyPeriodMath.Format(value, CultureInfo.InvariantCulture));
     }
 
+    /// <summary>
+    /// The counterpart to the negative-zero rows web added for issue #87 — and the one place the two
+    /// suites now deliberately disagree.
+    ///
+    /// <para>#87 was filed on the premise that <c>Format</c> "deliberately never emits -0", which
+    /// would make web the only unsafe side. Measured here on .NET 10, that premise does not hold: the
+    /// custom format string <c>"0.##"</c> keeps the sign under IEEE-compliant formatting, so this side
+    /// renders <c>"-0"</c> for exactly the inputs web used to. The extra safety established in #77
+    /// belongs to <see cref="CurrencyPeriodMath.RoundHalfUp"/>, which never *produces* a negative
+    /// zero, and <see cref="RoundHalfUp_does_not_produce_negative_zero"/> passes because it hands
+    /// <c>Format</c> a positive zero — not because <c>Format</c> normalises a negative one it is
+    /// given. The two facts were adjacent enough to be read as one.</para>
+    /// <para>Pinned as measured rather than fixed. #87 is scoped to the web formatter, and changing
+    /// shared display behaviour in Core is a separate decision. What makes it safe to leave is the
+    /// same thing that kept it invisible: the entry rejects negatives before they are converted (see
+    /// <see cref="A_negative_amount_never_reaches_the_rounding_helper"/>), so nothing below is
+    /// reachable from a field. Recorded so the next reader compares the suites against what the code
+    /// does rather than against #87's description of it.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(-0.0, "-0")]
+    [InlineData(-0.001, "-0")]
+    [InlineData(-1e-7, "-0")]
+    public void Format_still_signs_a_rounded_away_zero_where_web_no_longer_does(double value, string expected)
+    {
+        Assert.Equal(expected, CurrencyPeriodMath.Format(value, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// Guards the guard above: its three rows are three different numbers, and only the first is
+    /// negative zero.
+    ///
+    /// <para><c>double.IsNegative</c> is the C# counterpart to web's <c>Object.is</c> here.
+    /// <c>-0.0 == 0.0</c> is <c>true</c> in both languages, so an equality assertion cannot see the
+    /// sign at all — the blind spot that let #87 survive. The other two rows are ordinary negative
+    /// numbers whose magnitude the format string rounds away while the sign survives, so a fix
+    /// written against negative zero alone would miss them on either platform.</para>
+    /// </summary>
+    [Fact]
+    public void The_rounded_away_zero_rows_are_genuinely_different_inputs()
+    {
+        const double negativeZero = -0.0;
+
+        Assert.True(double.IsNegative(negativeZero));
+        Assert.False(double.IsNegative(0.0));
+        // The blind spot itself: this passes, and proves nothing about the sign.
+        Assert.Equal(0.0, negativeZero);
+
+        Assert.False(negativeZero < 0);
+        Assert.True(-0.001 < 0);
+        Assert.True(-1e-7 < 0);
+    }
+
+    /// <summary>
+    /// A negative large enough to survive the rounding keeps its sign, on both platforms. Half a cent
+    /// is the first magnitude that still shows, so it is the boundary worth pinning: any fix that
+    /// clamped every amount rounding to zero would swallow this row instead.
+    /// </summary>
+    [Theory]
+    [InlineData(-0.005, "-0.01")]
+    [InlineData(-0.01, "-0.01")]
+    [InlineData(-1_234.5, "-1234.5")]
+    [InlineData(-50_000, "-50000")]
+    public void Format_keeps_the_sign_of_a_negative_that_survives_the_rounding(double value, string expected)
+    {
+        Assert.Equal(expected, CurrencyPeriodMath.Format(value, CultureInfo.InvariantCulture));
+    }
+
     [Fact]
     public void Suffix_and_qualifier_name_the_period()
     {

--- a/web/src/utils/__tests__/currencyPeriod.test.ts
+++ b/web/src/utils/__tests__/currencyPeriod.test.ts
@@ -500,17 +500,16 @@ describe('the preconditions that keep negatives away from the rounding', () => {
   })
 
   /**
-   * A known divergence from the MAUI port, pinned as-is rather than fixed.
-   *
-   * `CurrencyPeriodMath.Format` deliberately never emits `"-0"`; `formatPeriodAmount` will, because
-   * `Intl.NumberFormat` preserves the sign of negative zero. It is unreachable today — the sanitizer
-   * strips `-`, the edit path floors negatives, and `0 / 12` is `+0` — so this pins the precondition
-   * and records the latent difference instead of changing behaviour that both platforms share.
+   * Issue #87, now fixed: `formatPeriodAmount` used to render `"-0"` here, where
+   * `CurrencyPeriodMath.RoundHalfUp` on the MAUI side returns positive zero. The formatter is
+   * asserted properly under `formatPeriodAmount` below; what this test still owns are the three
+   * preconditions that keep a negative away from it in the first place, which the fix does not
+   * replace. They are pinned so removing a guard shows up here rather than quietly making the
+   * negative rows live.
    */
-  it('would render negative zero as "-0", which is why negatives are kept out upstream', () => {
-    expect(formatPeriodAmount(-0)).toBe('-0')
-
-    // And the reasons it cannot happen.
+  it('cannot be handed a negative zero in the first place', () => {
+    // `Object.is`, not `===`: `-0 === 0` is true, so an equality assertion would pass on either zero
+    // and prove nothing about the sign these guards exist to keep out.
     expect(Object.is(convertPeriod(0, 'annual', 'monthly'), 0)).toBe(true)
     expect(Object.is(editField('-0', 50_000, 'annual', 'annual'), 0)).toBe(true)
     expect(formatPeriodAmount(convertPeriod(0, 'annual', 'monthly'))).toBe('0')
@@ -612,6 +611,55 @@ describe('formatPeriodAmount', () => {
     // compared without this looking like a bug in either.
     expect(formatPeriodAmount(50_000)).toBe('50,000')
     expect(sanitize(formatPeriodAmount(50_000))).toBe('50000')
+  })
+
+  /**
+   * Issue #87.
+   *
+   * `Intl.NumberFormat` keeps the sign of a value whose magnitude `maximumFractionDigits: 2` rounds
+   * away, so every one of these rendered `"-0"` before the normalisation.
+   *
+   * The rows are deliberately three *different* numbers. Only the first is negative zero; `-0.001`
+   * and `-1e-7` are ordinary negative numbers that merely round to nothing. A fix written as
+   * `Object.is(value, -0)` would have handled the rare input and left the likelier two broken, which
+   * is why the normalisation is applied to the rendered text instead of to the input.
+   */
+  it.each<[string, number]>([
+    ['negative zero', -0],
+    ['a negative just under half a cent', -0.001],
+    ['a negative far under half a cent', -1e-7],
+  ])('renders %s as an unsigned zero', (_name, value) => {
+    expect(formatPeriodAmount(value)).toBe('0')
+    expect(formatPeriodAmount(value)).not.toContain('-')
+  })
+
+  it('the three rows above are genuinely different inputs', () => {
+    // Guards the guard. `-0 === 0` is true, so an equality assertion is blind to the exact thing
+    // being fixed — that blind spot is why the bug survived. `Object.is` is what can see it, and it
+    // is also what shows the last two rows are not negative zero at all.
+    expect(Object.is(-0, 0)).toBe(false)
+    expect(Object.is(-0, -0)).toBe(true)
+    expect(Object.is(-0.001, -0)).toBe(false)
+    expect(Object.is(-1e-7, -0)).toBe(false)
+    expect([-0.001, -1e-7].every(value => value < 0)).toBe(true)
+  })
+
+  it('keeps the sign of a negative big enough to survive the rounding', () => {
+    // The normalisation rewrites a rendering that is nothing but zeros, so it cannot swallow a real
+    // amount. Half a cent is the first magnitude that still shows, and it still shows as negative.
+    expect(formatPeriodAmount(-0.005)).toBe('-0.01')
+    expect(formatPeriodAmount(-0.01)).toBe('-0.01')
+    expect(formatPeriodAmount(-1_234.5)).toBe('-1,234.5')
+    expect(formatPeriodAmount(-50_000)).toBe('-50,000')
+  })
+
+  it('leaves positive amounts exactly as they were', () => {
+    // The fix is scoped to the sign. Nothing above zero changes shape, including the boundary values
+    // the normalisation inspects.
+    expect(formatPeriodAmount(0)).toBe('0')
+    expect(formatPeriodAmount(0.001)).toBe('0')
+    expect(formatPeriodAmount(0.005)).toBe('0.01')
+    expect(formatPeriodAmount(50_000 / 12)).toBe('4,166.67')
   })
 })
 

--- a/web/src/utils/currencyPeriod.ts
+++ b/web/src/utils/currencyPeriod.ts
@@ -58,12 +58,31 @@ export function resolveEditedAmount(
 }
 
 /**
+ * A rendering that carries a minus sign in front of nothing but zeros.
+ *
+ * Matched against the *formatted* text rather than the input number on purpose. Two different inputs
+ * produce it and only one of them is negative zero: `Intl` keeps the sign while
+ * `maximumFractionDigits` rounds the magnitude away, so every negative under half a cent — `-0.001`,
+ * `-1e-7` — renders `"-0"` too, and those are ordinary negative numbers that `Object.is(value, -0)`
+ * does not catch. Testing the output catches both without having to enumerate the inputs. The
+ * optional fraction covers a future `minimumFractionDigits`, which would render `"-0.00"`.
+ */
+const NEGATIVE_ZERO_RENDERING = /^-0(?:\.0+)?$/
+
+/**
  * Format an amount for a currency field. Cents are shown only when the amount has them, so annual
  * figures stay clean while monthly conversions keep the precision needed to edit them accurately.
+ *
+ * Zero is always rendered unsigned, matching `CurrencyPeriodMath.RoundHalfUp` on the MAUI side, which
+ * returns positive zero where the JS `Math.round` this module was written against returns `-0`. Only
+ * a rendering that is entirely zeros is rewritten, so a real fraction of a cent keeps its sign:
+ * `-0.005` still renders `"-0.01"`.
  */
 export function formatPeriodAmount(value: number): string {
   if (!Number.isFinite(value)) return '0'
-  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value)
+
+  const formatted = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(value)
+  return NEGATIVE_ZERO_RENDERING.test(formatted) ? formatted.slice(1) : formatted
 }
 
 /**


### PR DESCRIPTION
Fixes #87.

`Intl.NumberFormat` keeps the sign of a value whose magnitude `maximumFractionDigits: 2` rounds away, so `formatPeriodAmount` rendered `"-0"` — display only, no calculation impact, and still unreachable through the UI.

## Before / after

Measured on node v24.11.0, `en-US`:

| input | before | after | note |
| --- | --- | --- | --- |
| `-0` | `"-0"` | `"0"` | negative zero |
| `-0.001` | `"-0"` | `"0"` | **ordinary negative number, not `-0`** |
| `-1e-7` | `"-0"` | `"0"` | same shape, added for range |
| `0` | `"0"` | `"0"` | unchanged |
| `-0.005` | `"-0.01"` | `"-0.01"` | a real half cent, sign kept |
| `-1234.5` | `"-1,234.5"` | `"-1,234.5"` | unchanged |

`-0.001` is the one that matters. It is not negative zero, so `Object.is(value, -0)` never sees it — the magnitude is rounded away while the sign survives, which makes *every* negative under half a cent render `"-0"`. The normalisation is therefore applied to the **rendered string** (`/^-0(?:\.0+)?$/`, the optional fraction covering a future `minimumFractionDigits`), not to the input number. That covers both inputs without enumerating them, and it cannot swallow a real amount.

The alternative the issue floated — clamping magnitudes below half a cent — was rejected after measuring: `-0.005` *is* half a cent and correctly renders `"-0.01"`, so a clamp keyed on `Math.round(value * 100) === 0` would have silently turned it into `"0"`. Sabotage 3 below is that exact mistake.

## Sabotage

Each variant was applied to the shipped code, run, then reverted. Failure text is verbatim.

**1 — normalisation removed entirely** → 3 failed | 129 passed

```
FAIL  src/utils/__tests__/currencyPeriod.test.ts > formatPeriodAmount > renders negative zero as an unsigned zero
FAIL  ... > renders a negative just under half a cent as an unsigned zero
FAIL  ... > renders a negative far under half a cent as an unsigned zero
AssertionError: expected '-0' to be '0' // Object.is equality
Expected: "0"
Received: "-0"
```

**2 — the naive fix, `Object.is(value, -0) ? 0 : value`** → 2 failed | 130 passed

```
FAIL  ... > renders a negative just under half a cent as an unsigned zero
FAIL  ... > renders a negative far under half a cent as an unsigned zero
AssertionError: expected '-0' to be '0' // Object.is equality
```

The literal `-0` row goes green and the two ordinary negatives stay red — this is the trap the issue called out, and the suite now catches it.

**3 — the over-broad clamp, `Math.round(value * 100) === 0 ? 0 : value`** → 1 failed | 131 passed

```
FAIL  ... > formatPeriodAmount > keeps the sign of a negative big enough to survive the rounding
AssertionError: expected '0' to be '-0.01' // Object.is equality
Expected: "-0.01"
Received: "0"
```

## Found but not fixed: #87's premise about the MAUI side is wrong

The issue states `CurrencyPeriodMath.Format` "deliberately never emits `-0`", making web the only unsafe side. Measured on .NET 10 with `InvariantCulture`, it does:

```
Format(-0.0)   => "-0"
Format(-0.001) => "-0"
Format(-1e-7)  => "-0"
Format(-0.005) => "-0.01"
```

The custom format string `"0.##"` keeps the sign under IEEE-compliant formatting, exactly as `Intl` did. The extra safety established in #77 belongs to **`RoundHalfUp`**, which never *produces* a negative zero — not to `Format`, which was never asked to normalise one it is handed. `RoundHalfUp_does_not_produce_negative_zero` passes its `Format(result)` assertion because `result` is positive zero, so the two facts sat adjacent enough to be read as one. Web is not, and was not, the only unsafe side.

Pinned as measured rather than fixed, per the "report, don't fix silently" instruction: `Format` is shared display surface and changing it is a decision outside this issue. It stays safe for the same reason it stayed invisible — the entry rejects negatives before conversion, so none of those inputs is reachable from a field. `Format_still_signs_a_rounded_away_zero_where_web_no_longer_does` carries the full explanation so the next reader compares the suites against what the code does rather than against #87's description of it. **Worth a follow-up issue if the two formatters should converge.**

## Testing

`-0 === 0` is `true`, so an equality assertion on the number is blind to the thing being fixed. Every sign assertion uses `Object.is` (web) or `double.IsNegative` (C#), and the rendering assertions are on strings, where the sign cannot hide.

Added on web, under `formatPeriodAmount`:
- three rendering rows (`-0`, `-0.001`, `-1e-7`), each asserting `'0'` and `not.toContain('-')`
- *the three rows above are genuinely different inputs* — guards the guard, so the rows cannot be mistaken for one case written three times: `Object.is(-0, 0)` is `false`, `Object.is(-0.001, -0)` is `false`, and both non-zero rows are `< 0`
- *keeps the sign of a negative big enough to survive the rounding*
- *leaves positive amounts exactly as they were*

The three preconditions that keep negatives unreachable (sanitizer strips `-`, edit path rejects `typed < 0`, `0 / 12` is `+0`) are **untouched and still pinned**. The test that previously asserted `formatPeriodAmount(-0) === '-0'` kept all three precondition assertions and lost only the now-fixed divergence line; its `Object.is` checks are intact.

Mirrored into `CurrencyPeriodMathTests` case-for-case (the only MAUI file touched): the rounded-away-zero theory, the different-inputs fact, and the sign-preservation theory.

## Test counts

| suite | baseline | after |
| --- | --- | --- |
| web (`npx vitest run`) | 971 passed / 17 files | **977 passed / 17 files** |
| .NET (`dotnet test app/MyFireNumber.Tests/`) | 293 passed | **301 passed** |

Nothing lost; `npm run build` passes; `designInvariants.test.ts` untouched and green; `css: true` left alone. No changes to `calculations.ts`, `excelExport.ts`, any export call site, `app/MyFireNumber/Views/`, or `CalculatorDefinition`.