### PR TITLE
Collapse three drifted colour token pairs

### DIFF
--- a/app/MyFireNumber/Resources/Styles/Colors.xaml
+++ b/app/MyFireNumber/Resources/Styles/Colors.xaml
@@ -37,15 +37,12 @@
 
 
     <!--
-    App theme tokens. Each entry is keyed on the exact (light, dark) pair it
-    replaced in the view XAML, so two colours that differ by even one channel
-    keep two tokens. Names ending in Alt mark near-duplicates that are
-    preserved deliberately rather than collapsed.
+    App theme tokens. Each entry carries an explicit light/dark pair. Names
+    ending in Alt identify distinct near-duplicate variants that remain
+    intentionally separate.
     -->
-    <Color x:Key="TextAccentLight">#326B57</Color>
+    <Color x:Key="TextAccentLight">#2F6B57</Color>
     <Color x:Key="TextAccentDark">#9ACCB3</Color>
-    <Color x:Key="TextAccentAltLight">#2F6B57</Color>
-    <Color x:Key="TextAccentAltDark">#9ACCB3</Color>
     <Color x:Key="TextAccentStrongLight">#245744</Color>
     <Color x:Key="TextAccentStrongDark">#C8E7D5</Color>
     <Color x:Key="TextDangerLight">#7C352E</Color>
@@ -64,8 +61,6 @@
     <Color x:Key="TextSecondaryDark">#B9D1C2</Color>
     <Color x:Key="TextSecondaryAltLight">#425D54</Color>
     <Color x:Key="TextSecondaryAltDark">#D8E8DE</Color>
-    <Color x:Key="TextSecondaryAltMutedLight">#425D54</Color>
-    <Color x:Key="TextSecondaryAltMutedDark">#D6E5DC</Color>
     <Color x:Key="TextWarningLight">#6B3B12</Color>
     <Color x:Key="TextWarningDark">#FFE0BC</Color>
     <Color x:Key="TextWarningAltLight">#9A5C17</Color>
@@ -73,8 +68,6 @@
 
     <Color x:Key="SurfaceAccentSoftLight">#E4F0E9</Color>
     <Color x:Key="SurfaceAccentSoftDark">#29483B</Color>
-    <Color x:Key="SurfaceAccentSoftAltLight">#E4F0E9</Color>
-    <Color x:Key="SurfaceAccentSoftAltDark">#29483A</Color>
     <Color x:Key="SurfaceAccentSoftWarmLight">#E6F0EA</Color>
     <Color x:Key="SurfaceAccentSoftWarmDark">#29483A</Color>
     <Color x:Key="SurfaceAccentTintDeepLight">#EAF4EC</Color>
@@ -139,7 +132,6 @@
     today; giving them a dark variant would change what the app looks like.
     -->
     <Color x:Key="FixedAccent">#2F6B57</Color>
-    <Color x:Key="FixedAccentAlt">#326B57</Color>
     <Color x:Key="FixedAccentLight">#9ACCB3</Color>
     <Color x:Key="FixedAccentStrong">#245744</Color>
     <Color x:Key="FixedAccentSurface">#E4F0E9</Color>

--- a/app/MyFireNumber/Views/CalculatorsPage.xaml
+++ b/app/MyFireNumber/Views/CalculatorsPage.xaml
@@ -87,7 +87,7 @@
                                        FontSize="19"
                                        HorizontalTextAlignment="Center"
                                        VerticalTextAlignment="Center"
-                                       TextColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                                        SemanticProperties.Description="{Binding Title, StringFormat='{0} icon'}" />
                             </Border>
                             <VerticalStackLayout Grid.Column="1" Spacing="4" VerticalOptions="Center">

--- a/app/MyFireNumber/Views/Controls/CalculatorInfoView.xaml
+++ b/app/MyFireNumber/Views/Controls/CalculatorInfoView.xaml
@@ -12,7 +12,7 @@
                 <Label Text="{Binding IconGlyph, Source={x:Reference Root}}"
                        FontFamily="FontAwesomeSolid"
                        VerticalTextAlignment="Center"
-                       TextColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}"
+                       TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                        SemanticProperties.Description="Calculator information" />
                 <Label Grid.Column="1"
                        Text="{Binding Title, Source={x:Reference Root}}"
