### PR TITLE
Align SurfaceAccentSoftWarmDark to #29483B, removing the last drifted colour byte

### DIFF
--- a/app/MyFireNumber/Resources/Styles/Colors.xaml
+++ b/app/MyFireNumber/Resources/Styles/Colors.xaml
@@ -69,7 +69,7 @@
     <Color x:Key="SurfaceAccentSoftLight">#E4F0E9</Color>
     <Color x:Key="SurfaceAccentSoftDark">#29483B</Color>
     <Color x:Key="SurfaceAccentSoftWarmLight">#E6F0EA</Color>
-    <Color x:Key="SurfaceAccentSoftWarmDark">#29483A</Color>
+    <Color x:Key="SurfaceAccentSoftWarmDark">#29483B</Color>
     <Color x:Key="SurfaceAccentTintDeepLight">#EAF4EC</Color>
     <Color x:Key="SurfaceAccentTintDeepDark">#1B3B2D</Color>
     <Color x:Key="SurfaceAccentTintFlatLight">#EAF4EC</Color>


### PR DESCRIPTION
Finishes the ruling made in #99. Closes #94.

## Why

#99 collapsed `SurfaceAccentSoftAlt` into `SurfaceAccentSoft` and, as part of that, normalised five Settings surfaces from `#29483A` to `#29483B` — an explicit judgement that the one-unit blue difference was drift, not intent.

`SurfaceAccentSoftWarmDark` still carried `#29483A`. So the theme asserted that the same byte was both a copy-paste artefact and a deliberate design choice, two lines apart in the same file. This removes the last occurrence of `#29483A`.

## What changed

One line. `SurfaceAccentSoftWarmDark`: `#29483A` → `#29483B`.

**`SurfaceAccentSoftWarmLight` is deliberately untouched** at `#E6F0EA` (vs `SurfaceAccentSoft`'s `#E4F0E9`). The token is *not* collapsed away — the "warm" distinction has a real basis on the light side, and only the dark value looked copy-pasted from the drifted `Alt`. Aligning just the dark side removes the contradiction without imposing a design decision that #94 says needs design authority.

The single affected surface is the calculator card border in `CalculatorsPage.xaml` — the token's only usage.

## Verification

The claim here is narrow and falsifiable, so it's measured rather than eyeballed. The delta is one unit of blue and is imperceptible by construction; the manifest is the proof, not a screenshot.

**Resolved theme manifest** (`tools/theme_color_manifest.py`, which resolves every `StaticResource` to its final value):

- 671 records before, 671 after — nothing added or removed
- **Exactly one record differs**, direction preserved:
  ```
  < CalculatorsPage.xaml|...|Background|#E6F0EA|#29483A
  > CalculatorsPage.xaml|...|Background|#E6F0EA|#29483B
  ```
- `#29483A` occurrences across all 671 records: **1 → 0**
- sha `02eb86f3` → `1392d9cf`

That the manifest resolves this border to `#29483B` is also the proof there's no dangling reference — the key was edited in value, not renamed, so the `StaticResource` lookup still binds. (Dangling refs throw at page-parse time, which a build can miss.)

**Contrast**, dark mode, for the two text tokens actually inside that card:

| text on card | before | after | |
|---|---|---|---|
| `TextPrimary` | 9.31 | 9.30 | AA pass |
| `TextAccent` | 5.60 | 5.59 | AA pass |

Worst case 5.59, still 1.09 above the 4.5 AA threshold.

**Other gates:**

- Raw hex guard passes; self-check `fixture=2, Colors.xaml=113` — count **unchanged**, confirming this is a value edit and not a declaration change
- .NET suite **347 passed, 0 failed, 0 skipped** — identical to baseline, nothing lost
- Web untouched (mobile-only change, per the repo's change discipline)

## On the rest of #94

Closing #94 with this. The other ~24 near-duplicate relationships were reviewed and left alone deliberately: they're deltas of 3–12 with plausible semantic distinctions and real usage on both sides — `SurfaceWarning`/`SurfaceWarningAlt` are used 20× and 4×, `SurfaceInset` and `SurfacePage` are genuinely two different light surfaces. Collapsing those would be imposing design opinions without the design authority #94 itself calls for.

Also checked for dead tokens and found none. An initial probe suggested `SurfaceAccentTintDeep` and `Primary` were unreferenced; both were wrong — `SurfaceAccentTintDeep` is used in `Views/Controls/CalculatorInfoView.xaml` (a subdirectory the first glob missed) and `Primary` is used throughout `Styles.xaml`.