### PR TITLE
Remember advanced assumptions disclosure per calculator for the session

### DIFF
--- a/app/MyFireNumber.Core/Presentation/AdvancedAssumptionsSessionState.cs
+++ b/app/MyFireNumber.Core/Presentation/AdvancedAssumptionsSessionState.cs
@@ -1,0 +1,64 @@
+namespace MyFireNumber.Core.Presentation;
+
+/// <summary>
+/// Remembers which calculators the user opened the advanced assumptions section on, for the
+/// lifetime of one app run.
+/// </summary>
+/// <remarks>
+/// <para>Calculator pages are registered <c>AddTransient</c> and reached through Shell routes, so
+/// every navigation builds a brand-new page and a brand-new expander. The disclosure state cannot
+/// live on the page: by the time the user comes back, the object that knew it has been collected.
+/// This is the thing that outlives the page.</para>
+/// <para>Deliberately in memory and deliberately not in SQLite next to the drafts. Collapsed on
+/// first visit is load-bearing — it is what keeps the results reachable without a long scroll on a
+/// phone — so a section opened once should not still be open on a relaunch weeks later. Within one
+/// run, reopening a calculator you just expanded should not forget what you did.</para>
+/// </remarks>
+public interface IAdvancedAssumptionsSessionState
+{
+    /// <summary>Whether <paramref name="calculatorId"/> was left expanded earlier in this app run.</summary>
+    bool IsExpanded(string calculatorId);
+
+    /// <summary>Records the disclosure state the user just chose for <paramref name="calculatorId"/>.</summary>
+    void SetExpanded(string calculatorId, bool isExpanded);
+}
+
+/// <inheritdoc cref="IAdvancedAssumptionsSessionState" />
+public sealed class AdvancedAssumptionsSessionState : IAdvancedAssumptionsSessionState
+{
+    /// <summary>
+    /// Only the expanded ids are held, so the set is bounded by the number of calculators the user
+    /// actually expanded — never more than the catalog — and it stores short strings rather than
+    /// any reference back to a page or view model.
+    /// </summary>
+    private readonly HashSet<string> expandedCalculatorIds = new(StringComparer.Ordinal);
+
+    private readonly object gate = new();
+
+    public bool IsExpanded(string calculatorId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(calculatorId);
+
+        lock (gate)
+        {
+            return expandedCalculatorIds.Contains(calculatorId);
+        }
+    }
+
+    public void SetExpanded(string calculatorId, bool isExpanded)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(calculatorId);
+
+        lock (gate)
+        {
+            if (isExpanded)
+            {
+                expandedCalculatorIds.Add(calculatorId);
+            }
+            else
+            {
+                expandedCalculatorIds.Remove(calculatorId);
+            }
+        }
+    }
+}

--- a/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
+++ b/app/MyFireNumber.Tests/MyFireNumber.Tests.csproj
@@ -31,6 +31,11 @@
          Shell route table is the only place a calculator becomes reachable natively, so it is the
          oracle CalculatorCatalogTests discovers its expected set from. -->
     <None Include="..\MyFireNumber\AppShell.xaml.cs" Link="NativeRoutes\AppShell.xaml.cs" CopyToOutputDirectory="PreserveNewest" />
