### PR TITLE
Stop CurrencyPeriodMath.Format rendering a signed zero (#91)

### DIFF
--- a/app/MyFireNumber.Core/Presentation/CurrencyPeriodMath.cs
+++ b/app/MyFireNumber.Core/Presentation/CurrencyPeriodMath.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace MyFireNumber.Core.Presentation;
 
 /// <summary>
@@ -12,6 +14,13 @@ namespace MyFireNumber.Core.Presentation;
 public static class CurrencyPeriodMath
 {
     public const int MonthsPerYear = 12;
+
+    /// <summary>
+    /// The custom numeric format every currency entry is written with. Held in one place because
+    /// <see cref="Format"/> renders zero with it a second time to decide whether a negative sign is
+    /// standing in front of nothing.
+    /// </summary>
+    private const string AmountFormat = "0.##";
 
     /// <summary>
     /// Convert an amount between periods. Exact for equal periods, so it is safe to call
@@ -101,15 +110,55 @@ public static class CurrencyPeriodMath
     /// accurately.
     /// </summary>
     /// <remarks>
-    /// <c>"0.##"</c> is the format the calculator entries already use, so the display period does not
-    /// change how any amount is written. It is also why this type has no counterpart to the web
-    /// helper <c>formatTypedAmount</c>: that exists purely to stop comma grouping from eating a
-    /// trailing <c>"."</c> mid-keystroke, and nothing here groups digits or rewrites text while the
-    /// user is typing.
+    /// <para><see cref="AmountFormat"/> is the format the calculator entries already use, so the
+    /// display period does not change how any amount is written. It is also why this type has no
+    /// counterpart to the web helper <c>formatTypedAmount</c>: that exists purely to stop comma
+    /// grouping from eating a trailing <c>"."</c> mid-keystroke, and nothing here groups digits or
+    /// rewrites text while the user is typing.</para>
+    /// <para><b>Zero is always rendered unsigned</b> (issue #91). <c>"0.##"</c> is IEEE-compliant, so
+    /// it drops the magnitude of a small negative while keeping the sign: <c>-0.0</c>, <c>-0.001</c>
+    /// and <c>-1e-7</c> all rendered <c>"-0"</c> in an entry. Like
+    /// <c>web/src/utils/currencyPeriod.ts</c>, the check is made against the <i>rendered text</i>
+    /// rather than the input value, because only the first of those is a negative zero — a guard
+    /// written against <c>double.IsNegative(value) &amp;&amp; value == 0</c> would miss the other two.
+    /// This also keeps the behaviour consistent with <see cref="RoundHalfUp"/>, which never produces
+    /// a negative zero in the first place.</para>
+    /// <para><b>The sign comes from the provider, never from a literal <c>"-"</c>.</b> The web
+    /// counterpart can match <c>/^-0(?:\.0+)?$/</c> only because it hardcodes
+    /// <c>Intl.NumberFormat('en-US')</c>. Here <see cref="PeriodicAmountField"/> defaults its
+    /// provider to <see cref="System.Globalization.CultureInfo.CurrentCulture"/>, so the sign is the
+    /// device's: 99 of the 1063 cultures on .NET 10 use something else, including U+2212 MINUS SIGN
+    /// (<c>sv-SE</c>, <c>fi-FI</c>, <c>et-EE</c>) and two-character sequences that begin with a
+    /// directional mark (<c>ar-EG</c> is U+061C U+002D, <c>fa-IR</c> is U+200E U+2212). Hence
+    /// <see cref="NumberFormatInfo.GetInstance(IFormatProvider)"/>, an ordinal
+    /// <see cref="string.StartsWith(string, StringComparison)"/> — the default overload is
+    /// culture-sensitive and treats those marks as ignorable — and a slice by the sign's own length
+    /// rather than by one character.</para>
+    /// <para>The "is this nothing but zeros" test is the remaining magnitude compared against zero
+    /// put through the <i>same</i> format and provider. That needs no assumption about which
+    /// characters spell a zero or separate its decimals, and it stays correct if
+    /// <see cref="AmountFormat"/> ever gains a minimum fraction width, where the rendering would
+    /// become <c>"-0.00"</c>. It is also deliberately no wider: half a cent is a real amount, so
+    /// <c>-0.005</c> still renders <c>"-0.01"</c>, which a tidier-looking clamp such as
+    /// <c>RoundHalfUp(value * 100) == 0</c> would silently swallow.</para>
     /// </remarks>
     public static string Format(double value, IFormatProvider formatProvider)
     {
-        return double.IsFinite(value) ? value.ToString("0.##", formatProvider) : "0";
+        if (!double.IsFinite(value))
+        {
+            return "0";
+        }
+
+        var formatted = value.ToString(AmountFormat, formatProvider);
+        var negativeSign = NumberFormatInfo.GetInstance(formatProvider).NegativeSign;
+
+        if (!formatted.StartsWith(negativeSign, StringComparison.Ordinal))
+        {
+            return formatted;
+        }
+
+        var magnitude = formatted[negativeSign.Length..];
+        return magnitude == 0d.ToString(AmountFormat, formatProvider) ? magnitude : formatted;
     }
 
     /// <summary>Short suffix shown inside the entry, e.g. <c>/mo</c>.</summary>

--- a/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/CurrencyPeriodMathTests.cs
@@ -106,14 +106,22 @@ public class CurrencyPeriodMathTests
     ///
     /// <para>JavaScript's <c>Math.round(-0.5)</c> is <c>-0</c>, not <c>0</c>. In C# — as in JS —
     /// <c>-0.0 == 0.0</c> is <c>true</c>, so <c>Assert.Equal(0, ...)</c> passes whichever zero comes
-    /// back and proves nothing about the sign. That matters because a negative zero reaching
-    /// <see cref="CurrencyPeriodMath.Format"/> would render as the string <c>"-0"</c> in an entry.
-    /// </para>
+    /// back and proves nothing about the sign. <see cref="double.IsNegative(double)"/> is the C#
+    /// counterpart to web's <c>Object.is</c> and is the only assertion here that can see it.</para>
     /// <para>This implementation returns <b>positive</b> zero: <c>Math.Floor(-0.5)</c> is
     /// <c>-1.0</c>, and IEEE-754 addition of exact opposites yields <c>+0.0</c> under
     /// round-to-nearest, so the <c>-0</c> path is never taken. So it is one step *safer* than the JS
-    /// original here rather than a match, and this test pins that rather than the JS bit pattern —
-    /// picking the behaviour that cannot surface "-0" in the UI.</para>
+    /// original here rather than a match, and this test pins that rather than the JS bit pattern.</para>
+    /// <para><b>This test used to also assert on <c>Format(result)</c>, and that assertion is what
+    /// hid issue #91.</b> <c>result</c> is always positive zero, so <c>Format</c> was called but
+    /// never once handed a negative value — the suite looked as though it covered <c>Format</c>'s
+    /// sign handling while proving only that <c>Format(+0.0)</c> is <c>"0"</c>. That misreading
+    /// became the premise of #87 ("MAUI's <c>Format</c> deliberately never emits -0"), which was
+    /// false. The two are different guarantees and are now tested apart: this one is about what
+    /// <c>RoundHalfUp</c> <i>produces</i>;
+    /// <see cref="Format_normalises_a_negative_zero_it_is_actually_handed"/> is about what
+    /// <c>Format</c> does with one it is <i>given</i>. Conflating them is what let the defect
+    /// survive two sessions.</para>
     /// <para>All three negative rows are defensive only. <c>RoundHalfUp</c> is reachable from the
     /// field solely through <c>IsSameToCent</c> &lt;- <c>ResolveEditedAmount</c> &lt;-
     /// <c>PeriodicAmountField.TrySetText</c>, which rejects <c>typed &lt; 0</c> before it converts,
@@ -127,7 +135,6 @@ public class CurrencyPeriodMathTests
 
         Assert.Equal(0, result);
         Assert.False(double.IsNegative(result), "-0.5 rounded to negative zero, which formats as \"-0\".");
-        Assert.Equal("0", CurrencyPeriodMath.Format(result, CultureInfo.InvariantCulture));
     }
 
     /// <summary>
@@ -228,42 +235,130 @@ public class CurrencyPeriodMathTests
     }
 
     /// <summary>