@@ -30,7 +30,7 @@
                     HorizontalOptions="Start"
                     Padding="0,6"
                     Background="Transparent"
-                    TextColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}"
+                    TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                     FontAttributes="Bold"
                     SemanticProperties.Description="Show more information about this calculator" />
             <Label x:Name="DetailsLabel"

--- a/app/MyFireNumber/Views/OnboardingChoicePage.xaml
+++ b/app/MyFireNumber/Views/OnboardingChoicePage.xaml
@@ -51,7 +51,7 @@
                         Background="Transparent"
                         BorderColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                         BorderWidth="1"
-                        TextColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}"
+                        TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                         SemanticProperties.Description="Open the Standard FIRE calculator with your saved defaults." />
                 <Button AutomationId="OnboardingExploreOnMyOwnButton"
                         Text="Explore on my own"

--- a/app/MyFireNumber/Views/PlansPage.xaml
+++ b/app/MyFireNumber/Views/PlansPage.xaml
@@ -68,7 +68,7 @@
                                               SemanticProperties.Description="Rename this saved plan.">
                                    <Border WidthRequest="84"
                                            Padding="8,6"
-                                           Background="{StaticResource FixedAccentAlt}"
+                                           Background="{StaticResource FixedAccent}"
                                            StrokeThickness="0"
                                            StrokeShape="RoundRectangle 12">
                                        <VerticalStackLayout Spacing="3"

--- a/app/MyFireNumber/Views/QuizPage.xaml
+++ b/app/MyFireNumber/Views/QuizPage.xaml
@@ -46,7 +46,7 @@
                                FontAttributes="Bold"
                                TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
                         <ProgressBar Progress="{Binding QuestionProgress}"
-                                     ProgressColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}"
+                                     ProgressColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                                      SemanticProperties.Description="{Binding QuestionProgressText}" />
                     </VerticalStackLayout>
 
@@ -242,7 +242,7 @@
                             Background="Transparent"
                             BorderColor="{AppThemeBinding Light={StaticResource BorderNeutralLight}, Dark={StaticResource BorderNeutralDark}}"
                             BorderWidth="1"
-                            TextColor="{AppThemeBinding Light={StaticResource TextSecondaryAltMutedLight}, Dark={StaticResource TextSecondaryAltMutedDark}}" />
+                            TextColor="{AppThemeBinding Light={StaticResource TextSecondaryAltLight}, Dark={StaticResource TextSecondaryAltDark}}" />
                 </VerticalStackLayout>
 
                 <controls:EducationalDisclaimerView />

--- a/app/MyFireNumber/Views/RetirementCashFlowPage.xaml
+++ b/app/MyFireNumber/Views/RetirementCashFlowPage.xaml
@@ -120,7 +120,7 @@
                         StrokeShape="RoundRectangle 8">
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
-                            <Label Text="&#xf0d6;" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}" SemanticProperties.Description="Retirement income" />
+                            <Label Text="&#xf0d6;" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" SemanticProperties.Description="Retirement income" />
                             <Label Grid.Column="1" Text="Income sources" Style="{StaticResource CalculatorSectionHeading}" />
                             <Button Grid.Column="2" Text="Add" Command="{Binding AddRetirementIncomeCommand}" Background="{StaticResource FixedAccentSurface}" TextColor="{StaticResource FixedAccentStrong}" FontSize="12" SemanticProperties.Description="Add a retirement income source.">
                                 <Button.ImageSource><FontImageSource FontFamily="FontAwesomeSolid" Glyph="&#xf067;" Color="{StaticResource FixedAccentStrong}" Size="12" /></Button.ImageSource>
@@ -134,7 +134,7 @@
                                             <Grid ColumnDefinitions="*,32,44" ColumnSpacing="{StaticResource SpaceSm}">
                                                 <Grid.GestureRecognizers><TapGestureRecognizer Command="{Binding ToggleExpandedCommand}" /></Grid.GestureRecognizers>
                                                 <Label Text="{Binding Name}" FontAttributes="Bold" VerticalTextAlignment="Center" TextColor="{AppThemeBinding Light={StaticResource TextAccentStrongLight}, Dark={StaticResource TextAccentStrongDark}}" SemanticProperties.Description="{Binding Name, StringFormat='Expand or collapse {0} income source.'}" />