+    <!-- Same reason, different file: the advanced assumptions store is unit-tested directly, but the
+         call site that decides WHICH key it is asked about lives in the MAUI single-project and is
+         therefore never compiled by this suite. Read as text by
+         AdvancedAssumptionsCallSiteGuardTests. -->
+    <None Include="..\MyFireNumber\Views\CalculatorPageBase.cs" Link="NativeCallSites\CalculatorPageBase.cs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/app/MyFireNumber.Tests/Presentation/AdvancedAssumptionsCallSiteGuardTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/AdvancedAssumptionsCallSiteGuardTests.cs
@@ -1,0 +1,157 @@
+using System.Text.RegularExpressions;
+
+namespace MyFireNumber.Tests.Presentation;
+
+/// <summary>
+/// Guards the one line of issue #81 that no other test in this suite can reach:
+/// <c>CalculatorPageBase</c> asking the session store about the <b>calculator id</b> rather than the
+/// page type.
+///
+/// <para><b>Why this exists at all.</b> <see cref="AdvancedAssumptionsSessionStateTests"/> proves the
+/// store keeps per-key state correctly, and it is thorough — including the standard/lean isolation
+/// pair. But it exercises a keyed collection through two string literals, so it is green under
+/// <i>every possible keying of the real app</i>. The bug in #81 does not live in the store. It lives
+/// at the call site, and <c>MyFireNumber.Tests.csproj</c> references only Core and Storage, so
+/// <c>app/MyFireNumber/</c> is never compiled here and <c>CalculatorPageBase</c> is unreachable by
+/// any conventional test. Replacing <c>viewModel.CalculatorId</c> with <c>GetType().Name</c>
+/// reintroduces #81 in full and leaves the entire suite passing. That was measured, not supposed.</para>
+///
+/// <para><b>Why the page type is the specific poison.</b> <c>standard-fire</c>, <c>lean-fire</c> and
+/// <c>fat-fire</c> all route to <c>FireNumberPage</c> (asserted in
+/// <see cref="Calculations.CalculatorCatalogTests"/>). Any key derived from the page therefore
+/// collapses those three onto one entry and makes them disclose together, while looking perfectly
+/// correct on the other eight calculators — so casual testing, and eight of eleven manual passes,
+/// report success.</para>
+///
+/// <para><b>Why it reads source text.</b> Same trade the route-table oracle already makes: text is a
+/// weak instrument, but the alternative is no instrument. It costs no MAUI project reference and no
+/// new test target. The weakness of a text guard is <i>vacuity</i> — it stops matching after an
+/// innocuous rename and reports success for a file it no longer understands — so the anchors are
+/// asserted to exist before anything is concluded from them, and the detector is validated against a
+/// known-bad and a known-good sample on every run rather than once by hand at authoring time.</para>
+/// </summary>
+public class AdvancedAssumptionsCallSiteGuardTests
+{
+    /// <summary>
+    /// The invocation, not the declaration. Requiring a <c>;</c> after the closing parenthesis is what
+    /// separates them: the declaration is followed by its body brace.
+    /// </summary>
+    /// <remarks>
+    /// The argument is <c>.*?</c> rather than <c>[^)]*</c>, and that is not incidental. The first
+    /// version of this pattern excluded parentheses from the argument, which meant it could not match
+    /// <c>RestoreAdvancedAssumptions(GetType().Name);</c> at all — the exact regression it exists to
+    /// catch. <see cref="The_detector_actually_detects_the_regression_it_claims_to"/> failed on that,
+    /// which is the whole reason the detector is validated against a known-bad sample instead of being
+    /// assumed correct. <c>.</c> does not match a newline here, so this stays within one statement.
+    /// </remarks>
+    private const string RestoreCallPattern =
+        """RestoreAdvancedAssumptions\s*\(\s*(?<argument>.*?)\s*\)\s*;""";
+
+    private const string RestoreDeclarationPattern =
+        """void\s+RestoreAdvancedAssumptions\s*\(""";
+
+    /// <summary>
+    /// Expressions that yield a type name rather than a catalog id. <c>GetType()</c> and
+    /// <c>typeof</c> are the direct forms; <c>nameof</c> and a bare <c>.Name</c> are the ways the
+    /// same mistake arrives looking tidier.
+    /// </summary>
+    private static readonly string[] PageTypeDerivedExpressions =
+        ["GetType", "typeof", "nameof", ".Name"];
+
+    private static readonly string PageBaseSource = LoadPageBaseSource();
+
+    [Fact]
+    public void Advanced_assumptions_state_is_keyed_on_the_calculator_id()
+    {
+        var argument = RestoreCallArgument();
+
+        Assert.Contains("CalculatorId", argument, StringComparison.Ordinal);
+        Assert.EndsWith(".CalculatorId", argument, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Advanced_assumptions_state_is_not_keyed_on_the_page_type()
+    {
+        var argument = RestoreCallArgument();
+
+        foreach (var banned in PageTypeDerivedExpressions)
+        {
+            Assert.False(
+                argument.Contains(banned, StringComparison.Ordinal),
+                $"CalculatorPageBase restores advanced assumptions using '{argument}', which derives the "
+                    + $"key from the page type via '{banned}'. Standard, Lean and Fat FIRE all route to "
+                    + "FireNumberPage, so this collapses those three calculators onto one key and makes "
+                    + "them disclose together — issue #81. Pass the view model's CalculatorId instead.");
+        }
+    }
+
+    [Fact]
+    public void The_restored_id_is_the_one_handed_to_each_expander()
+    {
+        // The other half of the round trip. Keying the restore correctly and then binding the expander
+        // to something else would defeat it just as completely, and lives in this same unreachable file.
+        Assert.Matches(
+            """BindSessionState\s*\(\s*advancedAssumptionsState\s*,\s*calculatorId\s*\)""",
+            PageBaseSource);
+    }
+
+    [Fact]
+    public void The_guard_is_reading_real_source_and_its_anchors_still_exist()
+    {
+        // Vacuity guard. Every assertion above is drawn from a regex over this file; a rename that
+        // stopped the patterns matching would turn them all green while checking nothing. The anchors
+        // are therefore asserted to exist as facts in their own right.
+        Assert.NotEmpty(PageBaseSource);
+        Assert.Contains("class CalculatorPageBase", PageBaseSource, StringComparison.Ordinal);
+        Assert.Contains("ApplyQueryAttributes", PageBaseSource, StringComparison.Ordinal);
+
+        Assert.Matches(RestoreDeclarationPattern, PageBaseSource);
+        Assert.Single(Regex.Matches(PageBaseSource, RestoreCallPattern));
+    }
+
+    [Fact]
+    public void The_detector_actually_detects_the_regression_it_claims_to()
+    {
+        // A scanner trusted on real source without ever being shown a positive is how a guard ends up
+        // reporting a codebase it cannot read as clean. Both samples are checked, so the guard cannot
+        // pass by matching everything or by matching nothing.
+        const string Sabotaged = "RestoreAdvancedAssumptions(GetType().Name);";
+        const string Correct = "RestoreAdvancedAssumptions(viewModel.CalculatorId);";
+
+        var sabotagedArgument = Regex.Match(Sabotaged, RestoreCallPattern).Groups["argument"].Value;
+        var correctArgument = Regex.Match(Correct, RestoreCallPattern).Groups["argument"].Value;
+
+        Assert.Equal("GetType().Name", sabotagedArgument);
+        Assert.Equal("viewModel.CalculatorId", correctArgument);
+
+        Assert.Contains(PageTypeDerivedExpressions, banned => sabotagedArgument.Contains(banned, StringComparison.Ordinal));
+        Assert.DoesNotContain(PageTypeDerivedExpressions, banned => correctArgument.Contains(banned, StringComparison.Ordinal));
+    }
+
+    private static string RestoreCallArgument()
+    {
+        var match = Regex.Match(PageBaseSource, RestoreCallPattern);
+
+        Assert.True(
+            match.Success,
+            "No call to RestoreAdvancedAssumptions(...) was found in app/MyFireNumber/Views/CalculatorPageBase.cs. "
+                + "Either the restore was removed — which is issue #81 — or it was renamed, in which case this "
+                + "guard is no longer reading the thing it claims to and must be updated rather than deleted.");
+
+        return match.Groups["argument"].Value;
+    }
+
+    private static string LoadPageBaseSource()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "NativeCallSites", "CalculatorPageBase.cs");
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException(
+                $"CalculatorPageBase source not found at '{path}'. It is copied from app/MyFireNumber by "
+                    + "MyFireNumber.Tests.csproj so this suite can guard a call site it cannot compile.",
+                path);
+        }
+
+        return File.ReadAllText(path);
+    }
+}

