### PR TITLE
Fix retirement spending label wrap and input row misalignment

### DIFF
--- a/.github/instructions/web.instructions.md
+++ b/.github/instructions/web.instructions.md
@@ -68,7 +68,7 @@ For a new calculator:
 ## Styling and Accessibility
 
 - Use Tailwind CSS v4 utilities and existing design tokens; do not add CSS modules or styled-components.
-- Include appropriate `dark:` variants for new UI.
+- Use semantic tokens that resolve per theme (for example `bg-surface-raised`, `text-content-muted`); do not hand-place `dark:` variants, raw hex colors, emoji, inline `<svg>`, or gradient utilities. These are enforced by `web/src/utils/__tests__/designInvariants.test.ts`, so code that ignores this fails CI.
 - Follow the existing mobile-first breakpoints and navigation behavior.
 - Use the accessible Tooltip and InputGroup patterns for contextual help.
 - Provide semantic headings, labels, ARIA descriptions, and keyboard access.

--- a/web/src/components/inputs/AgeInput.tsx
+++ b/web/src/components/inputs/AgeInput.tsx
@@ -63,47 +63,49 @@ export default function AgeInput({
         {label}
         {tooltip && <Tooltip content={tooltip} />}
       </label>
-      <div className="relative">
-        <input
-          id={id}
-          type="number"
-          value={inputValue}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          min={min}
-          max={max}
-          className="
-            w-full px-3 py-2.5 pr-16
-            bg-surface-raised 
-            border border-border-strong 
-            rounded-control 
-            text-content
-            placeholder-content-subtle
-            focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-accent
-            transition-colors
-          "
-        />
-        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-subtle pointer-events-none text-sm">
-          years old
-        </span>
+      <div>
+        <div className="relative">
+          <input
+            id={id}
+            type="number"
+            value={inputValue}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            min={min}
+            max={max}
+            className="
+              w-full px-3 py-2.5 pr-16
+              bg-surface-raised 
+              border border-border-strong 
+              rounded-control 
+              text-content
+              placeholder-content-subtle
+              focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-accent
+              transition-colors
+            "
+          />
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-subtle pointer-events-none text-sm">
+            years old
+          </span>
+        </div>
+        {showSlider && (
+          <input
+            type="range"
+            value={value}
+            onChange={(event) => (onSliderChange ?? onChange)(parseInt(event.target.value, 10))}
+            min={min}
+            max={max}
+            step={1}
+            aria-label={`${label} slider`}
+            className="
+              mt-3 w-full h-2
+              bg-border-subtle
+              rounded-control appearance-none cursor-pointer
+              accent-accent
+            "
+          />
+        )}
       </div>
-      {showSlider && (
-        <input
-          type="range"
-          value={value}
-          onChange={(event) => (onSliderChange ?? onChange)(parseInt(event.target.value, 10))}
-          min={min}
-          max={max}
-          step={1}
-          aria-label={`${label} slider`}
-          className="
-            mt-3 w-full h-2
-            bg-border-subtle
-            rounded-control appearance-none cursor-pointer
-            accent-accent
-          "
-        />
-      )}
     </div>
   )
 }