-                                                <Label Grid.Column="1" Text="{Binding ExpansionGlyph}" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" TextColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}" />
+                                                <Label Grid.Column="1" Text="{Binding ExpansionGlyph}" FontFamily="FontAwesomeSolid" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
                                                 <Button Grid.Column="2" Text="&#xf2ed;" FontFamily="FontAwesomeSolid" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveRetirementIncomeCommand}" CommandParameter="{Binding .}" Background="{StaticResource FixedDangerSurface}" TextColor="{StaticResource FixedDanger}" Padding="0" SemanticProperties.Description="Remove this retirement income source." />
                                             </Grid>
                                             <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="{StaticResource SpaceSm}">

--- a/app/MyFireNumber/Views/SettingsPage.xaml
+++ b/app/MyFireNumber/Views/SettingsPage.xaml
@@ -395,7 +395,7 @@
                                             FontFamily="FontAwesomeSolid"
                                             Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:SettingsViewModel}}, Path=MoveCalculatorUpCommand}"
                                             CommandParameter="{Binding .}"
-                                            Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftAltLight}, Dark={StaticResource SurfaceAccentSoftAltDark}}"
+                                            Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftLight}, Dark={StaticResource SurfaceAccentSoftDark}}"
                                             TextColor="{AppThemeBinding Light={StaticResource TextAccentStrongLight}, Dark={StaticResource TextAccentStrongDark}}"
                                             FontSize="14"
                                             Padding="0"
@@ -405,7 +405,7 @@
                                             FontFamily="FontAwesomeSolid"
                                             Command="{Binding Source={RelativeSource AncestorType={x:Type viewModels:SettingsViewModel}}, Path=MoveCalculatorDownCommand}"
                                             CommandParameter="{Binding .}"
-                                            Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftAltLight}, Dark={StaticResource SurfaceAccentSoftAltDark}}"
+                                            Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftLight}, Dark={StaticResource SurfaceAccentSoftDark}}"
                                             TextColor="{AppThemeBinding Light={StaticResource TextAccentStrongLight}, Dark={StaticResource TextAccentStrongDark}}"
                                             FontSize="14"
                                             Padding="0"
@@ -460,7 +460,7 @@
                             <Button Grid.Column="1"
                                     Text="Import backup"
                                     Command="{Binding ImportDataCommand}"
-                                    Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftAltLight}, Dark={StaticResource SurfaceAccentSoftAltDark}}"
+                                    Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftLight}, Dark={StaticResource SurfaceAccentSoftDark}}"
                                     TextColor="{AppThemeBinding Light={StaticResource TextAccentStrongLight}, Dark={StaticResource TextAccentStrongDark}}"
                                     SemanticProperties.Description="Choose a backup file to replace local app data after confirmation." />
                         </Grid>
@@ -497,13 +497,13 @@
                         <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
                             <Button Text="Terms"
                                     Command="{Binding OpenTermsCommand}"
-                                    Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftAltLight}, Dark={StaticResource SurfaceAccentSoftAltDark}}"
+                                    Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftLight}, Dark={StaticResource SurfaceAccentSoftDark}}"
                                     TextColor="{AppThemeBinding Light={StaticResource TextAccentStrongLight}, Dark={StaticResource TextAccentStrongDark}}"
                                     SemanticProperties.Description="Open the My Fire Number terms on the website." />
                             <Button Grid.Column="1"
                                     Text="Privacy policy"
                                     Command="{Binding OpenPrivacyCommand}"
-                                    Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftAltLight}, Dark={StaticResource SurfaceAccentSoftAltDark}}"
+                                    Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftLight}, Dark={StaticResource SurfaceAccentSoftDark}}"
                                     TextColor="{AppThemeBinding Light={StaticResource TextAccentStrongLight}, Dark={StaticResource TextAccentStrongDark}}"
                                     SemanticProperties.Description="Open the My Fire Number privacy policy on the website." />
                         </Grid>