--- a/app/MyFireNumber.Tests/Presentation/AdvancedAssumptionsSessionStateTests.cs
+++ b/app/MyFireNumber.Tests/Presentation/AdvancedAssumptionsSessionStateTests.cs
@@ -1,0 +1,176 @@
+using MyFireNumber.Core.Presentation;
+
+namespace MyFireNumber.Tests.Presentation;
+
+/// <summary>
+/// Covers the disclosure state that outlives a transient calculator page.
+/// </summary>
+/// <remarks>
+/// These are necessary but not sufficient: the actual bug is about object lifetime across Shell
+/// navigation, which only the app on a device can prove. What they do pin down is the part that is
+/// easy to get silently wrong — that the store is keyed per calculator rather than globally, and
+/// that a fresh store starts empty.
+/// </remarks>
+public class AdvancedAssumptionsSessionStateTests
+{
+    /// <summary>
+    /// Every calculator reachable through a Shell route. Written out rather than read from the
+    /// catalog so the isolation sweep below keeps meaning what it says even if the catalog moves.
+    /// </summary>
+    public static readonly string[] AllCalculatorIds =
+    [
+        "standard-fire",
+        "lean-fire",
+        "fat-fire",
+        "withdrawal-rate",
+        "savings-rate",
+        "healthcare-gap",
+        "coast-fire",
+        "barista-fire",
+        "reverse-fire",
+        "debt-payoff",
+        "retirement-cash-flow"
+    ];
+
+    public static TheoryData<string> CalculatorIds()
+    {
+        var data = new TheoryData<string>();
+        foreach (var id in AllCalculatorIds)
+        {
+            data.Add(id);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(CalculatorIds))]
+    public void FirstVisitIsCollapsed(string calculatorId)
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        Assert.False(state.IsExpanded(calculatorId));
+    }
+
+    [Fact]
+    public void ExpandingIsRemembered()
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        state.SetExpanded("coast-fire", true);
+
+        Assert.True(state.IsExpanded("coast-fire"));
+    }
+
+    [Fact]
+    public void CollapsingAgainIsRemembered()
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        state.SetExpanded("coast-fire", true);
+        state.SetExpanded("coast-fire", false);
+
+        Assert.False(state.IsExpanded("coast-fire"));
+    }
+
+    /// <summary>
+    /// The one pair in the app that catches a key derived from the page type. Standard, Lean, and
+    /// Fat FIRE all route to <c>FireNumberPage</c>, so a page-typed key looks correct on the other
+    /// eight calculators and only leaks inside this trio.
+    /// </summary>
+    [Fact]
+    public void ExpandingStandardFireLeavesLeanFireCollapsed()
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        state.SetExpanded("standard-fire", true);
+
+        Assert.True(state.IsExpanded("standard-fire"));
+        Assert.False(state.IsExpanded("lean-fire"));
+        Assert.False(state.IsExpanded("fat-fire"));
+    }
+
+    [Fact]
+    public void EachSharedPageVariantKeepsItsOwnState()
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        state.SetExpanded("lean-fire", true);
+
+        Assert.False(state.IsExpanded("standard-fire"));
+        Assert.True(state.IsExpanded("lean-fire"));
+        Assert.False(state.IsExpanded("fat-fire"));
+    }
+
+    /// <summary>
+    /// Sweeps every pair, so a single shared key cannot pass by luck of which two calculators a
+    /// narrower test happened to pick.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(CalculatorIds))]
+    public void ExpandingOneCalculatorLeavesEveryOtherCollapsed(string expandedId)
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        state.SetExpanded(expandedId, true);
+
+        Assert.True(state.IsExpanded(expandedId));
+        foreach (var otherId in AllCalculatorIds.Where(id => id != expandedId))
+        {
+            Assert.False(state.IsExpanded(otherId));
+        }
+    }
+
+    [Fact]
+    public void ExpandedCalculatorsDoNotInterfereWithEachOther()
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        state.SetExpanded("coast-fire", true);
+        state.SetExpanded("debt-payoff", true);
+        state.SetExpanded("coast-fire", false);
+
+        Assert.False(state.IsExpanded("coast-fire"));
+        Assert.True(state.IsExpanded("debt-payoff"));
+    }
+
+    /// <summary>
+    /// Stands in for a relaunch. A new store is a new app run, and the decided behaviour is that
+    /// everything is collapsed again — this is why the state is not written to SQLite beside the
+    /// drafts.
+    /// </summary>
+    [Fact]
+    public void AFreshStoreRemembersNothing()
+    {
+        var previousRun = new AdvancedAssumptionsSessionState();
+        previousRun.SetExpanded("standard-fire", true);
+        previousRun.SetExpanded("coast-fire", true);
+
+        var newRun = new AdvancedAssumptionsSessionState();
+
+        foreach (var id in AllCalculatorIds)
+        {
+            Assert.False(newRun.IsExpanded(id));
+        }
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ABlankCalculatorIdIsRejected(string calculatorId)
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        Assert.Throws<ArgumentException>(() => state.IsExpanded(calculatorId));
+        Assert.Throws<ArgumentException>(() => state.SetExpanded(calculatorId, true));
+    }
+
+    [Fact]
+    public void ANullCalculatorIdIsRejected()
+    {
+        var state = new AdvancedAssumptionsSessionState();
+
+        Assert.Throws<ArgumentNullException>(() => state.IsExpanded(null!));
+        Assert.Throws<ArgumentNullException>(() => state.SetExpanded(null!, true));
+    }
+}