--- a/web/src/components/inputs/CurrencyInput.tsx
+++ b/web/src/components/inputs/CurrencyInput.tsx
@@ -108,7 +108,7 @@ export default function CurrencyInput({
         >
           {label}
           {periodic && (
-            <span className="text-xs font-normal text-content-subtle">
+            <span className="sr-only">
               ({periodQualifier(displayPeriod)})
             </span>
           )}

--- a/web/src/components/inputs/InputGroup.tsx
+++ b/web/src/components/inputs/InputGroup.tsx
@@ -55,66 +55,68 @@ export default function InputGroup({
         {label}
         {tooltip && <Tooltip content={tooltip} />}
       </label>
-      <div className="relative">
-        {prefix && (
-          <span className="absolute left-3 top-1/2 -translate-y-1/2 text-content-subtle pointer-events-none">
-            {prefix}
-          </span>
+      <div>
+        <div className="relative">
+          {prefix && (
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-content-subtle pointer-events-none">
+              {prefix}
+            </span>
+          )}
+          <input
+            id={id}
+            type="number"
+            value={value}
+            onChange={handleChange}
+            min={min}
+            max={max}
+            step={step}
+            aria-describedby={helperText ? helperTextId : undefined}
+            className={`
+              w-full px-3 py-2.5 
+              bg-surface-raised 
+              border border-border-strong 
+              rounded-control 
+              text-content
+              placeholder-content-subtle
+              focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-accent
+              transition-colors
+              ${prefix ? 'pl-8' : ''}
+              ${suffix ? 'pr-12' : ''}
+            `}
+            {...props}
+          />
+          {suffix && (
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-subtle pointer-events-none">
+              {suffix}
+            </span>
+          )}
+        </div>
+        {showSlider && min !== undefined && max !== undefined && (
+          <input
+            type="range"
+            value={value}
+            onChange={(event) => {
+              const newValue = parseFloat(event.target.value)
+              ;(onSliderChange ?? onChange)(newValue)
+            }}
+            min={min}
+            max={max}
+            step={step}
+            aria-label={`${label} slider`}
+            className="
+              mt-3 w-full h-2
+              bg-border-subtle
+              rounded-control appearance-none cursor-pointer
+              accent-accent
+            "
+          />
         )}
-        <input
-          id={id}
-          type="number"
-          value={value}
-          onChange={handleChange}
-          min={min}
-          max={max}
-          step={step}
-          aria-describedby={helperText ? helperTextId : undefined}
-          className={`
-            w-full px-3 py-2.5 
-            bg-surface-raised 
-            border border-border-strong 
-            rounded-control 
-            text-content
-            placeholder-content-subtle
-            focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-accent
-            transition-colors
-            ${prefix ? 'pl-8' : ''}
-            ${suffix ? 'pr-12' : ''}
-          `}
-          {...props}
-        />
-        {suffix && (
-          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-content-subtle pointer-events-none">
-            {suffix}
-          </span>
+        {helperText && (
+          <p id={helperTextId} className="mt-1.5 text-xs text-content-subtle">
+            {helperText}
+          </p>
         )}
       </div>
-      {showSlider && min !== undefined && max !== undefined && (
-        <input
-          type="range"
-          value={value}
-          onChange={(event) => {
-            const newValue = parseFloat(event.target.value)
-            ;(onSliderChange ?? onChange)(newValue)
-          }}
-          min={min}
-          max={max}
-          step={step}
-          aria-label={`${label} slider`}
-          className="
-            mt-3 w-full h-2
-            bg-border-subtle
-            rounded-control appearance-none cursor-pointer
-            accent-accent
-          "
-        />
-      )}
-      {helperText && (
-        <p id={helperTextId} className="mt-1.5 text-xs text-content-subtle">
-          {helperText}
-        </p>
-      )}
     </div>
   )
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -220,3 +220,35 @@ input[type="number"] {
     scroll-behavior: auto !important;
   }
 }
+
+/*
+ * Alignment backstop for the calculator input grids.
+ *
+ * Each cell is `label track` + `control track`. Opting the grid into subgrid makes the
+ * label track a shared row, so one long label that wraps to two lines lifts the whole
+ * row instead of pushing its own input below its neighbours. Sliders live inside the
+ * control track, so a cell with a slider grows downward into its own space and cannot
+ * disturb the row -- which is why this does not need, and must not use, bottom-pinning.
+ *
+ * `row-gap: 0` is required, not cosmetic: a subgrid inherits the parent's `gap`, which
+ * would space the label 16px off its input instead of the 6px the label's own margin
+ * gives it. Measured: without this the gap becomes 22px and each card grows 32px.
+ *
+ * Gated on @supports because `grid-row: span 2` without `grid-template-rows: subgrid`
+ * would leave an empty second row. Where subgrid is unsupported this rule is skipped
+ * entirely and the layout is exactly what it is today.
+ *
+ * `align-items: start` is also load-bearing. The control track is as tall as the tallest
+ * control in the row, so in a row containing a slider a plain input's wrapper would
+ * stretch to slider height, and the absolutely positioned `$` and `/mo` adornments --
+ * which centre on that wrapper -- would sink below their own input.
+ */
+@supports (grid-template-rows: subgrid) {
+  .field-grid > * {
+    display: grid;
+    grid-template-rows: subgrid;
+    grid-row: span 2;
+    row-gap: 0;
+    align-items: start;
+  }
+}

--- a/web/src/pages/BaristaFIRE.tsx
+++ b/web/src/pages/BaristaFIRE.tsx
@@ -52,11 +52,11 @@ export default function BaristaFIRE() {
               <p className="mt-1 text-sm text-content-muted">Pair today-dollar spending with the income you expect from flexible work.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Your current age." min={18} max={80} showSlider />
               <CurrencyInput label="Current invested assets" value={params.currentSavings} onChange={value => setParam('currentSavings', value)} tooltip="Investments available for retirement." />
               <CurrencyInput label="Contributions" value={params.annualContribution} onChange={value => setParam('annualContribution', value)} tooltip="How much you expect to invest before Barista FIRE." periodic />
-              <CurrencyInput label="Retirement spending (today's dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
+              <CurrencyInput label="Retirement spending (today’s dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
               <CurrencyInput label="After-tax part-time take-home income" value={params.partTimeIncome} onChange={value => setParam('partTimeIncome', value)} tooltip="Expected income after taxes from part-time or flexible work." periodic />
             </CardContent>
           </Card>

--- a/web/src/pages/CoastFIRE.tsx
+++ b/web/src/pages/CoastFIRE.tsx
@@ -49,12 +49,12 @@ export default function CoastFIRE() {
               <p className="mt-1 text-sm text-content-muted">Your target age and today-dollar retirement spending set the Coast FIRE threshold.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Your current age." min={18} max={80} showSlider />
               <AgeInput label="Target retirement age" value={params.retirementAge} onChange={value => setParam('retirementAge', value)} onSliderChange={value => setParamDebounced('retirementAge', value)} tooltip="The age your Coast portfolio should support." min={params.currentAge} max={90} showSlider />
               <CurrencyInput label="Current invested assets" value={params.currentSavings} onChange={value => setParam('currentSavings', value)} tooltip="Investments available for retirement." />
               <CurrencyInput label="Contributions" value={params.annualContribution} onChange={value => setParam('annualContribution', value)} tooltip="Contributions used only to estimate how soon you can reach Coast FIRE." periodic />
-              <CurrencyInput label="Retirement spending (today's dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, stated in today’s purchasing power." periodic />
+              <CurrencyInput label="Retirement spending (today’s dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, stated in today’s purchasing power." periodic />
             </CardContent>
           </Card>
         </section>

--- a/web/src/pages/DeferredCompensation.tsx
+++ b/web/src/pages/DeferredCompensation.tsx
@@ -149,7 +149,7 @@ export default function DeferredCompensation() {
             <h2 className="text-lg font-semibold text-content">Start with your retirement scenario</h2>
             <PeriodToggle className="mt-3" />
           </CardHeader>
-          <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput
                 label="Current Age"
                 value={params.currentAge}
@@ -177,7 +177,7 @@ export default function DeferredCompensation() {
                 showSlider
               />
               <CurrencyInput
-                label="Retirement spending (today's dollars)"
+                label="Retirement spending (today’s dollars)"
                 value={params.annualExpenses}
                 onChange={value => setParam('annualExpenses', value)}
                 tooltip="Your after-tax annual spending target in today’s dollars."

--- a/web/src/pages/FatFIRE.tsx
+++ b/web/src/pages/FatFIRE.tsx
@@ -53,13 +53,13 @@ export default function FatFIRE() {
               <p className="mt-1 text-sm text-content-muted">Fat FIRE is commonly associated with annual spending of {formatCurrency(FAT_THRESHOLD)} or more in today&apos;s dollars.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Your current age." min={18} max={80} showSlider />
               <AgeInput label="Target retirement age" value={params.retirementAge} onChange={value => setParam('retirementAge', value)} onSliderChange={value => setParamDebounced('retirementAge', value)} tooltip="The age you want this plan to support." min={params.currentAge} max={90} showSlider />
               <CurrencyInput label="Current invested assets" value={params.currentSavings} onChange={value => setParam('currentSavings', value)} tooltip="Investments available for retirement." />
               <CurrencyInput label="Contributions" value={params.annualContribution} onChange={value => setParam('annualContribution', value)} tooltip="How much you expect to invest." periodic />
               <CurrencyInput label="After-tax take-home income" value={params.annualIncome} onChange={value => setParam('annualIncome', value)} tooltip="Income after taxes, used to calculate your savings rate." periodic />
-              <CurrencyInput label="Retirement spending (today's dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
+              <CurrencyInput label="Retirement spending (today’s dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
             </CardContent>
           </Card>
         </section>

--- a/web/src/pages/HealthcareGap.tsx
+++ b/web/src/pages/HealthcareGap.tsx
@@ -50,7 +50,7 @@ export default function HealthcareGap() {
               <p className="mt-1 text-sm text-content-muted">Enter the costs you expect to pay before Medicare begins. Every amount below uses the same period, so switch them all to monthly or annual with one control. These values are saved with this calculator.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Used to label the cost timeline." min={18} max={64} showSlider />
               <AgeInput label="Early retirement age" value={params.retirementAge} onChange={value => setParam('retirementAge', value)} onSliderChange={value => setParamDebounced('retirementAge', value)} tooltip="When employer-sponsored coverage ends." min={params.currentAge} max={64} showSlider />
               <CurrencyInput label="Health insurance premium" value={params.healthcareMonthlyPremium} onChange={value => setParam('healthcareMonthlyPremium', value)} tooltip="Expected health insurance premium." max={3000} periodic storedPeriod="monthly" />

--- a/web/src/pages/LeanFIRE.tsx
+++ b/web/src/pages/LeanFIRE.tsx
@@ -59,13 +59,13 @@ export default function LeanFIRE() {
               <p className="mt-1 text-sm text-content-muted">Lean FIRE is typically based on spending of {formatCurrency(LEAN_THRESHOLD)} a year or less in today&apos;s dollars.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Your current age." min={18} max={80} showSlider />
               <AgeInput label="Target retirement age" value={params.retirementAge} onChange={value => setParam('retirementAge', value)} onSliderChange={value => setParamDebounced('retirementAge', value)} tooltip="The age you want this plan to support." min={params.currentAge} max={90} showSlider />
               <CurrencyInput label="Current invested assets" value={params.currentSavings} onChange={value => setParam('currentSavings', value)} tooltip="Investments available for retirement." />
               <CurrencyInput label="Contributions" value={params.annualContribution} onChange={value => setParam('annualContribution', value)} tooltip="How much you expect to invest." periodic />
               <CurrencyInput label="After-tax take-home income" value={params.annualIncome} onChange={value => setParam('annualIncome', value)} tooltip="Income after taxes, used to calculate your savings rate." periodic />
-              <CurrencyInput label="Retirement spending (today's dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement. Lean FIRE plans typically stay at or below $40,000; higher amounts are still calculated as entered." periodic />
+              <CurrencyInput label="Retirement spending (today’s dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement. Lean FIRE plans typically stay at or below $40,000; higher amounts are still calculated as entered." periodic />
             </CardContent>
           </Card>
         </section>

--- a/web/src/pages/ReverseFIRE.tsx
+++ b/web/src/pages/ReverseFIRE.tsx
@@ -47,11 +47,11 @@ export default function ReverseFIRE() {
               <p className="mt-1 text-sm text-content-muted">Set a target age, then state the portfolio and spending you expect to need.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Your current age." min={18} max={80} showSlider />
               <AgeInput label="Target retirement age" value={params.retirementAge} onChange={value => setParam('retirementAge', value)} onSliderChange={value => setParamDebounced('retirementAge', value)} tooltip="When you want to reach financial independence." min={params.currentAge} max={90} showSlider />
               <CurrencyInput label="Current invested assets" value={params.currentSavings} onChange={value => setParam('currentSavings', value)} tooltip="Investments already available for retirement." />
-              <CurrencyInput label="Retirement spending (today's dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
+              <CurrencyInput label="Retirement spending (today’s dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
             </CardContent>
           </Card>
         </section>

--- a/web/src/pages/SavingsRate.tsx
+++ b/web/src/pages/SavingsRate.tsx
@@ -58,11 +58,11 @@ export default function SavingsRate() {
               <p className="mt-1 text-sm text-content-muted">Use after-tax take-home income to see the share of income you are investing.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Used to label the projection timeline." min={18} max={80} showSlider />
               <CurrencyInput label="Starting amount" value={params.currentSavings} onChange={value => setParam('currentSavings', value)} tooltip="Investments already in the account." />
-              <div className="space-y-2">
-                <span className="block text-sm font-medium text-content-muted">Contribution frequency</span>
+              <div>
+                <span className="mb-1.5 block text-sm font-medium text-content-muted">Contribution frequency</span>
                 <div className="inline-flex rounded-control border border-border-subtle p-1" role="group" aria-label="Contribution frequency">
                   {(['monthly', 'yearly'] as const).map(frequency => (
                     <button

--- a/web/src/pages/StandardFIRE.tsx
+++ b/web/src/pages/StandardFIRE.tsx
@@ -88,13 +88,13 @@ export default function StandardFIRE() {
               <p className="mt-1 text-sm text-content-muted">Use today&apos;s spending and after-tax income to make the estimate meaningful.</p>
               <PeriodToggle className="mt-3" />
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <AgeInput label="Current age" value={params.currentAge} onChange={value => setParam('currentAge', value)} onSliderChange={value => setParamDebounced('currentAge', value)} tooltip="Your current age." min={18} max={80} showSlider />
               <AgeInput label="Target retirement age" value={params.retirementAge} onChange={value => setParam('retirementAge', value)} onSliderChange={value => setParamDebounced('retirementAge', value)} tooltip="The age you want this plan to support." min={params.currentAge} max={90} showSlider />
               <CurrencyInput label="Current invested assets" value={params.currentSavings} onChange={value => setParam('currentSavings', value)} tooltip="Investments available for retirement, including workplace plans, IRAs, and brokerage accounts." />
               <CurrencyInput label="Contributions" value={params.annualContribution} onChange={value => setParam('annualContribution', value)} tooltip="How much you expect to invest." periodic />
               <CurrencyInput label="After-tax take-home income" value={params.annualIncome} onChange={value => setParam('annualIncome', value)} tooltip="Income after taxes. It is used to calculate your savings rate." periodic />
-              <CurrencyInput label="Retirement spending (today's dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
+              <CurrencyInput label="Retirement spending (today’s dollars)" value={params.annualExpenses} onChange={value => setParam('annualExpenses', value)} tooltip="Expected after-tax spending in retirement, expressed in today’s purchasing power." periodic />
             </CardContent>
           </Card>
         </section>

--- a/web/src/pages/WithdrawalRate.tsx
+++ b/web/src/pages/WithdrawalRate.tsx
@@ -48,7 +48,7 @@ export default function WithdrawalRate() {
               <h2 id="withdrawal-plan-heading" className="text-lg font-semibold text-content">Start with your withdrawal plan</h2>
               <p className="mt-1 text-sm text-content-muted">Choose a portfolio, a first-year withdrawal rate, and how long the money needs to last.</p>
             </CardHeader>
-            <CardContent className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <CardContent className="field-grid grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
               <CurrencyInput label="Portfolio value" value={params.portfolioValue} onChange={value => setParam('portfolioValue', value)} tooltip="Current total invested assets available for withdrawals." />
               <PercentageInput label="Withdrawal rate" value={params.withdrawalRate} onChange={value => setParam('withdrawalRate', value)} onSliderChange={value => setParamDebounced('withdrawalRate', value)} tooltip="Percentage of the starting portfolio withdrawn in the first year." min={0.02} max={0.08} step={0.005} />
               <InputGroup label="Retirement duration" value={params.retirementYears} onChange={value => setParam('retirementYears', value)} onSliderChange={value => setParamDebounced('retirementYears', value)} tooltip="How many years the portfolio needs to support withdrawals." suffix="years" min={10} max={60} showSlider />

--- a/web/src/utils/__tests__/designInvariants.test.ts
+++ b/web/src/utils/__tests__/designInvariants.test.ts
@@ -1,5 +1,18 @@
 /**
- * Guards the five invariants the web UI redesign established.
+ * Guards the five invariants the web UI redesign established, plus one the label-wrap fix added.
+ *
+ * The sixth guard is a different shape from the other five and worth reading separately. Those ban a
+ * visible thing; this one REQUIRES an invisible thing, because the period qualifier on a periodic
+ * input renders nothing at all — it exists solely to reach the accessible name. That makes it look
+ * exactly like dead markup to anyone tidying up, and deleting it costs a screen reader the period on
+ * the one field whose entire ambiguity is monthly-vs-annual. Measured, not assumed:
+ *
+ *   as shipped         "Retirement spending (today's dollars) (per year) More information"
+ *   qualifier deleted  "Retirement spending (today's dollars) More information"
+ *
+ * The in-field `/yr` adornment does not rescue it: that span is `pointer-events-none` and sits
+ * OUTSIDE the `<label>`, so it contributes nothing to the name. Hence the guard is scoped to label
+ * content specifically, not to the file as a whole.
  *
  * The redesign removed 57 emoji, 743 hand-placed `dark:` utilities, 44 inline `<svg>` elements,
  * 13 stray hex colours and 7 gradient panels. Nothing in the suite noticed any of that, which meant
@@ -141,6 +154,53 @@ const GRADIENT = /\bbg-(?:gradient|linear|radial|conic)-/g
  */
 const HEX_ALLOWED = ['index.css', 'components/charts/chartTheme.ts']
 
+/**
+ * A `<label>…</label>` element.
+ *
+ * Scoping to the label is the whole point rather than an optimisation. A periodic input renders the
+ * period twice: once as this qualifier inside the label, and once as a `/yr` adornment outside it.
+ * Only the first reaches the accessible name, so a file-wide search for `periodQualifier` would be
+ * satisfied by markup that announces nothing.
+ */
+const LABEL_BLOCK = /<label[\s>][\s\S]*?<\/label>/g
+
+/** Any call to the qualifier helper. The `(` excludes the bare identifier on the import line. */
+const QUALIFIER_CALL = /periodQualifier\(/g
+
+/**
+ * The qualifier wrapped in a screen-reader-only span.
+ *
+ * `[^<]*` spans the newline and the literal `(` that sit between the tag and the call, while
+ * stopping at the next tag so a distant sr-only span elsewhere in the label cannot vouch for a
+ * qualifier it does not contain.
+ */
+const SR_ONLY_QUALIFIER = /<span\s+className="sr-only"[^>]*>[^<]*periodQualifier\(/g
+
+/**
+ * The file that must carry a hidden qualifier, named rather than discovered — the one deliberate
+ * exception to this file's discover-never-enumerate rule, and it exists because of that rule.
+ *
+ * A guard that only inspects files calling `periodQualifier` evaporates the moment someone deletes
+ * the call, which is precisely the deletion it is here to catch: the file drops out of the scan and
+ * the suite goes green on the regression. Naming the file makes its absence a failure. The sweep
+ * below still covers anything new that adopts the helper.
+ */
+const QUALIFIER_REQUIRED = 'components/inputs/CurrencyInput.tsx'
+
+function findQualifierViolations(source: string): string[] {
+  const labels = (source.match(LABEL_BLOCK) ?? []).join('\n')
+  const calls = (labels.match(QUALIFIER_CALL) ?? []).length
+  const hidden = (labels.match(SR_ONLY_QUALIFIER) ?? []).length
+
+  if (calls === 0) {
+    return ['no period qualifier inside <label> (the /yr adornment is outside it and does not count)']
+  }
+  if (hidden < calls) {
+    return [`${calls - hidden} qualifier(s) rendered as visible label text instead of sr-only`]
+  }
+  return []
+}
+
 function report(hits: Array<[string, string[]]>): string {
   return hits.map(([path, found]) => `  ${path}: ${found.join(' ')}`).join('\n')
 }
@@ -187,6 +247,68 @@ describe('design invariant detectors', () => {
     expect('className="bg-gradient-to-r"'.match(GRADIENT)).toHaveLength(1)
     expect('className="bg-linear-to-br"'.match(GRADIENT)).toHaveLength(1)
     expect('<linearGradient id="g">'.match(GRADIENT)).toBeNull()
+  })
+
+  // This detector guards markup that renders nothing, so both ways of losing it have to be caught:
+  // rendering the qualifier visibly, and deleting it outright. Each is exercised here before the
+  // detector is believed about real source.
+  it('accepts a qualifier hidden inside the label', () => {
+    const shipped = `
+      <label htmlFor={id} className="flex items-center gap-1.5">
+        {label}
+        {periodic && (
+          <span className="sr-only">
+            ({periodQualifier(displayPeriod)})
+          </span>
+        )}
+        {tooltip && <Tooltip content={tooltip} />}
+      </label>
+      <span className="absolute right-3 pointer-events-none">{periodSuffix(displayPeriod)}</span>`
+    expect(findQualifierViolations(shipped)).toEqual([])
+  })
+
+  it('flags a qualifier rendered as visible label text', () => {
+    const visible = `
+      <label htmlFor={id}>
+        {label}
+        <span className="text-xs font-normal text-content-subtle">
+          ({periodQualifier(displayPeriod)})
+        </span>
+      </label>`
+    expect(findQualifierViolations(visible)).toHaveLength(1)
+    expect(findQualifierViolations(visible)[0]).toContain('visible label text')
+  })
+
+  it('flags a deleted qualifier, and is not fooled by the adornment outside the label', () => {
+    // The exact shape of the regression: the span looks like dead markup, so it goes, and the `/yr`
+    // adornment below is mistaken for the period surviving. It is outside the label and does not.
+    const deleted = `
+      <label htmlFor={id}>
+        {label}
+        {tooltip && <Tooltip content={tooltip} />}
+      </label>
+      <span className="absolute right-3 pointer-events-none">{periodQualifier(displayPeriod)}</span>`
+    expect(findQualifierViolations(deleted)).toHaveLength(1)
+    expect(findQualifierViolations(deleted)[0]).toContain('no period qualifier inside <label>')
+  })
+
+  it('flags a qualifier that is hidden once but also printed visibly', () => {
+    const both = `
+      <label htmlFor={id}>
+        {label}
+        <span className="sr-only">({periodQualifier(displayPeriod)})</span>
+        <span className="text-xs">({periodQualifier(displayPeriod)})</span>
+      </label>`
+    expect(findQualifierViolations(both)).toHaveLength(1)
+  })
+
+  it('does not let a distant sr-only span vouch for a visible qualifier', () => {
+    const decoy = `
+      <label htmlFor={id}>
+        <span className="sr-only">Required</span>
+        <span className="text-xs">({periodQualifier(displayPeriod)})</span>
+      </label>`
+    expect(findQualifierViolations(decoy)).toHaveLength(1)
   })
 
   it('strips comments without blanking the strings utilities live in', () => {
@@ -264,5 +386,44 @@ describe('web UI design invariants', () => {
   it('ships no gradient backgrounds', () => {
     const hits = scan(source => source.match(GRADIENT) ?? [])
     expect(hits.length, `Use a flat surface token:\n${report(hits)}`).toBe(0)
+  })
+})
+
+describe('accessible name invariants', () => {
+  /**
+   * The period must survive in the accessible name of every periodic input.
+   *
+   * Unlike the five bans above, this asserts the PRESENCE of markup that renders nothing. The span
+   * is invisible by design and therefore looks removable; removing it silently drops "(per month)"
+   * from what a screen reader announces, on a field whose whole ambiguity is the period. Nothing
+   * else in the repo notices, because the visible output is byte-identical either way.
+   */
+  it('keeps the period qualifier inside the label, hidden rather than deleted', () => {
+    const source = SHIPPED.find(([path]) => shortPath(path) === QUALIFIER_REQUIRED)?.[1]
+
+    // Absence is a failure, not a skip. If this file is renamed, the guard must be moved with it.
+    expect(source, `${QUALIFIER_REQUIRED} not found; move this guard to its new path`).toBeDefined()
+
+    const violations = findQualifierViolations(stripComments(source ?? '', QUALIFIER_REQUIRED))
+    expect(
+      violations,
+      `${QUALIFIER_REQUIRED}: ${violations.join('; ')}\n` +
+        'The qualifier renders nothing on screen but carries the period into the accessible name. ' +
+        'The /yr adornment sits outside the <label> and does not replace it.',
+    ).toEqual([])
+  })
+
+  // The named file above catches deletion; this catches anything new that adopts the helper and
+  // prints it visibly, which would reintroduce the label wrap the fix removed.
+  //
+  // `includes`, not `QUALIFIER_CALL.test`: that regex carries the `g` flag, so `.test` advances
+  // `lastIndex` and returns false on every second call against the same input. A stateful filter
+  // would skip half the files and still report clean.
+  it('renders no period qualifier as visible label text anywhere', () => {
+    const hits = scan((source, path) =>
+      path.endsWith('.tsx') && source.includes('periodQualifier(') ? findQualifierViolations(source) : [],
+    ).filter(([, found]) => found.some(problem => problem.includes('visible label text')))
+
+    expect(hits.length, `Wrap it in <span className="sr-only">:\n${report(hits)}`).toBe(0)
   })
 })


### PR DESCRIPTION
## The defect

On the Standard FIRE "Start with your plan" card, the third field of row 2 rendered its input **19px below** its two neighbours, because its label wrapped to two lines and the `(per year)` qualifier split mid-phrase into `(per` / `year)`.

**Before** (`/standard`, Monthly, 1280px) — both right-hand labels wrap, the qualifier splits, and two inputs sit low:

<img width="900" alt="Before: labels wrapped to two lines, (per month) split mid-phrase, right-hand inputs sitting lower than Contributions" src="https://github.com/user-attachments/assets/cfb804e7-a9cb-4d04-91b6-fa04aa70bfbb" />

**After** — every label on one line, all six inputs sharing a baseline, sliders untouched:

<img width="900" alt="After: every label on one line and all six inputs sharing a baseline" src="https://github.com/user-attachments/assets/b70e008e-3ea5-414a-af7c-0d8d62dd07d0" />

## Measured, not eyeballed

Every figure here is `getBoundingClientRect()` from headless Chromium against a real dev server.

The grid column **caps at 335px**, so in **Monthly** the row was misaligned at *every* desktop width — 1280, 1400, 1500, 1600, 2000, 2400 — and never resolved:

| viewport | 1280 | 1400 | 1500 | 1600 | 2000 | 2400 |
|---|---|---|---|---|---|---|
| row 2 spread | 19px | 19px | 19px | 19px | 19px | 19px |

Annual self-corrected at ≥1440px, which is why the original report looked width-dependent. `periodQualifier('monthly')` is **11px wider** than `'per year'`, and that 11px was the whole difference. The qualifier also split at **390px**, where row alignment isn't even in play — so the split was not merely a symptom of the misalignment.

## Root cause

The period was stated **three times** for the same field: the card header's `PeriodToggle`, the label's `(per year)`, and the input's own `/mo` adornment. The label qualifier is the redundant one, and it was simultaneously the thing that split *and* the thing consuming the width that forced the text to wrap. Removing it visibly fixes both defects at their shared root.

## The accessible name — why the qualifier is hidden, not deleted

The `/mo` adornment is `pointer-events-none` and sits **outside** the `<label>`, so it contributes nothing to the accessible name. Verified with CDP `Accessibility.getFullAXTree`:

| variant | computed accessible name |
|---|---|
| as shipped before | `Retirement spending (today's dollars) (per year) More information` |
| qualifier **deleted** | `Retirement spending (today's dollars) More information` ← **period lost** |
| qualifier **`sr-only`** (this PR) | `Retirement spending (today's dollars) (per year) More information` |

Deleting it would have silently stripped the period from what a screen reader announces — on the one field whose entire ambiguity is monthly-vs-annual. `sr-only` keeps the name identical in both periods.

## The alignment backstop, and why it isn't bottom-pinning

The tightest label now clears its cell by only 5px, so a structural guard is included. Each field cell becomes a **two-row subgrid** (`.field-grid`), sharing the label track across the row: a label that ever does wrap lifts the whole row instead of dropping one input.

The obvious fix — `h-full flex flex-col` + `mt-auto`, or `justify-end` — would have been wrong. `AgeInput` renders a range slider *after* its input **inside the same grid cell**, and row 1 is two sliders plus one plain currency field. Bottom-pinning would have dropped `Current invested assets` to slider level, breaking a row that already measured `spread = 0px`. Here sliders live **inside** the control track, so a slider cell grows into its own space and cannot disturb its neighbours.

Three things the subgrid needed, each found by measuring rather than reasoning:

- **`row-gap: 0`** — a subgrid inherits the parent's `gap`, which pushed the label **22px** off its input instead of 6px and grew every card by 32px.
- **`align-items: start`** — without it a plain input's wrapper stretched to slider height in row 1, and the absolutely-centred `$` adornment sank *below* its own input. This one was invisible in the numbers and only showed up in a screenshot.
- **`@supports` gating** — `grid-row: span 2` without subgrid support would leave an empty second row, so where subgrid is unsupported the rule is skipped entirely and the layout is exactly what it is today.

`AgeInput` and `InputGroup` gained a wrapper `div` so each cell is `label + control`. The wrapper is inert: measured identical geometry before and after.

## Rename

`Retirement spending (today's dollars)` → `Retirement spending (today’s dollars)` — same words, typographic apostrophe, applied to **all 7 sites** in one commit. The tooltip on the same line and every neighbouring string already used the curly form; these labels were the only holdouts.

`today's dollars` is the payload of the today's-vs-at-retirement decision, so it stays in the **visible** label — not deleted, and not demoted into the hover/tap-gated tooltip where it would be invisible at rest.

## What the harness could not see

Two of the three subgrid hazards above were found by *looking*, not by measuring, and that is the most transferable thing in this PR.

The verification harness runs 144 configurations and asserts input alignment and label wrapping. Both regressions I introduced were invisible to it:

- **`row-gap`**: a subgrid inherits the parent's `gap-4`, which moved the label 22px off its input — **uniformly across all three cells**. Every configuration still reported `spread=[0,0]`, perfectly aligned, while every card silently grew 32px. The metric was blind to the change the fix made, because it measured *relative* alignment and the damage was *uniform*.
- **`align-items`**: the `$` adornment sank below its own input in slider rows. The harness measured input tops and label wraps; nobody had told it to look at adornments, so it did not.

A numeric harness catches exactly what it was told to measure and nothing else. It is a regression net, not a substitute for rendering the page and looking at it. Both of these were caught by diffing an after-screenshot against the pre-change baseline.

## What is enforced going forward, and what is not

Worth stating plainly, so nobody assumes more coverage than exists:

- **Enforced in CI**: the source-text guard on the `sr-only` qualifier, and the five existing design invariants. These run on every commit.
- **Not in CI**: the 144-configuration geometry harness and the CDP accessible-name check. Both were run by hand against a live dev server for this change. The geometry was verified once; nothing re-verifies it automatically.

Making the geometry harness part of CI would mean adding a browser runner to the suite, which is a larger decision than this PR should make on its own.

## Verification

- **144 configurations**: 9 periodic pages × {annual, monthly} × {light, dark} × {1280, 1440, 900, 390} — **0 failures**. Every row shares a baseline, no label wraps, no visible qualifier, and label→input spacing is **exactly 6px everywhere** (it was 6px before).
- **Accessible name** re-read via CDP on `/standard`, `/barista`, `/retirement-cash-flow` in both periods — period qualifier present in all 10.
- **Broke the fix on purpose, twice.** Reverting `sr-only` brings the 19px back at 1280 both periods and 1440 monthly (annual@1440 self-corrects, matching the original measurement). Separately disabling `.field-grid` with an over-long label brings 19px back in all four configs while row 1 stays at 0px. Each mechanism is therefore known to be the thing holding.
- **984 tests / 17 files** (977 before, plus the 7 that make up the new guard and its controls). `npm run build` clean. Design-invariant guard green. impeccable detector returns `[]`.

## The committed guard, sabotaged twice

The accessibility fix was one line — a `className` changed to `sr-only` — and nothing in the repo watched it. The span renders nothing, so it reads as dead markup to anyone tidying up, and no visual check can notice its removal. A fix that cannot be broken on demand is not known to be load-bearing; this one could not be broken on demand at all.

Added to `designInvariants.test.ts`, in that file's existing style — source read as text, `environment: 'node'` preserved, no jsdom or testing-library. The detector is validated against a known positive and a known negative before it is trusted on real source, and it is scoped to `<label>` content specifically, because the `/yr` adornment lives outside the label and would otherwise vouch for a period that is never announced.

**Sabotage 1 — strip `sr-only`, render the qualifier visibly:**

```
FAIL  accessible name invariants > keeps the period qualifier inside the label, hidden rather than deleted
AssertionError: components/inputs/CurrencyInput.tsx: 1 qualifier(s) rendered as visible label text instead of sr-only

FAIL  accessible name invariants > renders no period qualifier as visible label text anywhere
AssertionError: Wrap it in <span className="sr-only">: expected 1 to be +0

Tests  2 failed | 20 passed (22)
```

**Sabotage 2 — delete the span entirely:**

```
FAIL  accessible name invariants > keeps the period qualifier inside the label, hidden rather than deleted
AssertionError: components/inputs/CurrencyInput.tsx: no period qualifier inside <label>
                (the /yr adornment is outside it and does not count)

Tests  1 failed | 21 passed (22)
```

**Sabotage 2 failing only *one* test is the interesting result.** `CurrencyInput.tsx` is named explicitly rather than discovered — the single exception to this file's discover-never-enumerate rule, and it exists *because* of that rule. Once the span is deleted the file no longer calls `periodQualifier`, so it drops out of any usage-based sweep and the suite goes green on the regression. The sweep did exactly that here and passed; only the named anchor caught it. A purely discovered guard would have been vacuous against the deletion it was written to prevent.

## Stale instruction fixed

`.github/instructions/web.instructions.md` said *"Include appropriate `dark:` variants for new UI"* — code the design-invariant guard rejects. That file is path-scoped to `web/**` and auto-loaded into every session that touches the web app, so it was not a dormant documentation nit; it was actively handing the next contributor a CI failure. Replaced with what the codebase requires (semantic tokens that resolve per theme), naming the enforcing test so it reads as a rule rather than a preference. The rest of the file was checked for the same contradiction and recommends no emoji, hex, inline `<svg>` or gradients.

## Scope notes

- The report listed 8 label sites; there are **7**.
- `SavingsRate`'s contribution-frequency cell used `space-y-2`, which left it 1px out of step once the label track was shared. Aligned to the 6px field pattern so every field in the app now matches.
- No `app/` changes. No changes to `currencyPeriod.ts`, `calculations.ts`, `excelExport.ts`, or any export call site.
- **Follow-up, not fixed here:** web and MAUI word this field differently — web `Retirement spending (today's dollars)` vs MAUI header `Retirement expenses` with today's-dollars demoted to `HelpText`, and MAUI workbooks say `Annual retirement spending (today's dollars)`, whose "Annual" prefix contradicts the monthly toggle. Filed separately.