-    /// The counterpart to the negative-zero rows web added for issue #87 — and the one place the two
-    /// suites now deliberately disagree.
+    /// Issue #91: a negative whose magnitude the format string rounds away renders <b>unsigned</b>.
     ///
-    /// <para>#87 was filed on the premise that <c>Format</c> "deliberately never emits -0", which
-    /// would make web the only unsafe side. Measured here on .NET 10, that premise does not hold: the
-    /// custom format string <c>"0.##"</c> keeps the sign under IEEE-compliant formatting, so this side
-    /// renders <c>"-0"</c> for exactly the inputs web used to. The extra safety established in #77
-    /// belongs to <see cref="CurrencyPeriodMath.RoundHalfUp"/>, which never *produces* a negative
-    /// zero, and <see cref="RoundHalfUp_does_not_produce_negative_zero"/> passes because it hands
-    /// <c>Format</c> a positive zero — not because <c>Format</c> normalises a negative one it is
-    /// given. The two facts were adjacent enough to be read as one.</para>
-    /// <para>Pinned as measured rather than fixed. #87 is scoped to the web formatter, and changing
-    /// shared display behaviour in Core is a separate decision. What makes it safe to leave is the
-    /// same thing that kept it invisible: the entry rejects negatives before they are converted (see
-    /// <see cref="A_negative_amount_never_reaches_the_rounding_helper"/>), so nothing below is
-    /// reachable from a field. Recorded so the next reader compares the suites against what the code
-    /// does rather than against #87's description of it.</para>
+    /// <para>These three rows were added by PR #90 asserting <c>"-0"</c>, to record MAUI's
+    /// divergence from web as measured fact rather than fix it out of scope. They are inverted here
+    /// rather than deleted, so the suite keeps naming the exact inputs that used to be wrong.</para>
+    /// <para>#87 was filed on the premise that <c>Format</c> "deliberately never emits -0". That was
+    /// false: <c>"0.##"</c> keeps the sign under IEEE-compliant formatting while dropping the
+    /// magnitude, exactly as <c>Intl.NumberFormat</c> does. The safety established in #77 belongs to
+    /// <see cref="CurrencyPeriodMath.RoundHalfUp"/>, which never <i>produces</i> a negative zero, and
+    /// was mistaken for a property of <c>Format</c> — see
+    /// <see cref="RoundHalfUp_does_not_produce_negative_zero"/> for how the old test made that
+    /// misreading look verified.</para>
+    /// <para>Only the first row is a negative zero. <c>-0.001</c> and <c>-1e-7</c> are ordinary
+    /// negative numbers, so a fix written against <c>double.IsNegative(value) &amp;&amp; value == 0</c>
+    /// — the C# analogue of <c>Object.is(value, -0)</c> — would leave them rendering a signed zero.
+    /// That is why both platforms normalise the <i>rendered text</i> instead of the input.</para>
     /// </summary>
     [Theory]