--- a/app/MyFireNumber/MauiProgram.cs
+++ b/app/MyFireNumber/MauiProgram.cs
@@ -2,6 +2,7 @@
 using LiveChartsCore.SkiaSharpView.Maui;
 using MyFireNumber.Core.Books;
 using MyFireNumber.Core.Calculators;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Services;
 using MyFireNumber.Storage;
 using MyFireNumber.ViewModels;
@@ -55,6 +56,9 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IAppBehaviorPreferencesService, AppBehaviorPreferencesService>();
 		builder.Services.AddSingleton<ICurrencyPreferencesService, CurrencyPreferencesService>();
 		builder.Services.AddSingleton<IDisplayPeriodPreferencesService, DisplayPeriodPreferencesService>();
+		// Singleton on purpose: this is the only thing that outlives a transient calculator page, so
+		// it is what lets a reopened calculator remember its advanced assumptions were showing.
+		builder.Services.AddSingleton<IAdvancedAssumptionsSessionState, AdvancedAssumptionsSessionState>();
 		builder.Services.AddSingleton<ITemporaryExportCleanupService, TemporaryExportCleanupService>();
 		builder.Services.AddSingleton<IErrorPresentationService, ErrorPresentationService>();
 		builder.Services.AddSingleton<IExternalLinkService, ExternalLinkService>();