--- a/app/MyFireNumber/Views/WelcomePage.xaml
+++ b/app/MyFireNumber/Views/WelcomePage.xaml
@@ -23,7 +23,7 @@
                 <Label Text="&#xf0d6;"
                        FontFamily="FontAwesomeSolid"
                        FontSize="48"
-                       TextColor="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}"
+                       TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                        SemanticProperties.Description="A sprouting plant representing growth" />
             </Border>
 
@@ -75,7 +75,7 @@
             <Button AutomationId="WelcomeGetStartedButton"
                     Text="Get started"
                     Command="{Binding GetStartedCommand}"
-                    Background="{AppThemeBinding Light={StaticResource TextAccentAltLight}, Dark={StaticResource TextAccentAltDark}}"
+                    Background="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                     TextColor="{AppThemeBinding Light={StaticResource TextOnAccentLight}, Dark={StaticResource TextOnAccentDark}}"
                     SemanticProperties.Description="Get started with your starting assumptions." />
             <controls:EducationalDisclaimerView />


### PR DESCRIPTION
## Intentional visual change

Relates to #94. This deliberately resolves only the three owner-selected drift pairs; it is not the byte-identical refactor from #93. The remaining near-duplicate relationships in #94 are intentionally undecided, so this PR does **not** close the issue.

## Decisions

- `SurfaceAccentSoft` survives over `SurfaceAccentSoftAlt`: retain `#E4F0E9` / `#29483B`. The alternative differs by one blue unit only in dark mode, the clearest copy/paste drift.
- `TextAccent` survives as the semantic token name, but adopts the established accent value `#2F6B57` / `#9ACCB3`; `TextAccentAlt` is removed. `#2F6B57` is also the primary/fixed accent used 31 times, versus one `#326B57` fixed variant. `FixedAccentAlt` is removed and its Plans rename action now uses `FixedAccent`, so themed and fixed accents agree.
- `TextSecondaryAlt` survives over `TextSecondaryAltMuted`: retain `#425D54` / `#D8E8DE`. The muted alternative differed by three dark-mode channels only.

## Resolved-colour manifest

The manifest intentionally differs while retaining 671 resolved attributes. The concrete changes are `#29483A -> #29483B` on five Settings surfaces, `#326B57 -> #2F6B57` for themed accent text and the fixed Plans rename surface, and `#D6E5DC -> #D8E8DE` for the Quiz retake text. Alias-only repoints that already resolved to the survivor do not change a manifest line.

## WCAG contrast (before -> after)

| Pair and affected foreground/background | Light | Dark |
| --- | ---: | ---: |
| Surface accent soft: `TextAccentStrong` / soft surface | 7.11 -> 7.11 | 7.61 -> 7.60 |
| Text accent / page surface | 5.77 -> 5.79 | 9.21 -> 9.21 |
| Fixed accent / fixed white (Plans rename) | 6.22 -> 6.25 | 6.22 -> 6.25 |
| Text accent alternative / soft surface | 5.34 -> 5.34 | 5.59 -> 5.59 |
| Secondary alt muted / page surface (Quiz retake) | 6.66 -> 6.66 | 12.72 -> 13.04 |
| Secondary alt / soft surface | 6.13 -> 6.13 | 7.92 -> 7.92 |

All affected text and UI combinations remain above WCAG AA.

## Validation

- .NET: 347 -> 347 passed
- Web: 992 / 17 files -> 992 / 17 files passed (run from `web/`)
- iOS MAUI build: 0 warnings; `MAUIG2045`: 0
- Raw-hex guard: passed (25 view XAML files)
- Removed-token references under `Views/`: 0

## Screenshots

Before/after iOS screenshots in light and dark mode are attached below. The one-unit dark-blue surface adjustment is deliberately imperceptible; resolved manifest values, rather than pixels, are the proof of the intended change.

### Light

Before

![Before light](https://github.com/user-attachments/assets/68f01521-b86b-4364-9ada-c87aa537f2f3)

After

![After light](https://github.com/user-attachments/assets/591f64bb-6a03-47c6-b85c-da09bb2d5738)

### Dark

Before

![Before dark](https://github.com/user-attachments/assets/6848649a-6c58-4a0e-b250-05c360481b7f)

After

![After dark](https://github.com/user-attachments/assets/c12d43ed-2e9c-4159-b9e3-2a43d5cda76a)