-    [InlineData(-0.0, "-0")]
-    [InlineData(-0.001, "-0")]
-    [InlineData(-1e-7, "-0")]
-    public void Format_still_signs_a_rounded_away_zero_where_web_no_longer_does(double value, string expected)
+    [InlineData(-0.0, "0")]
+    [InlineData(-0.001, "0")]
+    [InlineData(-1e-7, "0")]
+    public void Format_renders_a_rounded_away_negative_unsigned(double value, string expected)
     {
+        // Guards the table against going vacuous. -0.0 == 0.0, so if the sign were lost passing
+        // through the InlineData attribute the first row would silently become a duplicate of
+        // Format(0.0) and would pass no matter what Format did with a real negative zero.
+        Assert.True(
+            double.IsNegative(value),
+            $"{value:R} reached the test unsigned, so this row proves nothing about negatives.");
+
         Assert.Equal(expected, CurrencyPeriodMath.Format(value, CultureInfo.InvariantCulture));
     }
 
     /// <summary>
-    /// Guards the guard above: its three rows are three different numbers, and only the first is
-    /// negative zero.
+    /// <see cref="CurrencyPeriodMath.Format"/> handed a genuine negative zero — the single case the
+    /// suite appeared to cover before #91 and never actually exercised.
+    /// </summary>
+    [Fact]
+    public void Format_normalises_a_negative_zero_it_is_actually_handed()
+    {
+        const double negativeZero = -0.0;
+
+        // Without this the assertion below is worthless: an unsigned zero would satisfy it too.
+        Assert.True(double.IsNegative(negativeZero));
+
+        Assert.Equal("0", CurrencyPeriodMath.Format(negativeZero, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// The negative sign is culture data, not the character <c>'-'</c>.
+    ///
+    /// <para>Every other row in this file formats under <see cref="CultureInfo.InvariantCulture"/>,
+    /// but production does not: <c>PeriodicAmountField</c> defaults its provider to
+    /// <see cref="CultureInfo.CurrentCulture"/>, so the sign a user actually sees is whatever their
+    /// device locale prescribes. On .NET 10, 99 of the 1063 available cultures render a negative
+    /// with something other than U+002D HYPHEN-MINUS:</para>
+    /// <code>
+    /// sv-SE   U+2212           MINUS SIGN
+    /// fi-FI   U+2212           MINUS SIGN
+    /// et-EE   U+2212           MINUS SIGN
+    /// ar-EG   U+061C U+002D    ARABIC LETTER MARK + hyphen    (two chars)
+    /// fa-IR   U+200E U+2212    LEFT-TO-RIGHT MARK + MINUS     (two chars, no hyphen at all)
+    /// </code>
+    /// <para>A fix built on a literal <c>"-"</c> — <c>StartsWith("-")</c>, <c>TrimStart('-')</c>, or
+    /// <c>Substring(1)</c> — passes every Invariant-culture assertion in this suite and still leaves
+    /// the defect in place for all five. Worse for the two-character signs: the default
+    /// <c>StartsWith(string)</c> overload is culture-sensitive and treats U+200E and U+061C as
+    /// ignorable, so it can report a match and then <c>Substring(1)</c> strips only the mark and
+    /// hands back <c>"-0"</c> unchanged. These rows exist so that shape of fix cannot ship green.
+    /// </para>
+    /// </summary>
+    [Theory]
+    [InlineData("sv-SE")]
+    [InlineData("fi-FI")]
+    [InlineData("et-EE")]
+    [InlineData("ar-EG")]
+    [InlineData("fa-IR")]
+    public void Format_normalises_a_signed_zero_under_a_culture_whose_negative_sign_is_not_a_hyphen(
+        string cultureName)
+    {
+        var culture = CultureInfo.GetCultureInfo(cultureName);
+
+        // The row only means anything while this holds. If ICU data ever changes it, or the suite is
+        // run in invariant globalization mode, this fails loudly rather than quietly degrading into
+        // another copy of the Invariant test above.
+        Assert.NotEqual("-", culture.NumberFormat.NegativeSign);
+
+        Assert.Equal("0", CurrencyPeriodMath.Format(-0.0, culture));
+        Assert.Equal("0", CurrencyPeriodMath.Format(-0.001, culture));
+        Assert.Equal("0", CurrencyPeriodMath.Format(-1e-7, culture));
+    }
+
+    /// <summary>
+    /// The contract itself, free of any ICU data on the build machine: whatever the provider says its
+    /// negative sign is, that is what a rendering of nothing but zeros is stripped of.
+    ///
+    /// <para>The sign here is deliberately two characters and contains no hyphen, so
+    /// <c>StartsWith("-")</c> never fires and <c>Substring(1)</c> would leave <c>"~0"</c> behind. The
+    /// decimal separator is changed too, so nothing can pass by assuming <c>'.'</c>. The last two
+    /// rows keep the fix from being over-broad in the same breath.</para>
+    /// </summary>
+    [Fact]
+    public void Format_takes_the_negative_sign_from_the_format_provider()
+    {
+        var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+        culture.NumberFormat.NegativeSign = "~~";
+        culture.NumberFormat.NumberDecimalSeparator = "|";
+
+        Assert.Equal("0", CurrencyPeriodMath.Format(-0.0, culture));
+        Assert.Equal("0", CurrencyPeriodMath.Format(-0.001, culture));
+        Assert.Equal("~~0|01", CurrencyPeriodMath.Format(-0.005, culture));
+        Assert.Equal("~~1234|5", CurrencyPeriodMath.Format(-1_234.5, culture));
+        Assert.Equal("0|5", CurrencyPeriodMath.Format(0.5, culture));
+    }
+
+    /// <summary>
+    /// Guards the rows above: they are three different numbers, and only the first is negative zero.
     ///
     /// <para><c>double.IsNegative</c> is the C# counterpart to web's <c>Object.is</c> here.
     /// <c>-0.0 == 0.0</c> is <c>true</c> in both languages, so an equality assertion cannot see the
-    /// sign at all — the blind spot that let #87 survive. The other two rows are ordinary negative
-    /// numbers whose magnitude the format string rounds away while the sign survives, so a fix
-    /// written against negative zero alone would miss them on either platform.</para>
+    /// sign at all — the blind spot that let #87 be written with a false premise and #91 survive
+    /// undetected. The other two rows are ordinary negative numbers whose magnitude the format string
+    /// rounds away while the sign survives, so a fix written against negative zero alone would miss
+    /// them on either platform.</para>
     /// </summary>
     [Fact]
     public void The_rounded_away_zero_rows_are_genuinely_different_inputs()
@@ -282,8 +377,10 @@ public class CurrencyPeriodMathTests
 
     /// <summary>
     /// A negative large enough to survive the rounding keeps its sign, on both platforms. Half a cent
-    /// is the first magnitude that still shows, so it is the boundary worth pinning: any fix that
-    /// clamped every amount rounding to zero would swallow this row instead.
+    /// is the first magnitude that still shows, so it is the boundary worth pinning: a tidier-looking
+    /// clamp such as <c>Math.Round(value * 100) == 0</c> would swallow this row instead, turning a
+    /// real amount into an unsigned zero. The fix has to be neither narrower nor wider than "the
+    /// rendering is nothing but zeros".
     /// </summary>
     [Theory]
     [InlineData(-0.005, "-0.01")]
@@ -293,6 +390,20 @@ public class CurrencyPeriodMathTests
     public void Format_keeps_the_sign_of_a_negative_that_survives_the_rounding(double value, string expected)
     {
         Assert.Equal(expected, CurrencyPeriodMath.Format(value, CultureInfo.InvariantCulture));
+    }
+
+    /// <summary>
+    /// The same boundary under a culture that changes both the sign and the decimal separator, so
+    /// "do not over-correct" is pinned everywhere "normalise the signed zero" is.
+    /// </summary>
+    [Fact]
+    public void Format_keeps_a_surviving_negative_under_a_non_hyphen_culture()
+    {
+        var culture = CultureInfo.GetCultureInfo("sv-SE");
+
+        // U+2212 MINUS SIGN, then a comma decimal separator.
+        Assert.Equal("\u22120,01", CurrencyPeriodMath.Format(-0.005, culture));
+        Assert.Equal("\u22121234,5", CurrencyPeriodMath.Format(-1_234.5, culture));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #91.

`"0.##"` is IEEE-compliant, so it drops the magnitude of a small negative while keeping the sign. `Format(-0.0)`, `Format(-0.001)` and `Format(-1e-7)` all rendered `"-0"` in a currency entry. Web fixed the identical defect in #90; MAUI did not, so the two platforms diverged.

Normalisation is applied to the **rendered text** rather than the input value, as web does — only the first of those three inputs is a negative zero, so a guard written against `double.IsNegative(value) && value == 0` (the C# analogue of `Object.is(value, -0)`) would miss the other two.

## The web fix does not port directly

`/^-0(?:\.0+)?$/` is safe on web only because `Intl.NumberFormat('en-US', …)` hardcodes the locale. This signature takes an `IFormatProvider`, and `PeriodicAmountField.cs:38` defaults it to `CultureInfo.CurrentCulture` — so **production formats under the device's locale, while every pre-existing test passed `InvariantCulture`.**

That gap is load-bearing. On .NET 10, **99 of 1063 cultures** render a negative with something other than U+002D:

| culture | negative sign | `Format(-0.0)` before |
|---|---|---|
| `sv-SE`, `fi-FI`, `et-EE` | U+2212 MINUS SIGN | `−0` |
| `ar-EG` | U+061C U+002D (two chars) | `؜-0` |
| `fa-IR` | U+200E U+2212 (two chars, no hyphen) | `‎−0` |

A fix built on a literal `"-"` — `StartsWith("-")`, `TrimStart('-')`, `Substring(1)` — **passes all 301 existing tests and still leaves the bug in place for every one of those cultures.** I verified this rather than assuming it: running the new culture rows against a naive `"-"` implementation left 6 failures while every Invariant-culture row went green (see the check-in comment for the output).

It is worse than merely missing, too: the default `string.StartsWith(string)` overload is culture-sensitive and treats U+200E/U+061C as ignorable, so it can report a match and then `Substring(1)` strips only the mark, handing back `"-0"` unchanged.

So the implementation reads the sign from `NumberFormatInfo.GetInstance(formatProvider).NegativeSign`, compares with `StringComparison.Ordinal`, and slices by the sign's own length rather than by one character.

## Neither too narrow nor too wide

"Nothing but zeros" is decided by comparing the remaining magnitude against zero put through the *same* format and provider. That needs no assumption about which characters spell a zero or separate its decimals, and it stays correct if the format string ever gains a minimum fraction width (`"-0.00"`).

It is deliberately no wider: `-0.005` is exactly half a cent, a real amount, and still renders `"-0.01"`. A tidier-looking clamp such as `RoundHalfUp(value * 100) == 0` would silently swallow it. That boundary is pinned under both Invariant and `sv-SE`.

## Test changes

- **The three rows PR #90 added to pin the divergence are inverted, not deleted**, so the suite keeps naming the exact inputs that used to be wrong.
- **Fixed the test-design flaw that hid this.** `RoundHalfUp_does_not_produce_negative_zero` asserted on `Format(result)`, but `result` is always positive zero — so `Format` was called and never once handed a negative. That made `Format` look covered while proving only that `Format(+0.0)` is `"0"`, and it is why the false premise of #87 ("MAUI's `Format` deliberately never emits -0") survived two sessions. The two guarantees are now tested apart: what `RoundHalfUp` *produces*, and what `Format` does with a negative it is *given*.
- **Guarded the tables against going vacuous.** `-0.0 == 0.0` is true in C#, so the `-0.0` row asserts `double.IsNegative` on its own input before formatting — if the sign were lost passing through the `InlineData` attribute, that row would otherwise silently become a duplicate of `Format(0.0)`. The culture rows likewise assert their sign is not `"-"`, so they fail loudly rather than degrading into another copy of the Invariant test if ICU data changes.
- Added real-culture coverage (`sv-SE`, `fi-FI`, `et-EE`, `ar-EG`, `fa-IR`) plus a synthetic `CultureInfo` with a two-character sign `"~~"` and separator `"|"`, which pins the contract hermetically regardless of the build machine's ICU data.

## Verification

- `dotnet test app/MyFireNumber.Tests/` — **301 → 309 passing, 0 failed**, Debug and Release. Nothing lost.
- `dotnet build app/MyFireNumber/MyFireNumber.csproj -f net10.0-ios` — **0 Warnings, 0 Errors**; MAUIG2045 count stays at 0.
- Scope is the two files named in the issue; `web/` untouched, no `bin/`/`obj/`.
- No calculation, formula or default changes — `Format` is presentation only. The sole production caller is `PeriodicAmountField.cs:115`, and the shared parity fixture contains no negative values.