--- a/app/MyFireNumber/ViewModels/CalculatorViewModelBase.cs
+++ b/app/MyFireNumber/ViewModels/CalculatorViewModelBase.cs
@@ -250,6 +250,12 @@ public abstract partial class CalculatorViewModelBase<TDraft> : ObservableObject
     /// <summary>Catalog identifier, e.g. <c>withdrawal-rate</c>.</summary>
     protected abstract string CalculatorId { get; }
 
+    /// <summary>
+    /// Explicit implementation so <see cref="CalculatorId"/> stays <c>protected</c> for the eleven
+    /// derived view models while the page base can still read it.
+    /// </summary>
+    string ICalculatorViewModel.CalculatorId => CalculatorId;
+
     /// <summary>Serialization version guarding stored draft and plan payloads.</summary>
     protected abstract int DraftPayloadVersion { get; }
 

--- a/app/MyFireNumber/ViewModels/ICalculatorViewModel.cs
+++ b/app/MyFireNumber/ViewModels/ICalculatorViewModel.cs
@@ -6,6 +6,13 @@ namespace MyFireNumber.ViewModels;
 /// </summary>
 public interface ICalculatorViewModel
 {
+    /// <summary>
+    /// Catalog identifier, e.g. <c>withdrawal-rate</c>. Surfaced here because Standard, Lean, and
+    /// Fat FIRE share one page type, so the page cannot infer which calculator it is showing from
+    /// its own type — only the selected view model knows.
+    /// </summary>
+    string CalculatorId { get; }
+
     Task LoadAsync(string? planId = null, bool returnHomeAfterSave = false);
 
     Task FlushPendingDraftAsync();

--- a/app/MyFireNumber/Views/BaristaFirePage.xaml.cs
+++ b/app/MyFireNumber/Views/BaristaFirePage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class BaristaFirePage : CalculatorPageBase
 {
-    public BaristaFirePage(BaristaFireViewModel viewModel)
+    public BaristaFirePage(BaristaFireViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);

--- a/app/MyFireNumber/Views/CalculatorPageBase.cs
+++ b/app/MyFireNumber/Views/CalculatorPageBase.cs
@@ -1,15 +1,24 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
+using MyFireNumber.Views.Controls;
 
 namespace MyFireNumber.Views;
 
 /// <summary>
-/// Shared lifecycle for calculator pages: applies navigation query attributes and
-/// flushes the pending local draft when the page or window goes away.
+/// Shared lifecycle for calculator pages: applies navigation query attributes, restores the
+/// advanced assumptions disclosure state, and flushes the pending local draft when the page or
+/// window goes away.
 /// </summary>
 public abstract class CalculatorPageBase : ContentPage, IQueryAttributable
 {
+    private readonly IAdvancedAssumptionsSessionState advancedAssumptionsState;
     private ICalculatorViewModel? calculatorViewModel;
     private Window? subscribedWindow;
+
+    protected CalculatorPageBase(IAdvancedAssumptionsSessionState advancedAssumptionsState)
+    {
+        this.advancedAssumptionsState = advancedAssumptionsState;
+    }
 
     protected void InitializeCalculator(ICalculatorViewModel viewModel)
     {
@@ -43,7 +52,51 @@ public abstract class CalculatorPageBase : ContentPage, IQueryAttributable
             && bool.TryParse(returnHomeValue?.ToString(), out var parsedReturnHome)
             && parsedReturnHome;
 
+        RestoreAdvancedAssumptions(viewModel.CalculatorId);
+
         await viewModel.LoadAsync(planId, returnHomeAfterSave);
+    }
+
+    /// <summary>
+    /// Reapplies the disclosure state the user last chose for this calculator in this app run.
+    /// </summary>
+    /// <remarks>
+    /// <para>Runs synchronously, before the first <c>await</c> above. Shell applies query attributes
+    /// after the page's XAML is inflated but before the page is given a handler and drawn, so a
+    /// restored expansion lands ahead of the first paint and never flashes.</para>
+    /// <para>Keyed on the view model's calculator id rather than the page type on purpose: Standard,
+    /// Lean, and Fat FIRE all resolve to <see cref="FireNumberPage"/>, so a page-typed key would let
+    /// one variant open the other two.</para>
+    /// </remarks>
+    private void RestoreAdvancedAssumptions(string calculatorId)
+    {
+        foreach (var expander in FindExpanders(this))
+        {
+            expander.BindSessionState(advancedAssumptionsState, calculatorId);
+        }
+    }
+
+    /// <summary>
+    /// Walks the page's own logical tree for expanders, so the state survives without every
+    /// calculator's XAML having to name itself.
+    /// </summary>
+    private static IEnumerable<AdvancedAssumptionsExpander> FindExpanders(Element root)
+    {
+        foreach (var child in ((IVisualTreeElement)root).GetVisualChildren())
+        {
+            if (child is AdvancedAssumptionsExpander expander)
+            {
+                // Expanders are never nested inside one another, so stop descending here.
+                yield return expander;
+            }
+            else if (child is Element element)
+            {
+                foreach (var nested in FindExpanders(element))
+                {
+                    yield return nested;
+                }
+            }
+        }
     }
 
     protected override void OnAppearing()

--- a/app/MyFireNumber/Views/CoastFirePage.xaml.cs
+++ b/app/MyFireNumber/Views/CoastFirePage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class CoastFirePage : CalculatorPageBase
 {
-    public CoastFirePage(CoastFireViewModel viewModel)
+    public CoastFirePage(CoastFireViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);

--- a/app/MyFireNumber/Views/Controls/AdvancedAssumptionsExpander.cs
+++ b/app/MyFireNumber/Views/Controls/AdvancedAssumptionsExpander.cs
@@ -1,3 +1,5 @@
+using MyFireNumber.Core.Presentation;
+
 namespace MyFireNumber.Views.Controls;
 
 public sealed class AdvancedAssumptionsExpander : VerticalStackLayout
@@ -5,6 +7,8 @@ public sealed class AdvancedAssumptionsExpander : VerticalStackLayout
     private readonly Button toggleButton;
     private bool isExpanded;
     private bool hasAppliedInitialState;
+    private IAdvancedAssumptionsSessionState? sessionState;
+    private string? calculatorId;
 
     public static readonly BindableProperty TitleProperty = BindableProperty.Create(
         nameof(Title),
@@ -42,9 +46,35 @@ public sealed class AdvancedAssumptionsExpander : VerticalStackLayout
     }
 
     /// <summary>
+    /// Restores what the user last chose for this calculator in this app run, and starts recording
+    /// their choices against it.
+    /// </summary>
+    /// <remarks>
+    /// Called from <see cref="CalculatorPageBase.ApplyQueryAttributes"/>, which Shell runs after the
+    /// page's XAML is inflated but before the page is given a handler and drawn. That ordering is
+    /// what keeps this flash-free in both directions: children were already hidden by
+    /// <see cref="OnChildAdded"/>, and a restored expansion is applied before the first paint rather
+    /// than after it.
+    /// </remarks>
+    /// <param name="state">Session-scoped store shared by every calculator.</param>
+    /// <param name="calculatorId">
+    /// Catalog id, not the page type. Standard, Lean, and Fat FIRE share one page type, so keying on
+    /// the page would make all three disclose together.
+    /// </param>
+    public void BindSessionState(IAdvancedAssumptionsSessionState state, string calculatorId)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(calculatorId);
+
+        sessionState = state;
+        this.calculatorId = calculatorId;
+        SetExpanded(state.IsExpanded(calculatorId));
+    }
+
+    /// <summary>
     /// Safety net in case a child is ever added without going through <see cref="OnChildAdded"/>.
-    /// Runs once: Shell reuses cached pages, so collapsing on every <c>Loaded</c> would throw away
-    /// the user's expanded section each time they returned to a calculator.
+    /// Runs once, and re-applies whatever state is current rather than forcing a collapse, so it
+    /// cannot undo a restore from <see cref="BindSessionState"/>.
     /// </summary>
     protected override void OnHandlerChanged()
     {
@@ -73,7 +103,15 @@ public sealed class AdvancedAssumptionsExpander : VerticalStackLayout
         }
     }
 
-    private void OnToggleClicked(object? sender, EventArgs e) => SetExpanded(!isExpanded);
+    private void OnToggleClicked(object? sender, EventArgs e)
+    {
+        SetExpanded(!isExpanded);
+
+        if (sessionState is not null && calculatorId is not null)
+        {
+            sessionState.SetExpanded(calculatorId, isExpanded);
+        }
+    }
 
     private void SetExpanded(bool value)
     {

--- a/app/MyFireNumber/Views/DebtPayoffPage.xaml.cs
+++ b/app/MyFireNumber/Views/DebtPayoffPage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class DebtPayoffPage : CalculatorPageBase
 {
-    public DebtPayoffPage(DebtPayoffViewModel viewModel)
+    public DebtPayoffPage(DebtPayoffViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);

--- a/app/MyFireNumber/Views/FireNumberPage.xaml.cs
+++ b/app/MyFireNumber/Views/FireNumberPage.xaml.cs
@@ -1,3 +1,4 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
@@ -11,7 +12,8 @@ public partial class FireNumberPage : CalculatorPageBase
 {
     private readonly IServiceProvider services;
 
-    public FireNumberPage(IServiceProvider services)
+    public FireNumberPage(IServiceProvider services, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         this.services = services;
         InitializeComponent();

--- a/app/MyFireNumber/Views/HealthcareGapPage.xaml.cs
+++ b/app/MyFireNumber/Views/HealthcareGapPage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class HealthcareGapPage : CalculatorPageBase
 {
-    public HealthcareGapPage(HealthcareGapViewModel viewModel)
+    public HealthcareGapPage(HealthcareGapViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);

--- a/app/MyFireNumber/Views/RetirementCashFlowPage.xaml.cs
+++ b/app/MyFireNumber/Views/RetirementCashFlowPage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class RetirementCashFlowPage : CalculatorPageBase
 {
-    public RetirementCashFlowPage(RetirementCashFlowViewModel viewModel)
+    public RetirementCashFlowPage(RetirementCashFlowViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);

--- a/app/MyFireNumber/Views/ReverseFirePage.xaml.cs
+++ b/app/MyFireNumber/Views/ReverseFirePage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class ReverseFirePage : CalculatorPageBase
 {
-    public ReverseFirePage(ReverseFireViewModel viewModel)
+    public ReverseFirePage(ReverseFireViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);

--- a/app/MyFireNumber/Views/SavingsInvestmentPage.xaml.cs
+++ b/app/MyFireNumber/Views/SavingsInvestmentPage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class SavingsInvestmentPage : CalculatorPageBase
 {
-    public SavingsInvestmentPage(SavingsInvestmentViewModel viewModel)
+    public SavingsInvestmentPage(SavingsInvestmentViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);

--- a/app/MyFireNumber/Views/WithdrawalRatePage.xaml.cs
+++ b/app/MyFireNumber/Views/WithdrawalRatePage.xaml.cs
@@ -1,10 +1,12 @@
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.ViewModels;
 
 namespace MyFireNumber.Views;
 
 public partial class WithdrawalRatePage : CalculatorPageBase
 {
-    public WithdrawalRatePage(WithdrawalRateViewModel viewModel)
+    public WithdrawalRatePage(WithdrawalRateViewModel viewModel, IAdvancedAssumptionsSessionState advancedAssumptionsState)
+        : base(advancedAssumptionsState)
     {
         InitializeComponent();
         InitializeCalculator(viewModel);


### PR DESCRIPTION
Fixes #81.

## The actual cause

The issue text said Shell caches the page so `Loaded` re-fires and re-collapses the expander. That is not what happens. All calculator pages are registered `AddTransient` in `MauiProgram.cs` and reached through Shell routes, so **every navigation constructs a brand-new page instance**. The old expanded state was not being reset — it had never existed on that object. There was nothing to stop from re-collapsing.

That rules out the whole class of fix the original wording implies, and it is why #82 (which moved the collapse into `OnChildAdded` to kill a first-paint flash) fixed the flash and left the state loss completely untouched.

So the state has to live outside the page.

## The fix

A small in-memory `IAdvancedAssumptionsSessionState` singleton, restored from `ApplyQueryAttributes`.

`ApplyQueryAttributes` is the right hook because Shell runs it after the page's XAML is inflated but **before** the page is given a handler and drawn. A restored expansion therefore lands ahead of the first paint, so it does not flash in either direction. The `OnChildAdded` collapse from #82 is left intact and still does the first-paint work.

The store holds a `HashSet<string>` of expanded calculator ids and nothing else — no page or view-model references, so nothing leaks and the footprint stays bounded by the catalog size.

## Keyed on calculator id, not page type

`standard-fire`, `lean-fire`, and `fat-fire` **all route to `FireNumberPage`**. Keying on the page type (or anything derived from it) would make expanding Standard silently expand Lean and Fat, while looking perfectly correct on the other 8 calculators.

The id is taken from the view model, which `FireNumberPage` already selects from the route's `calculatorId` query. `ICalculatorViewModel` gains a `CalculatorId` member; `CalculatorViewModelBase` satisfies it with an explicit interface implementation so the existing `protected abstract` member is reused and **none of the 11 derived view models change**.

## Behaviour

Per app run, in memory, deliberately **not** persisted to SQLite.

- First visit to a calculator in an app run → collapsed
- Expand it, navigate away, come back → expanded
- A different calculator not expanded this run → collapsed
- Force-quit and relaunch → all collapsed

Collapsed-on-first-visit is load-bearing for scroll length on a phone, not a stylistic default, so a disclosure opened once should not still be open weeks later. Reusing the existing draft persistence was considered and rejected for that reason.

## Verification

**Tests: 309 → 345.** 36 added, none lost, 0 failures.

**Read this before trusting that number.** The 31 store tests cover the store *only*. They exercise a keyed collection through string literals, so they stay green under every possible keying of the real app — including a broken one. `MyFireNumber.Tests` references only Core and Storage, so `app/MyFireNumber/` is never compiled by the suite and `CalculatorPageBase` is unreachable by any conventional test written there. Replacing `viewModel.CalculatorId` with `GetType().Name` reintroduces #81 in full and **leaves all 340 tests passing**. That was measured, not supposed — credit to the reviewer who ran that third sabotage rather than accepting the first two.

The call site is therefore guarded by **source text** (`AdvancedAssumptionsCallSiteGuardTests`), reading `CalculatorPageBase.cs` as content — the same trade `CalculatorCatalogTests` already makes against the Shell route table, and it needs no MAUI project reference or new test target. A text guard's failure mode is vacuity, so the anchors are asserted to exist before anything is concluded from them, and the detector is validated against a known-bad and a known-good sample on every run. That validation paid for itself immediately: the first pattern excluded parentheses from the argument and so could not match `GetType().Name` at all — the single input it exists to catch.

**Build: 0 warnings, 0 errors**, measured after rebasing onto `254847a` (post-#93). MAUIG2045 is 0 — relevant because this PR edits `ICalculatorViewModel.cs`, and `FireNumberPage` is the only page typed against an interface. `CalculatorId` is consumed only from C#, never from a XAML binding.

**Sabotage checks** — a test that passes under a broken implementation proves nothing, so all three failure modes were induced deliberately:

| Sabotage | Result |
| --- | --- |
| Store always reports collapsed | **15 failed / 324**. `Assert.True() Failure / Expected: True / Actual: False` |
| Store re-keyed to a single global key | **14 failed / 324**, incl. `ExpandingStandardFireLeavesLeanFireCollapsed`: `Assert.False() Failure / Expected: False / Actual: True` |
| **Call site keyed on page type** (`GetType().Name`) — the literal #81 bug | Was **0 failed / 340** before the guard; now **2 failed / 345** |

That last one is the one that mattered. Its failure message names the cause directly:

> `CalculatorPageBase restores advanced assumptions using 'GetType().Name', which derives the key from the page type via 'GetType'. Standard, Lean and Fat FIRE all route to FireNumberPage, so this collapses those three calculators onto one key and makes them disclose together — issue #81. Pass the view model's CalculatorId instead.`

All three restored cleanly afterwards.

**On the Android emulator** (Pixel 7a, API 35), walked by hand: first visit collapsed; expand → navigate away → return → still expanded; an unexpanded calculator still collapsed; and expanding Standard FIRE leaves Lean FIRE collapsed. Instrumented tracing confirmed the restore path resolves the correct id on the shared page and applies the stored value before paint.

## Scope

**No calculator page XAML was touched** — 9 `.xaml.cs` code-behinds only, so this does not collide with the colour-token migration in #93. No calculation, formula, or default changes. Nothing under `web/`.
