### PR TITLE
Collect more profile details during onboarding, and label every Profile field

### DIFF
--- a/app/MyFireNumber.Core/Profile/ProfileDraftResolver.cs
+++ b/app/MyFireNumber.Core/Profile/ProfileDraftResolver.cs
@@ -19,8 +19,8 @@ public static class ProfileDraftResolver
                 RetirementAge = TargetAge(snapshot, draft.RetirementAge),
                 CurrentSavings = snapshot.TotalAccountBalance,
                 AnnualContribution = snapshot.TotalAnnualContributions,
-                AnnualIncome = snapshot.TotalAnnualIncome,
-                AnnualExpenses = snapshot.TotalAnnualExpenses
+                AnnualIncome = snapshot.EffectiveAnnualIncome ?? draft.AnnualIncome,
+                AnnualExpenses = snapshot.EffectiveAnnualExpenses ?? draft.AnnualExpenses
             },
             LeanFireDraft draft => draft with
             {
@@ -28,8 +28,8 @@ public static class ProfileDraftResolver
                 RetirementAge = TargetAge(snapshot, draft.RetirementAge),
                 CurrentSavings = snapshot.TotalAccountBalance,
                 AnnualContribution = snapshot.TotalAnnualContributions,
-                AnnualIncome = snapshot.TotalAnnualIncome,
-                AnnualExpenses = snapshot.TotalAnnualExpenses
+                AnnualIncome = snapshot.EffectiveAnnualIncome ?? draft.AnnualIncome,
+                AnnualExpenses = snapshot.EffectiveAnnualExpenses ?? draft.AnnualExpenses
             },
             FatFireDraft draft => draft with
             {
@@ -37,8 +37,8 @@ public static class ProfileDraftResolver
                 RetirementAge = TargetAge(snapshot, draft.RetirementAge),
                 CurrentSavings = snapshot.TotalAccountBalance,
                 AnnualContribution = snapshot.TotalAnnualContributions,
-                AnnualIncome = snapshot.TotalAnnualIncome,
-                AnnualExpenses = snapshot.TotalAnnualExpenses
+                AnnualIncome = snapshot.EffectiveAnnualIncome ?? draft.AnnualIncome,
+                AnnualExpenses = snapshot.EffectiveAnnualExpenses ?? draft.AnnualExpenses
             },
             CoastFireDraft draft => draft with
             {
@@ -46,28 +46,28 @@ public static class ProfileDraftResolver
                 RetirementAge = TargetAge(snapshot, draft.RetirementAge),
                 CurrentSavings = snapshot.TotalAccountBalance,
                 AnnualContribution = snapshot.TotalAnnualContributions,
-                AnnualExpenses = snapshot.TotalAnnualExpenses
+                AnnualExpenses = snapshot.EffectiveAnnualExpenses ?? draft.AnnualExpenses
             },
             BaristaFireDraft draft => draft with
             {
                 CurrentAge = CurrentAge(snapshot, today, draft.CurrentAge),
                 CurrentSavings = snapshot.TotalAccountBalance,
                 AnnualContribution = snapshot.TotalAnnualContributions,
-                AnnualExpenses = snapshot.TotalAnnualExpenses
+                AnnualExpenses = snapshot.EffectiveAnnualExpenses ?? draft.AnnualExpenses
             },
             ReverseFireDraft draft => draft with
             {
                 CurrentAge = CurrentAge(snapshot, today, draft.CurrentAge),
                 TargetRetirementAge = TargetAge(snapshot, draft.TargetRetirementAge),
                 CurrentSavings = snapshot.TotalAccountBalance,
-                AnnualExpenses = snapshot.TotalAnnualExpenses
+                AnnualExpenses = snapshot.EffectiveAnnualExpenses ?? draft.AnnualExpenses
             },
             SavingsInvestmentDraft draft => draft with
             {
                 StartingAmount = snapshot.TotalAccountBalance,
                 ContributionAmount = snapshot.TotalAnnualContributions / 12,
                 ContributionFrequency = ContributionFrequency.Monthly,
-                AnnualIncome = snapshot.TotalAnnualIncome,
+                AnnualIncome = snapshot.EffectiveAnnualIncome ?? draft.AnnualIncome,
                 CurrentAge = CurrentAge(snapshot, today, draft.CurrentAge)
             },
             HealthcareGapDraft draft => draft with
@@ -83,7 +83,7 @@ public static class ProfileDraftResolver
             {
                 CurrentAge = CurrentAge(snapshot, today, draft.CurrentAge),
                 SemiRetirementAge = PhasedAge(snapshot, draft.SemiRetirementAge),
-                AnnualExpenses = snapshot.TotalAnnualExpenses,
+                AnnualExpenses = snapshot.EffectiveAnnualExpenses ?? draft.AnnualExpenses,
                 Accounts = snapshot.Accounts.Select(ToRetirementAccount).ToArray()
             },
             _ => source
@@ -114,16 +114,18 @@ public static class ProfileDraftResolver
             errors.Add("Add at least one account to Profile to use linked mode.");
         }
 
-        if (draft is StandardFireDraft or LeanFireDraft or FatFireDraft && snapshot.Income.Count == 0)
+        // Either source satisfies the requirement now that both feed the same effective value, so a
+        // profile that only answered the onboarding income question is still linkable.
+        if (draft is StandardFireDraft or LeanFireDraft or FatFireDraft && snapshot.EffectiveAnnualIncome is null)
         {
-            errors.Add("Add at least one recurring income item to Profile to use linked mode.");
+            errors.Add("Add your household income or a recurring income item to Profile to use linked mode.");
         }
 
         if (draft is StandardFireDraft or LeanFireDraft or FatFireDraft or CoastFireDraft or
             BaristaFireDraft or ReverseFireDraft or DeferredCompensationDraft &&
-            snapshot.Expenses.Count == 0)
+            snapshot.EffectiveAnnualExpenses is null)
         {
-            errors.Add("Add at least one recurring expense to Profile to use linked mode.");
+            errors.Add("Add your household spending or a recurring expense to Profile to use linked mode.");
         }
 
         if (snapshot.Accounts.Any(account => account.Balance < 0 || account.AnnualContribution < 0))

--- a/app/MyFireNumber.Core/Profile/ProfileInventoryModels.cs
+++ b/app/MyFireNumber.Core/Profile/ProfileInventoryModels.cs
@@ -51,6 +51,27 @@ public sealed record ProfileFinancialSnapshot(
     public double TotalAnnualContributions => Accounts.Sum(account => account.AnnualContribution);
     public double TotalAnnualIncome => Income.Sum(item => item.AnnualAmount);
     public double TotalAnnualExpenses => Expenses.Sum(item => item.AnnualAmount);
+
+    /// <summary>
+    /// The income every calculator should use. Itemised entries win when the user has added any,
+    /// because they are the more specific answer; the single household figure from onboarding is the
+    /// fallback. Null when neither has been provided.
+    /// <para>This precedence has to live in one place: linked plans read the itemised totals while
+    /// new scenarios read the household figure, so without a shared rule the same profile produces
+    /// two different numbers depending on how the scenario was created.</para>
+    /// </summary>
+    public double? EffectiveAnnualIncome =>
+        Income.Count > 0 ? TotalAnnualIncome : Profile.AnnualIncome;
+
+    /// <inheritdoc cref="EffectiveAnnualIncome"/>
+    public double? EffectiveAnnualExpenses =>
+        Expenses.Count > 0 ? TotalAnnualExpenses : Profile.AnnualExpenses;
+
+    /// <summary>Whether itemised entries are overriding the single household income figure.</summary>
+    public bool IsIncomeItemised => Income.Count > 0;
+
+    /// <inheritdoc cref="IsIncomeItemised"/>
+    public bool AreExpensesItemised => Expenses.Count > 0;
 }
 
 public sealed record ProfileResolution<TDraft>(

--- a/app/MyFireNumber.Core/Profile/ProfileModels.cs
+++ b/app/MyFireNumber.Core/Profile/ProfileModels.cs
@@ -56,6 +56,19 @@ public sealed record ProfileAccount(
 
 public static class ProfileAgeCalculator
 {
+    /// <summary>
+    /// The selectable retirement-age range for a person of <paramref name="currentAge"/>.
+    /// <para>The minimum never exceeds the maximum: someone already older than
+    /// <paramref name="ceiling"/> would otherwise produce an inverted range that a slider cannot
+    /// represent and that <see cref="Math.Clamp(int, int, int)"/> rejects.</para>
+    /// </summary>
+    public static (int Minimum, int Maximum) RetirementAgeRange(int currentAge, int floor, int ceiling)
+    {
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(floor, ceiling);
+        var minimum = Math.Min(Math.Max(floor, currentAge), ceiling);
+        return (minimum, ceiling);
+    }
+
     public static int AgeOn(DateOnly birthDate, DateOnly date)
     {
         if (date < birthDate)
@@ -71,6 +84,17 @@ public static class ProfileAgeCalculator
         birthDate.Month == 2 && birthDate.Day == 29 && !DateTime.IsLeapYear(year)
             ? new DateOnly(year, 2, 28)
             : new DateOnly(year, birthDate.Month, birthDate.Day);
+
+    /// <summary>
+    /// The date the person turns <paramref name="age"/>. Onboarding asks for a retirement age
+    /// because it is quicker to answer than a calendar date, while the profile stores dates, so this
+    /// is the single conversion both use.
+    /// </summary>
+    public static DateOnly DateAtAge(DateOnly birthDate, int age)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(age);
+        return BirthdayInYear(birthDate, birthDate.Year + age);
+    }
 
     public static bool TryValidate(FinancialProfile profile, out string validationMessage) =>
         TryValidate(profile, today: null, out validationMessage);

--- a/app/MyFireNumber.Tests/Profile/ProfileAgeCalculatorTests.cs
+++ b/app/MyFireNumber.Tests/Profile/ProfileAgeCalculatorTests.cs
@@ -76,4 +76,58 @@ public sealed class ProfileAgeCalculatorTests
 
         Assert.True(ProfileAgeCalculator.TryValidate(profile, today, out _));
     }
+
+    [Theory]
+    [InlineData(1990, 8, 16, 55, 2045, 8, 16)]
+    [InlineData(1990, 12, 31, 65, 2055, 12, 31)]
+    [InlineData(2000, 2, 29, 55, 2055, 2, 28)]
+    [InlineData(2000, 2, 29, 60, 2060, 2, 29)]
+    public void DateAtAge_ReturnsBirthdayInTheTargetYear(
+        int birthYear,
+        int birthMonth,
+        int birthDay,
+        int age,
+        int expectedYear,
+        int expectedMonth,
+        int expectedDay)
+    {
+        var date = ProfileAgeCalculator.DateAtAge(new DateOnly(birthYear, birthMonth, birthDay), age);
+
+        Assert.Equal(new DateOnly(expectedYear, expectedMonth, expectedDay), date);
+    }
+
+    [Fact]
+    public void DateAtAge_RoundTripsThroughAgeOn()
+    {
+        var birthDate = new DateOnly(1988, 3, 7);
+
+        var retirementDate = ProfileAgeCalculator.DateAtAge(birthDate, 62);
+
+        Assert.Equal(62, ProfileAgeCalculator.AgeOn(birthDate, retirementDate));
+    }
+
+    [Theory]
+    [InlineData(30, 30, 90)]
+    [InlineData(20, 30, 90)]
+    [InlineData(64, 64, 90)]
+    public void RetirementAgeRange_StartsAtTheLaterOfTheFloorAndCurrentAge(
+        int currentAge,
+        int expectedMinimum,
+        int expectedMaximum)
+    {
+        var range = ProfileAgeCalculator.RetirementAgeRange(currentAge, 30, 90);
+
+        Assert.Equal(expectedMinimum, range.Minimum);
+        Assert.Equal(expectedMaximum, range.Maximum);
+    }
+
+    [Fact]
+    public void RetirementAgeRange_NeverInvertsForSomeoneOlderThanTheCeiling()
+    {
+        var range = ProfileAgeCalculator.RetirementAgeRange(105, 30, 90);
+
+        Assert.Equal(90, range.Minimum);
+        Assert.Equal(90, range.Maximum);
+        Assert.True(range.Minimum <= range.Maximum);
+    }
 }

--- a/app/MyFireNumber.Tests/Profile/ProfileDraftResolverTests.cs
+++ b/app/MyFireNumber.Tests/Profile/ProfileDraftResolverTests.cs
@@ -71,6 +71,72 @@ public sealed class ProfileDraftResolverTests
         Assert.Collection(result.Draft.Debts, debt => Assert.Equal("card", debt.Id));
     }
 
+    [Fact]
+    public void Resolve_PrefersItemisedIncomeOverTheHouseholdFigure()
+    {
+        var snapshot = Snapshot(
+            accounts: [Account("one", 100_000, 10_000)],
+            income: [new ProfileIncome("salary", "Salary", 100_000, CurrencyPeriod.Annual, null)],
+            expenses: [new ProfileExpense("living", "Living", 40_000, CurrencyPeriod.Annual, null)]) with
+        {
+            Profile = FinancialProfile.Empty with { AnnualIncome = 55_000, AnnualExpenses = 22_000 }
+        };
+
+        var result = ProfileDraftResolver.Resolve(StandardFireDraft.Default, snapshot, new DateOnly(2026, 1, 1));
+
+        Assert.True(result.IsValid);
+        Assert.Equal(100_000, result.Draft.AnnualIncome);
+        Assert.Equal(40_000, result.Draft.AnnualExpenses);
+    }
+
+    [Fact]
+    public void Resolve_FallsBackToTheHouseholdFigureWhenNothingIsItemised()
+    {
+        var snapshot = Snapshot(accounts: [Account("one", 100_000, 10_000)]) with
+        {
+            Profile = FinancialProfile.Empty with { AnnualIncome = 55_000, AnnualExpenses = 22_000 }
+        };
+
+        var result = ProfileDraftResolver.Resolve(StandardFireDraft.Default, snapshot, new DateOnly(2026, 1, 1));
+
+        Assert.True(result.IsValid);
+        Assert.Equal(55_000, result.Draft.AnnualIncome);
+        Assert.Equal(22_000, result.Draft.AnnualExpenses);
+    }
+
+    [Fact]
+    public void Resolve_BlocksOnlyWhenNeitherSourceHasIncome()
+    {
+        var snapshot = Snapshot(
+            accounts: [Account("one", 100_000, 10_000)],
+            expenses: [new ProfileExpense("living", "Living", 40_000, CurrencyPeriod.Annual, null)]);
+
+        var result = ProfileDraftResolver.Resolve(StandardFireDraft.Default, snapshot, new DateOnly(2026, 1, 1));
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, error => error.Contains("income", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EffectiveValues_MatchWhatTheResolverApplies()
+    {
+        var itemised = Snapshot(
+            income: [new ProfileIncome("a", "A", 1_000, CurrencyPeriod.Monthly, null)]) with
+        {
+            Profile = FinancialProfile.Empty with { AnnualIncome = 99_000 }
+        };
+        var householdOnly = Snapshot() with
+        {
+            Profile = FinancialProfile.Empty with { AnnualIncome = 99_000 }
+        };
+
+        Assert.Equal(12_000, itemised.EffectiveAnnualIncome);
+        Assert.True(itemised.IsIncomeItemised);
+        Assert.Equal(99_000, householdOnly.EffectiveAnnualIncome);
+        Assert.False(householdOnly.IsIncomeItemised);
+        Assert.Null(Snapshot().EffectiveAnnualIncome);
+    }
+
     private static ProfileFinancialSnapshot Snapshot(
         IReadOnlyList<ProfileAccount>? accounts = null,
         IReadOnlyList<ProfileIncome>? income = null,

--- a/app/MyFireNumber/AppShell.xaml.cs
+++ b/app/MyFireNumber/AppShell.xaml.cs
@@ -27,7 +27,10 @@ public partial class AppShell : Shell
 		Items.Add(CreateTab("Home", "home", "tab_home.png", homePage));
 		Items.Add(CreateTab("Calculators", "calculators", "tab_calculators.png", calculatorsPage));
 		Items.Add(CreateTab("Plans", "plans", "tab_plans.png", plansPage));
-		Items.Add(CreateTab("Profile", "profile", "tab_profile.png", profilePage));
+
+		// Profile keeps the platform nav bar so its Settings action sits in the standard toolbar
+		// position rather than being a button drawn inside the scrolling content.
+		Items.Add(CreateTab("Profile", "profile", "tab_profile.png", profilePage, showNavBar: true));
 		Routing.RegisterRoute("settings", typeof(SettingsPage));
 
 		Routing.RegisterRoute("quiz", typeof(QuizPage));
@@ -51,9 +54,9 @@ public partial class AppShell : Shell
 		Loaded += OnLoaded;
 	}
 
-	private static Tab CreateTab(string title, string route, string icon, Page page)
+	private static Tab CreateTab(string title, string route, string icon, Page page, bool showNavBar = false)
 	{
-		Shell.SetNavBarIsVisible(page, false);
+		Shell.SetNavBarIsVisible(page, showNavBar);
 
 		var shellContent = new ShellContent
 		{

--- a/app/MyFireNumber/AppShell.xaml.cs
+++ b/app/MyFireNumber/AppShell.xaml.cs
@@ -33,6 +33,7 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute("quiz", typeof(QuizPage));
 		Routing.RegisterRoute("welcome", typeof(WelcomePage));
 		Routing.RegisterRoute("onboarding-defaults", typeof(DefaultsOnboardingPage));
+		Routing.RegisterRoute("onboarding-timeline", typeof(TimelineOnboardingPage));
 		Routing.RegisterRoute("onboarding-withdrawal-rate", typeof(WithdrawalRateOnboardingPage));
 		Routing.RegisterRoute("onboarding-choice", typeof(OnboardingChoicePage));
 		Routing.RegisterRoute("standard-fire", typeof(FireNumberPage));

--- a/app/MyFireNumber/MauiProgram.cs
+++ b/app/MyFireNumber/MauiProgram.cs
@@ -114,6 +114,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<QuizPage>();
 		builder.Services.AddTransient<WelcomePage>();
 		builder.Services.AddTransient<DefaultsOnboardingPage>();
+		builder.Services.AddTransient<TimelineOnboardingPage>();
 		builder.Services.AddTransient<WithdrawalRateOnboardingPage>();
 		builder.Services.AddTransient<OnboardingChoicePage>();
 		builder.Services.AddTransient<RetirementAnnualDetailsPage>();
@@ -137,6 +138,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<QuizViewModel>();
 		builder.Services.AddTransient<WelcomeViewModel>();
 		builder.Services.AddTransient<DefaultsOnboardingViewModel>();
+		builder.Services.AddTransient<TimelineOnboardingViewModel>();
 		builder.Services.AddTransient<WithdrawalRateOnboardingViewModel>();
 		builder.Services.AddTransient<OnboardingChoiceViewModel>();
 		builder.Services.AddTransient<RetirementAnnualDetailsViewModel>();

--- a/app/MyFireNumber/Resources/Styles/Styles.xaml
+++ b/app/MyFireNumber/Resources/Styles/Styles.xaml
@@ -83,7 +83,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="DatePicker">
+    <Style x:Key="BaseDatePicker" TargetType="DatePicker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
@@ -103,6 +103,8 @@
             </VisualStateGroupList>
         </Setter>
     </Style>
+
+    <Style TargetType="DatePicker" BasedOn="{StaticResource BaseDatePicker}" />
 
     <Style TargetType="Editor">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
@@ -126,7 +128,7 @@
         </Setter>
     </Style>
 
-    <Style TargetType="Entry">
+    <Style x:Key="BaseEntry" TargetType="Entry">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
         <Setter Property="FontFamily" Value="OpenSansRegular"/>
@@ -147,6 +149,8 @@
             </VisualStateGroupList>
         </Setter>
     </Style>
+
+    <Style TargetType="Entry" BasedOn="{StaticResource BaseEntry}" />
 
     <Style TargetType="ImageButton">
         <Setter Property="Opacity" Value="1" />
@@ -203,7 +207,7 @@
         <Setter Property="HorizontalTextAlignment" Value="Center" />
     </Style>
 
-    <Style TargetType="Picker">
+    <Style x:Key="BasePicker" TargetType="Picker">
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource White}}" />
         <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource Gray900}, Dark={StaticResource Gray200}}" />
         <Setter Property="BackgroundColor" Value="Transparent" />
@@ -225,6 +229,8 @@
             </VisualStateGroupList>
         </Setter>
     </Style>
+
+    <Style TargetType="Picker" BasedOn="{StaticResource BasePicker}" />
 
     <Style TargetType="ProgressBar">
         <Setter Property="ProgressColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
@@ -390,19 +396,19 @@
     </Style>
 
     <!-- A form input on a card or inset surface, so the field reads as editable. -->
-    <Style x:Key="FormEntry" TargetType="Entry">
+    <Style x:Key="FormEntry" TargetType="Entry" BasedOn="{StaticResource BaseEntry}">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
         <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
     </Style>
 
-    <Style x:Key="FormPicker" TargetType="Picker">
+    <Style x:Key="FormPicker" TargetType="Picker" BasedOn="{StaticResource BasePicker}">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
         <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
     </Style>
 
-    <Style x:Key="FormDatePicker" TargetType="DatePicker">
+    <Style x:Key="FormDatePicker" TargetType="DatePicker" BasedOn="{StaticResource BaseDatePicker}">
         <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" />
         <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
     </Style>

--- a/app/MyFireNumber/Resources/Styles/Styles.xaml
+++ b/app/MyFireNumber/Resources/Styles/Styles.xaml
@@ -376,6 +376,38 @@
     </Style>
 
     <!--
+    The visible name of a single form field, sitting directly above its input.
+    A placeholder is not a label: it disappears as soon as the field has a value, so a
+    form that relies on placeholders alone leaves the user guessing what they typed and
+    gives assistive technology nothing stable to announce. Every editable field pairs
+    this label with its input, and placeholders are reserved for example values.
+    -->
+    <Style x:Key="FormFieldLabel" TargetType="Label">
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="LineBreakMode" Value="WordWrap" />
+    </Style>
+
+    <!-- A form input on a card or inset surface, so the field reads as editable. -->
+    <Style x:Key="FormEntry" TargetType="Entry">
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
+    </Style>
+
+    <Style x:Key="FormPicker" TargetType="Picker">
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+        <Setter Property="TitleColor" Value="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
+    </Style>
+
+    <Style x:Key="FormDatePicker" TargetType="DatePicker">
+        <Setter Property="Background" Value="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+    </Style>
+
+    <!--
     Dynamic result sentences ("You're already Coast FIRE!", "To FIRE by age 55 you
     need to save $X per month."). These are full sentences, so they wrap freely and
     are never truncated - the sentence is the result. Smaller and semibold rather

--- a/app/MyFireNumber/Services/CalculatorDefaultsService.cs
+++ b/app/MyFireNumber/Services/CalculatorDefaultsService.cs
@@ -45,7 +45,6 @@ public sealed class CalculatorDefaultsService(IProfileService profileService) : 
     {
         get
         {
-            var profile = profileService.Current;
             return new(
                 Preferences.Default.Get(ExpectedReturnKey, 0.07),
                 Preferences.Default.Get(InflationRateKey, 0.03),
@@ -53,8 +52,10 @@ public sealed class CalculatorDefaultsService(IProfileService profileService) : 
                 profileService.DerivedCurrentAge ?? Preferences.Default.Get(CurrentAgeKey, 30),
                 profileService.DerivedTargetRetirementAge ?? Preferences.Default.Get(RetirementAgeKey, 55))
             {
-                AnnualIncome = profile.AnnualIncome ?? Preferences.Default.Get(AnnualIncomeKey, StandardFireDraft.Default.AnnualIncome),
-                AnnualExpenses = profile.AnnualExpenses ?? Preferences.Default.Get(AnnualExpensesKey, StandardFireDraft.Default.AnnualExpenses)
+                // Effective values so a new scenario starts from the same income and spending a
+                // linked plan would resolve, whether the user itemised them or answered once.
+                AnnualIncome = profileService.EffectiveAnnualIncome ?? Preferences.Default.Get(AnnualIncomeKey, StandardFireDraft.Default.AnnualIncome),
+                AnnualExpenses = profileService.EffectiveAnnualExpenses ?? Preferences.Default.Get(AnnualExpensesKey, StandardFireDraft.Default.AnnualExpenses)
             };
         }
     }

--- a/app/MyFireNumber/Services/ProfileService.cs
+++ b/app/MyFireNumber/Services/ProfileService.cs
@@ -23,6 +23,15 @@ public interface IProfileService
     /// </summary>
     long DataRevision { get; }
 
+    /// <summary>
+    /// Annual income for new scenarios, applying the same itemised-wins-over-household rule that
+    /// linked plans use, so both routes agree. Null when the user has provided neither.
+    /// </summary>
+    double? EffectiveAnnualIncome { get; }
+
+    /// <inheritdoc cref="EffectiveAnnualIncome"/>
+    double? EffectiveAnnualExpenses { get; }
+
     Task LoadAsync(CancellationToken cancellationToken = default);
 
     Task SaveAsync(FinancialProfile profile, CancellationToken cancellationToken = default);
@@ -38,15 +47,22 @@ public interface IProfileService
 }
 
 public sealed class ProfileService(
+    IProfileFinancialSnapshotRepository snapshotRepository,
     IProfileRepository profileRepository,
     ILocalDateProvider localDateProvider) : IProfileService
 {
     private FinancialProfile current = FinancialProfile.Empty;
+    private double? effectiveAnnualIncome;
+    private double? effectiveAnnualExpenses;
     private long dataRevision;
 
     public FinancialProfile Current => current;
 
     public long DataRevision => Interlocked.Read(ref dataRevision);
+
+    public double? EffectiveAnnualIncome => effectiveAnnualIncome;
+
+    public double? EffectiveAnnualExpenses => effectiveAnnualExpenses;
 
     public int? DerivedCurrentAge => DeriveAge(localDateProvider.Today);
 
@@ -56,13 +72,20 @@ public sealed class ProfileService(
 
     public async Task LoadAsync(CancellationToken cancellationToken = default)
     {
-        current = await profileRepository.GetAsync(cancellationToken);
+        var snapshot = await snapshotRepository.GetAsync(cancellationToken);
+        current = snapshot.Profile;
+        effectiveAnnualIncome = snapshot.EffectiveAnnualIncome;
+        effectiveAnnualExpenses = snapshot.EffectiveAnnualExpenses;
     }
 
     public async Task SaveAsync(FinancialProfile profile, CancellationToken cancellationToken = default)
     {
         await profileRepository.SaveAsync(profile, cancellationToken);
         current = profile;
+
+        // Re-read the inventory so a saved household figure does not keep overriding, or being
+        // overridden by, a stale itemised total.
+        await LoadAsync(cancellationToken);
     }
 
     public async Task NotifyExternalChangeAsync(CancellationToken cancellationToken = default)

--- a/app/MyFireNumber/ViewModels/DefaultsOnboardingViewModel.cs
+++ b/app/MyFireNumber/ViewModels/DefaultsOnboardingViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using MyFireNumber.Core.Profile;
 using MyFireNumber.Services;
+using System.Globalization;
 
 namespace MyFireNumber.ViewModels;
 
@@ -9,29 +11,52 @@ public partial class DefaultsOnboardingViewModel : ObservableObject
     private const double RoundingTolerance = 0.000001;
     private readonly ICalculatorDefaultsService calculatorDefaultsService;
     private readonly ICurrencyPreferencesService currencyPreferencesService;
+    private readonly ILocalDateProvider localDateProvider;
     private readonly INavigationService navigationService;
     private readonly IProfileService profileService;
 
     public DefaultsOnboardingViewModel(
         ICalculatorDefaultsService calculatorDefaultsService,
         ICurrencyPreferencesService currencyPreferencesService,
+        ILocalDateProvider localDateProvider,
         INavigationService navigationService,
         IProfileService profileService)
     {
         this.calculatorDefaultsService = calculatorDefaultsService;
         this.currencyPreferencesService = currencyPreferencesService;
+        this.localDateProvider = localDateProvider;
         this.navigationService = navigationService;
         this.profileService = profileService;
 
         var defaults = calculatorDefaultsService.Current;
-        currentAge = defaults.CurrentAge;
+        var profile = profileService.Current;
         annualIncome = defaults.AnnualIncome;
         annualExpenses = defaults.AnnualExpenses;
+        displayName = profile.DisplayName ?? string.Empty;
+        householdSize = profile.HouseholdSize ?? 1;
+
+        // A saved birth date wins. Otherwise the picker opens on the saved default age so the wheel
+        // starts somewhere plausible instead of today.
+        hasBirthDate = profile.BirthDate is not null;
+        birthDate = (profile.BirthDate ?? localDateProvider.Today.AddYears(-defaults.CurrentAge))
+            .ToDateTime(TimeOnly.MinValue);
     }
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(CurrentAgeText))]
-    private double currentAge;
+    private string displayName = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HouseholdSizeText))]
+    private double householdSize;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DerivedAgeText))]
+    private DateTime birthDate;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(DerivedAgeText))]
+    [NotifyPropertyChangedFor(nameof(HasNoBirthDate))]
+    private bool hasBirthDate;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(AnnualIncomeText))]
@@ -41,14 +66,34 @@ public partial class DefaultsOnboardingViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(AnnualExpensesText))]
     private double annualExpenses;
 
-    public string CurrentAgeText => $"{CurrentAge:0}";
+    public bool HasNoBirthDate => !HasBirthDate;
+    public string HouseholdSizeText => HouseholdSize <= 1 ? "Just me" : $"{HouseholdSize:0} people";
     public string AnnualIncomeText => currencyPreferencesService.Format(AnnualIncome);
     public string AnnualExpensesText => currencyPreferencesService.Format(AnnualExpenses);
     public double MaximumAnnualIncome => 1_000_000;
     public double MaximumAnnualExpenses => 500_000;
+    public double MaximumHouseholdSize => 10;
 
-    partial void OnCurrentAgeChanged(double value) =>
-        RoundSliderValue(value, rounded => CurrentAge = rounded, 1);
+    /// <summary>Keeps the picker from offering a date the age math cannot evaluate.</summary>
+    public DateTime MaximumBirthDate => localDateProvider.Today.ToDateTime(TimeOnly.MinValue);
+
+    public string DerivedAgeText => HasBirthDate
+        ? $"That makes you {DerivedAge.ToString(CultureInfo.CurrentCulture)} today, and your age stays current as time passes."
+        : $"Skip this and calculators start from age {calculatorDefaultsService.Current.CurrentAge.ToString(CultureInfo.CurrentCulture)} instead.";
+
+    private int DerivedAge
+    {
+        get
+        {
+            var selected = DateOnly.FromDateTime(BirthDate);
+            return selected > localDateProvider.Today
+                ? 0
+                : ProfileAgeCalculator.AgeOn(selected, localDateProvider.Today);
+        }
+    }
+
+    partial void OnHouseholdSizeChanged(double value) =>
+        RoundSliderValue(value, rounded => HouseholdSize = rounded, 1);
 
     partial void OnAnnualIncomeChanged(double value) =>
         RoundSliderValue(value, rounded => AnnualIncome = rounded, 1_000);
@@ -57,27 +102,57 @@ public partial class DefaultsOnboardingViewModel : ObservableObject
         RoundSliderValue(value, rounded => AnnualExpenses = rounded, 1_000);
 
     [RelayCommand]
-    private async Task SaveAndContinueAsync()
-    {
-        var defaults = calculatorDefaultsService.Current;
-        calculatorDefaultsService.Save(defaults with
-        {
-            CurrentAge = (int)CurrentAge,
-            RetirementAge = Math.Max(defaults.RetirementAge, (int)CurrentAge),
-            AnnualIncome = AnnualIncome,
-            AnnualExpenses = AnnualExpenses
-        });
-        await profileService.SaveAsync(profileService.Current with
-        {
-            AnnualIncome = AnnualIncome,
-            AnnualExpenses = AnnualExpenses
-        });
-
-        await navigationService.GoToAsync("../onboarding-withdrawal-rate");
-    }
+    private void UseBirthDate() => HasBirthDate = true;
 
     [RelayCommand]
-    private Task SkipAsync() => navigationService.GoToAsync("../onboarding-withdrawal-rate");
+    private void SkipBirthDate() => HasBirthDate = false;
+
+    [RelayCommand]
+    private async Task SaveAndContinueAsync()
+    {
+        var selectedBirthDate = HasBirthDate ? DateOnly.FromDateTime(BirthDate) : (DateOnly?)null;
+
+        // A future date the picker should have prevented still must not reach the profile, because
+        // age derivation cannot evaluate it.
+        if (selectedBirthDate > localDateProvider.Today)
+        {
+            selectedBirthDate = localDateProvider.Today;
+        }
+
+        var defaults = calculatorDefaultsService.Current;
+        var currentAge = selectedBirthDate is DateOnly birth
+            ? ProfileAgeCalculator.AgeOn(birth, localDateProvider.Today)
+            : defaults.CurrentAge;
+
+        calculatorDefaultsService.Save(defaults with
+        {
+            CurrentAge = currentAge,
+            RetirementAge = Math.Max(defaults.RetirementAge, currentAge),
+            AnnualIncome = AnnualIncome,
+            AnnualExpenses = AnnualExpenses
+        });
+
+        try
+        {
+            await profileService.SaveAsync(profileService.Current with
+            {
+                DisplayName = string.IsNullOrWhiteSpace(DisplayName) ? null : DisplayName.Trim(),
+                HouseholdSize = (int)HouseholdSize,
+                BirthDate = selectedBirthDate,
+                AnnualIncome = AnnualIncome,
+                AnnualExpenses = AnnualExpenses
+            });
+        }
+        catch (Exception)
+        {
+            // Onboarding must never dead-end on a storage failure. The calculator defaults saved
+            // above still apply, and Profile can be completed later.
+        }
+
+        await navigationService.GoToAsync("../onboarding-timeline");
+    }
+    [RelayCommand]
+    private Task SkipAsync() => navigationService.GoToAsync("../onboarding-timeline");
 
     private static void RoundSliderValue(double value, Action<double> update, double increment)
     {

--- a/app/MyFireNumber/ViewModels/HomeViewModel.cs
+++ b/app/MyFireNumber/ViewModels/HomeViewModel.cs
@@ -29,6 +29,7 @@ public partial class HomeViewModel : ObservableObject
     private readonly IAppBehaviorPreferencesService behaviorPreferencesService;
     private readonly IExternalLinkService externalLinkService;
     private readonly IErrorPresentationService errorPresentationService;
+    private readonly IProfileService profileService;
 
     public HomeViewModel(
         ICalculatorCatalog catalog,
@@ -40,7 +41,8 @@ public partial class HomeViewModel : ObservableObject
         IRecentActivityRepository recentActivityRepository,
         IAppBehaviorPreferencesService behaviorPreferencesService,
         IExternalLinkService externalLinkService,
-        IErrorPresentationService errorPresentationService)
+        IErrorPresentationService errorPresentationService,
+        IProfileService profileService)
     {
         this.catalog = catalog;
         this.recommendedBookCatalog = recommendedBookCatalog;
@@ -52,6 +54,7 @@ public partial class HomeViewModel : ObservableObject
         this.behaviorPreferencesService = behaviorPreferencesService;
         this.externalLinkService = externalLinkService;
         this.errorPresentationService = errorPresentationService;
+        this.profileService = profileService;
     }
 
     public ObservableCollection<CalculatorDefinition> FeaturedCalculators { get; } = [];
@@ -61,6 +64,18 @@ public partial class HomeViewModel : ObservableObject
 
     public bool HasRecentCalculators => RecentCalculators.Count > 0;
     public bool HasRecentPlans => RecentPlans.Count > 0;
+
+    /// <summary>
+    /// The profile display name, shown only when onboarding or Profile captured one. The header
+    /// falls back to the product name so an anonymous profile still reads correctly.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasGreeting))]
+    [NotifyPropertyChangedFor(nameof(HasNoGreeting))]
+    private string greeting = string.Empty;
+
+    public bool HasGreeting => !string.IsNullOrWhiteSpace(Greeting);
+    public bool HasNoGreeting => !HasGreeting;
     public bool ShowGettingStarted { get; private set; }
     public bool HasQuizRecommendation => ShowGettingStarted && RecommendedCalculator is not null;
     public bool ShowFeaturedCalculators => ShowGettingStarted && RecommendedCalculator is null;
@@ -73,6 +88,10 @@ public partial class HomeViewModel : ObservableObject
 
     public async Task LoadAsync()
     {
+        await profileService.LoadAsync();
+        var displayName = profileService.Current.DisplayName;
+        Greeting = string.IsNullOrWhiteSpace(displayName) ? string.Empty : $"Welcome back, {displayName.Trim()}";
+
         var preferencesTask = preferencesRepository.ListAsync();
         var recentCalculatorsTask = recentActivityRepository.ListAsync(RecentActivityKind.Calculator, 3);
         var recentPlansTask = recentActivityRepository.ListAsync(RecentActivityKind.Plan, 3);

--- a/app/MyFireNumber/ViewModels/ProfileViewModel.cs
+++ b/app/MyFireNumber/ViewModels/ProfileViewModel.cs
@@ -15,6 +15,7 @@ public sealed partial class ProfileViewModel(
     IProfileIncomeRepository profileIncomeRepository,
     IProfileExpenseRepository profileExpenseRepository,
     IProfileDebtRepository profileDebtRepository,
+    ICalculatorDefaultsService calculatorDefaultsService,
     ILocalDateProvider localDateProvider,
     INavigationService navigationService) : ObservableObject
 {
@@ -39,6 +40,15 @@ public sealed partial class ProfileViewModel(
     [ObservableProperty] private bool hasTargetRetirementDate;
     [ObservableProperty] private string validationMessage = string.Empty;
     [ObservableProperty] private string statusMessage = string.Empty;
+
+    // Planning assumptions. These live with the profile rather than in Settings because they are
+    // personal planning inputs, not app preferences, and every new calculator starts from them.
+    [ObservableProperty] private string expectedReturnText = string.Empty;
+    [ObservableProperty] private string inflationRateText = string.Empty;
+    [ObservableProperty] private string withdrawalRateText = string.Empty;
+
+    /// <summary>The page heading, personalized once the profile has a name.</summary>
+    [ObservableProperty] private string headerTitle = "Profile";
 
     public bool HasValidationMessage => !string.IsNullOrWhiteSpace(ValidationMessage);
     public bool HasNoBirthDate => !HasBirthDate;
@@ -96,6 +106,7 @@ public sealed partial class ProfileViewModel(
 
         await profileService.LoadAsync();
         ApplyProfile(profileService.Current);
+        ApplyAssumptions();
 
         Accounts.Clear();
         Income.Clear();
@@ -128,10 +139,67 @@ public sealed partial class ProfileViewModel(
         isLoaded = true;
     }
 
+    private void ApplyAssumptions()
+    {
+        var defaults = calculatorDefaultsService.Current;
+        ExpectedReturnText = (defaults.ExpectedReturn * 100).ToString("0.##", CultureInfo.CurrentCulture);
+        InflationRateText = (defaults.InflationRate * 100).ToString("0.##", CultureInfo.CurrentCulture);
+        WithdrawalRateText = (defaults.WithdrawalRate * 100).ToString("0.##", CultureInfo.CurrentCulture);
+    }
+
+    /// <summary>
+    /// Validates the planning assumptions without writing anything, so an invalid entry is caught
+    /// before any part of the profile is persisted.
+    /// </summary>
+    private bool TryReadAssumptions(out (double ExpectedReturn, double InflationRate, double WithdrawalRate) assumptions)
+    {
+        assumptions = default;
+        if (!TryPercent(ExpectedReturnText, 0, 15, out var expectedReturn) ||
+            !TryPercent(InflationRateText, 0, 10, out var inflationRate) ||
+            !TryPercent(WithdrawalRateText, 2, 6, out var withdrawalRate))
+        {
+            ValidationMessage = "Enter an expected return of 0% to 15%, inflation of 0% to 10%, and a withdrawal rate of 2% to 6%.";
+            return false;
+        }
+
+        assumptions = (expectedReturn, inflationRate, withdrawalRate);
+        return true;
+    }
+
+    /// <summary>
+    /// Persists the assumptions. Runs after the profile is saved and re-reads
+    /// <see cref="ICalculatorDefaultsService.Current"/>, which resolves age, income, and spending
+    /// from the profile, so the stored fallbacks mirror the values just saved rather than the
+    /// previous ones.
+    /// </summary>
+    private void SaveAssumptions((double ExpectedReturn, double InflationRate, double WithdrawalRate) assumptions)
+    {
+        calculatorDefaultsService.Save(calculatorDefaultsService.Current with
+        {
+            ExpectedReturn = assumptions.ExpectedReturn,
+            InflationRate = assumptions.InflationRate,
+            WithdrawalRate = assumptions.WithdrawalRate
+        });
+    }
+
+    private static bool TryPercent(string text, double minimum, double maximum, out double value)
+    {
+        value = 0;
+        if (!double.TryParse(text, NumberStyles.Number, CultureInfo.CurrentCulture, out var percent) ||
+            percent < minimum ||
+            percent > maximum)
+        {
+            return false;
+        }
+
+        value = percent / 100;
+        return true;
+    }
+
     [RelayCommand]
     private async Task SaveAsync()
     {
-        if (!TryCreateProfile(out var profile))
+        if (!TryCreateProfile(out var profile) || !TryReadAssumptions(out var assumptions))
         {
             return;
         }
@@ -221,8 +289,13 @@ public sealed partial class ProfileViewModel(
         }
 
         await profileService.SaveAsync(profile);
+
+        // Written last so the stored fallbacks mirror the profile that was just saved.
+        SaveAssumptions(assumptions);
+
         ValidationMessage = string.Empty;
         StatusMessage = "Profile saved on this device.";
+        HeaderTitle = FirstNonEmpty(profile.HouseholdName, profile.DisplayName) ?? "Profile";
         NotifyCompletionChanged();
     }
 
@@ -340,8 +413,14 @@ public sealed partial class ProfileViewModel(
         if (profile.BirthDate is DateOnly birth) BirthDate = birth.ToDateTime(TimeOnly.MinValue);
         if (profile.PhasedRetirementDate is DateOnly phased) PhasedRetirementDate = phased.ToDateTime(TimeOnly.MinValue);
         if (profile.TargetRetirementDate is DateOnly target) TargetRetirementDate = target.ToDateTime(TimeOnly.MinValue);
+
+        // Prefer the household label, then the person's name, so a shared plan reads correctly.
+        HeaderTitle = FirstNonEmpty(profile.HouseholdName, profile.DisplayName) ?? "Profile";
         NotifyCompletionChanged();
     }
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value))?.Trim();
 
     private static RetirementAccountEditorItem ToEditor(ProfileAccount account) =>
         RetirementAccountEditorItem.FromAccount(new RetirementAccount(

--- a/app/MyFireNumber/ViewModels/ProfileViewModel.cs
+++ b/app/MyFireNumber/ViewModels/ProfileViewModel.cs
@@ -1,10 +1,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using MyFireNumber.Core.Calculations;
+using MyFireNumber.Core.Presentation;
 using MyFireNumber.Core.Profile;
 using MyFireNumber.Services;
 using MyFireNumber.Storage;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Globalization;
 
 namespace MyFireNumber.ViewModels;
@@ -20,13 +23,13 @@ public sealed partial class ProfileViewModel(
     INavigationService navigationService) : ObservableObject
 {
     private bool isLoaded;
+    private bool isTrackingCollections;
     private long loadedDataRevision = -1;
 
     public ObservableCollection<RetirementAccountEditorItem> Accounts { get; } = [];
     public ObservableCollection<ProfileRecurringEditorItem> Income { get; } = [];
     public ObservableCollection<ProfileRecurringEditorItem> Expenses { get; } = [];
     public ObservableCollection<ProfileDebtEditorItem> Debts { get; } = [];
-
     [ObservableProperty] private string displayName = string.Empty;
     [ObservableProperty] private string householdName = string.Empty;
     [ObservableProperty] private string householdSizeText = string.Empty;
@@ -54,6 +57,21 @@ public sealed partial class ProfileViewModel(
     public bool HasNoBirthDate => !HasBirthDate;
     public bool HasNoPhasedRetirementDate => !HasPhasedRetirementDate;
     public bool HasNoTargetRetirementDate => !HasTargetRetirementDate;
+
+    /// <summary>
+    /// Explains which figure calculators will actually use, because the itemised list silently wins
+    /// over the single household figure and a user editing both deserves to see that.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasIncomeOverride))]
+    private string incomeOverrideText = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasExpenseOverride))]
+    private string expenseOverrideText = string.Empty;
+
+    public bool HasIncomeOverride => !string.IsNullOrWhiteSpace(IncomeOverrideText);
+    public bool HasExpenseOverride => !string.IsNullOrWhiteSpace(ExpenseOverrideText);
 
     /// <summary>Keeps the birth-date picker from offering a future date the age math cannot use.</summary>
     public DateTime MaximumBirthDate => localDateProvider.Today.ToDateTime(TimeOnly.MinValue);
@@ -97,12 +115,81 @@ public sealed partial class ProfileViewModel(
     /// </summary>
     public void Invalidate() => isLoaded = false;
 
+    /// <summary>
+    /// Subscribes once so the override notices follow the lists, including edits to an existing
+    /// item's amount or period, not just additions and removals.
+    /// </summary>
+    private void TrackRecurringCollections()
+    {
+        if (isTrackingCollections)
+        {
+            return;
+        }
+
+        isTrackingCollections = true;
+        Income.CollectionChanged += OnRecurringCollectionChanged;
+        Expenses.CollectionChanged += OnRecurringCollectionChanged;
+    }
+
+    private void OnRecurringCollectionChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
+    {
+        foreach (var item in eventArgs.OldItems?.OfType<ProfileRecurringEditorItem>() ?? [])
+        {
+            item.PropertyChanged -= OnRecurringItemChanged;
+        }
+
+        foreach (var item in eventArgs.NewItems?.OfType<ProfileRecurringEditorItem>() ?? [])
+        {
+            item.PropertyChanged += OnRecurringItemChanged;
+        }
+
+        UpdateOverrideNotices();
+    }
+
+    private void OnRecurringItemChanged(object? sender, PropertyChangedEventArgs eventArgs)
+    {
+        if (eventArgs.PropertyName is nameof(ProfileRecurringEditorItem.AmountText)
+            or nameof(ProfileRecurringEditorItem.Period))
+        {
+            UpdateOverrideNotices();
+        }
+    }
+
+    /// <summary>
+    /// Recomputes the notices that tell the user the itemised lists are overriding the single
+    /// household figures. Kept live so adding a first income item immediately explains why the
+    /// household number above it stopped mattering.
+    /// </summary>
+    private void UpdateOverrideNotices()
+    {
+        IncomeOverrideText = BuildOverrideText(Income, "income");
+        ExpenseOverrideText = BuildOverrideText(Expenses, "spending");
+    }
+
+    private static string BuildOverrideText(
+        IReadOnlyCollection<ProfileRecurringEditorItem> items,
+        string noun)
+    {
+        if (items.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var total = items.Sum(item => item.TryGetAmount(out var amount)
+            ? CurrencyPeriodMath.Convert(amount, item.Period, CurrencyPeriod.Annual)
+            : 0);
+        var label = items.Count == 1 ? "entry" : "entries";
+        return $"Your {items.Count} {noun} {label} total {total.ToString("C0", CultureInfo.CurrentCulture)} a year, and calculators use that instead of the figure above.";
+    }
+
     public async Task LoadAsync()
     {
         if (isLoaded && loadedDataRevision == profileService.DataRevision)
         {
             return;
         }
+
+        TrackRecurringCollections();
 
         await profileService.LoadAsync();
         ApplyProfile(profileService.Current);

--- a/app/MyFireNumber/ViewModels/SettingsViewModel.cs
+++ b/app/MyFireNumber/ViewModels/SettingsViewModel.cs
@@ -63,7 +63,6 @@ public partial class SettingsViewModel : ObservableObject
         highContrast = behavior.HighContrast;
         showRecommendedBooks = behavior.ShowRecommendedBooks;
         selectedCurrencyOption = currencyPreferencesService.SelectedOption;
-        LoadCalculatorDefaults();
     }
 
     public IReadOnlyList<ThemePreference> ThemeOptions { get; } = Enum.GetValues<ThemePreference>();
@@ -74,38 +73,16 @@ public partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private ThemePreference selectedTheme;
 
-    [ObservableProperty]
-    private string expectedReturnPercent = string.Empty;
 
-    [ObservableProperty]
-    private string inflationRatePercent = string.Empty;
 
-    [ObservableProperty]
-    private string withdrawalRatePercent = string.Empty;
 
-    [ObservableProperty]
-    private double expectedReturnSlider;
 
-    [ObservableProperty]
-    private double inflationRateSlider;
 
-    [ObservableProperty]
-    private double withdrawalRateSlider;
 
-    [ObservableProperty]
-    private string defaultCurrentAge = string.Empty;
 
-    [ObservableProperty]
-    private string defaultRetirementAge = string.Empty;
 
-    [ObservableProperty]
-    private string defaultAnnualIncome = string.Empty;
 
-    [ObservableProperty]
-    private string defaultAnnualExpenses = string.Empty;
 
-    [ObservableProperty]
-    private string defaultsStatus = string.Empty;
 
     [ObservableProperty]
     private string selectedCurrencyOption = CurrencyPreferencesService.DeviceRegion;
@@ -139,25 +116,12 @@ public partial class SettingsViewModel : ObservableObject
 
     public string LaunchDestinationDescription => $"{SelectedLaunchDestination} will open after onboarding.";
 
-    private bool isSynchronizingDefaultPercentages;
 
-    partial void OnExpectedReturnPercentChanged(string value) =>
-        SyncTextToSlider(value, slider => ExpectedReturnSlider = slider);
 
-    partial void OnInflationRatePercentChanged(string value) =>
-        SyncTextToSlider(value, slider => InflationRateSlider = slider);
 
-    partial void OnWithdrawalRatePercentChanged(string value) =>
-        SyncTextToSlider(value, slider => WithdrawalRateSlider = slider);
 
-    partial void OnExpectedReturnSliderChanged(double value) =>
-        SyncSliderToText(value, slider => ExpectedReturnSlider = slider, text => ExpectedReturnPercent = text);
 
-    partial void OnInflationRateSliderChanged(double value) =>
-        SyncSliderToText(value, slider => InflationRateSlider = slider, text => InflationRatePercent = text);
 
-    partial void OnWithdrawalRateSliderChanged(double value) =>
-        SyncSliderToText(value, slider => WithdrawalRateSlider = slider, text => WithdrawalRatePercent = text);
 
     partial void OnSelectedLaunchDestinationChanged(LaunchDestination value) => SaveBehaviorPreferences();
     partial void OnRestoreDraftsChanged(bool value) => SaveBehaviorPreferences();
@@ -178,42 +142,15 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private void SetLaunchDestination(LaunchDestination destination) => SelectedLaunchDestination = destination;
 
+    /// <summary>
+    /// Sends the user to Profile, which now owns their age, retirement date, income, spending, and
+    /// planning assumptions. Settings keeps only app-level preferences such as currency and theme.
+    /// </summary>
     [RelayCommand]
-    private void SaveCalculatorDefaults()
-    {
-        if (!TryParsePercent(ExpectedReturnPercent, out var expectedReturn, 0, 15)
-            || !TryParsePercent(InflationRatePercent, out var inflationRate, 0, 10)
-            || !TryParsePercent(WithdrawalRatePercent, out var withdrawalRate, 2, 6)
-            || !int.TryParse(DefaultCurrentAge, NumberStyles.Integer, CultureInfo.CurrentCulture, out var currentAge)
-            || !int.TryParse(DefaultRetirementAge, NumberStyles.Integer, CultureInfo.CurrentCulture, out var retirementAge)
-            || !double.TryParse(DefaultAnnualIncome, NumberStyles.Number, CultureInfo.CurrentCulture, out var annualIncome)
-            || !double.TryParse(DefaultAnnualExpenses, NumberStyles.Number, CultureInfo.CurrentCulture, out var annualExpenses)
-            || currentAge is < 18 or > 100
-            || retirementAge < currentAge
-            || retirementAge > 100
-            || annualIncome < 0
-            || annualExpenses < 0)
-        {
-            DefaultsStatus = "Enter an expected return of 0% to 15%, inflation of 0% to 10%, a withdrawal rate of 2% to 6%, ages from 18 to 100, and non-negative annual income and expenses. Retirement age cannot be earlier than your current age.";
-            return;
-        }
-
-        calculatorDefaultsService.Save(new CalculatorDefaults(
-            expectedReturn,
-            inflationRate,
-            withdrawalRate,
-            currentAge,
-            retirementAge)
-        {
-            AnnualIncome = annualIncome,
-            AnnualExpenses = annualExpenses
-        });
-        DefaultsStatus = "Saved. These assumptions apply only to new calculators.";
-    }
+    private Task OpenProfileAsync() => navigationService.GoToAsync("//profile");
 
     public async Task LoadAsync()
     {
-        LoadCalculatorDefaults();
         var storedPreferences = await preferencesRepository.ListAsync();
         var preferencesByCalculator = storedPreferences.ToDictionary(preference => preference.CalculatorId);
         CalculatorPreferences.Clear();
@@ -384,72 +321,6 @@ public partial class SettingsViewModel : ObservableObject
             item.SortOrder));
     }
 
-    private void LoadCalculatorDefaults()
-    {
-        var defaults = calculatorDefaultsService.Current;
-        isSynchronizingDefaultPercentages = true;
-        ExpectedReturnPercent = (defaults.ExpectedReturn * 100).ToString("0.##", CultureInfo.CurrentCulture);
-        InflationRatePercent = (defaults.InflationRate * 100).ToString("0.##", CultureInfo.CurrentCulture);
-        WithdrawalRatePercent = (defaults.WithdrawalRate * 100).ToString("0.##", CultureInfo.CurrentCulture);
-        ExpectedReturnSlider = defaults.ExpectedReturn * 100;
-        InflationRateSlider = defaults.InflationRate * 100;
-        WithdrawalRateSlider = defaults.WithdrawalRate * 100;
-        isSynchronizingDefaultPercentages = false;
-        DefaultCurrentAge = defaults.CurrentAge.ToString(CultureInfo.CurrentCulture);
-        DefaultRetirementAge = defaults.RetirementAge.ToString(CultureInfo.CurrentCulture);
-        DefaultAnnualIncome = defaults.AnnualIncome.ToString("0", CultureInfo.CurrentCulture);
-        DefaultAnnualExpenses = defaults.AnnualExpenses.ToString("0", CultureInfo.CurrentCulture);
-        DefaultsStatus = string.Empty;
-    }
-
-    /// <summary>
-    /// Parses a default percentage against the same bounds the calculators enforce, so a saved
-    /// default can never be rejected by the calculator that consumes it.
-    /// </summary>
-    private static bool TryParsePercent(string text, out double value, double minimumPercent, double maximumPercent)
-    {
-        if (double.TryParse(text, NumberStyles.Number, CultureInfo.CurrentCulture, out var percent)
-            && percent >= minimumPercent
-            && percent <= maximumPercent)
-        {
-            value = percent / 100;
-            return true;
-        }
-
-        value = 0;
-        return false;
-    }
-
-    private void SyncTextToSlider(string text, Action<double> updateSlider)
-    {
-        if (isSynchronizingDefaultPercentages ||
-            !double.TryParse(text, NumberStyles.Number, CultureInfo.CurrentCulture, out var value))
-        {
-            return;
-        }
-
-        isSynchronizingDefaultPercentages = true;
-        updateSlider(value);
-        isSynchronizingDefaultPercentages = false;
-    }
-
-    private void SyncSliderToText(double value, Action<double> updateSlider, Action<string> updateText)
-    {
-        if (isSynchronizingDefaultPercentages)
-        {
-            return;
-        }
-
-        var rounded = Math.Round(value, 1);
-        isSynchronizingDefaultPercentages = true;
-        if (Math.Abs(value - rounded) > double.Epsilon)
-        {
-            updateSlider(rounded);
-        }
-
-        updateText(rounded.ToString("0.0", CultureInfo.CurrentCulture));
-        isSynchronizingDefaultPercentages = false;
-    }
 
     private void SaveBehaviorPreferences()
     {

--- a/app/MyFireNumber/ViewModels/TimelineOnboardingViewModel.cs
+++ b/app/MyFireNumber/ViewModels/TimelineOnboardingViewModel.cs
@@ -1,0 +1,161 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using MyFireNumber.Core.Profile;
+using MyFireNumber.Services;
+
+namespace MyFireNumber.ViewModels;
+
+public partial class TimelineOnboardingViewModel : ObservableObject
+{
+    private const double RoundingTolerance = 0.000001;
+    private const int MinimumRetirementAge = 30;
+    private const int HighestRetirementAge = 90;
+    private readonly ICalculatorDefaultsService calculatorDefaultsService;
+    private readonly ILocalDateProvider localDateProvider;
+    private readonly INavigationService navigationService;
+    private readonly IProfileService profileService;
+
+    public TimelineOnboardingViewModel(
+        ICalculatorDefaultsService calculatorDefaultsService,
+        ILocalDateProvider localDateProvider,
+        INavigationService navigationService,
+        IProfileService profileService)
+    {
+        this.calculatorDefaultsService = calculatorDefaultsService;
+        this.localDateProvider = localDateProvider;
+        this.navigationService = navigationService;
+        this.profileService = profileService;
+
+        var defaults = calculatorDefaultsService.Current;
+        var profile = profileService.Current;
+        currentAge = profileService.DerivedCurrentAge ?? defaults.CurrentAge;
+        ageRange = ProfileAgeCalculator.RetirementAgeRange(currentAge, MinimumRetirementAge, HighestRetirementAge);
+        retirementAge = Math.Clamp(
+            (double)(profileService.DerivedTargetRetirementAge ?? defaults.RetirementAge),
+            ageRange.Minimum,
+            ageRange.Maximum);
+        hasPhasedRetirement = profile.PhasedRetirementDate is not null;
+        phasedRetirementAge = Math.Clamp(
+            (double)(profileService.DerivedPhasedRetirementAge ?? (int)retirementAge),
+            ageRange.Minimum,
+            retirementAge);
+    }
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(RetirementAgeText))]
+    [NotifyPropertyChangedFor(nameof(TimelineSummary))]
+    private double retirementAge;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PhasedRetirementAgeText))]
+    [NotifyPropertyChangedFor(nameof(TimelineSummary))]
+    private double phasedRetirementAge;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TimelineSummary))]
+    [NotifyPropertyChangedFor(nameof(HasNoPhasedRetirement))]
+    private bool hasPhasedRetirement;
+
+    private readonly int currentAge;
+    private readonly (int Minimum, int Maximum) ageRange;
+
+    public bool HasNoPhasedRetirement => !HasPhasedRetirement;
+
+    /// <summary>
+    /// Never exceeds <see cref="MaximumRetirementAge"/>. Someone already older than the slider's top
+    /// value would otherwise produce a minimum above the maximum, which the slider cannot represent.
+    /// </summary>
+    public double MinimumAllowedRetirementAge => ageRange.Minimum;
+
+    public double MaximumRetirementAge => ageRange.Maximum;
+    public string RetirementAgeText => $"{RetirementAge:0}";
+    public string PhasedRetirementAgeText => $"{PhasedRetirementAge:0}";
+    public bool HasBirthDate => profileService.Current.BirthDate is not null;
+
+    public string TimelineSummary
+    {
+        get
+        {
+            if (!HasBirthDate)
+            {
+                return "Add a birth date in Profile to turn these ages into dates. Until then they are saved as calculator starting points.";
+            }
+
+            var yearsAway = Math.Max(0, (int)RetirementAge - currentAge);
+            var target = $"You plan to retire fully at {RetirementAge:0}, about {yearsAway} years from now.";
+            return HasPhasedRetirement
+                ? $"{target} You expect to step back to part-time work at {PhasedRetirementAge:0}."
+                : target;
+        }
+    }
+
+    partial void OnRetirementAgeChanged(double value)
+    {
+        RoundSliderValue(value, rounded => RetirementAge = rounded, 1);
+
+        // Full retirement can never come before the phased step, so pull the phased age down with it
+        // rather than saving a pair the profile would reject.
+        if (PhasedRetirementAge > RetirementAge)
+        {
+            PhasedRetirementAge = RetirementAge;
+        }
+    }
+
+    partial void OnPhasedRetirementAgeChanged(double value)
+    {
+        RoundSliderValue(value, rounded => PhasedRetirementAge = rounded, 1);
+        if (PhasedRetirementAge > RetirementAge)
+        {
+            PhasedRetirementAge = RetirementAge;
+        }
+    }
+
+    [RelayCommand]
+    private void AddPhasedRetirement() => HasPhasedRetirement = true;
+
+    [RelayCommand]
+    private void RemovePhasedRetirement() => HasPhasedRetirement = false;
+
+    [RelayCommand]
+    private async Task SaveAndContinueAsync()
+    {
+        calculatorDefaultsService.Save(calculatorDefaultsService.Current with
+        {
+            RetirementAge = (int)RetirementAge
+        });
+
+        // Ages only become profile dates once a birth date anchors them.
+        if (profileService.Current.BirthDate is DateOnly birthDate)
+        {
+            try
+            {
+                await profileService.SaveAsync(profileService.Current with
+                {
+                    TargetRetirementDate = ProfileAgeCalculator.DateAtAge(birthDate, (int)RetirementAge),
+                    PhasedRetirementDate = HasPhasedRetirement
+                        ? ProfileAgeCalculator.DateAtAge(birthDate, (int)PhasedRetirementAge)
+                        : null
+                });
+            }
+            catch (Exception)
+            {
+                // Onboarding must never dead-end. The calculator defaults above already carry the
+                // chosen retirement age, and Profile can be completed later.
+            }
+        }
+
+        await navigationService.GoToAsync("../onboarding-withdrawal-rate");
+    }
+
+    [RelayCommand]
+    private Task SkipAsync() => navigationService.GoToAsync("../onboarding-withdrawal-rate");
+
+    private static void RoundSliderValue(double value, Action<double> update, double increment)
+    {
+        var rounded = Math.Round(value / increment) * increment;
+        if (Math.Abs(value - rounded) > RoundingTolerance)
+        {
+            update(rounded);
+        }
+    }
+}

--- a/app/MyFireNumber/Views/DefaultsOnboardingPage.xaml
+++ b/app/MyFireNumber/Views/DefaultsOnboardingPage.xaml
@@ -13,20 +13,20 @@
     <ContentPage.ToolbarItems>
         <ToolbarItem Text="Skip"
                      Command="{Binding SkipCommand}"
-                     SemanticProperties.Description="Skip these details and continue to withdrawal rate." />
+                     SemanticProperties.Description="Skip these details and continue to your timeline." />
     </ContentPage.ToolbarItems>
 
     <Grid>
         <ScrollView>
             <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
                 <VerticalStackLayout Spacing="6">
-                    <Label Text="Tell us about today"
+                    <Label Text="Tell us about you"
                            FontSize="28"
                            FontAttributes="Bold"
                            LineHeight="1.1"
                            TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
                            SemanticProperties.HeadingLevel="Level1" />
-                    <Label Text="These three details give your calculators a useful starting point. You can fine-tune everything later."
+                    <Label Text="These details personalize your plans and give every calculator a useful starting point. Everything stays on this device, and you can change it later in Profile."
                            LineHeight="1.35"
                            TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
                 </VerticalStackLayout>
@@ -37,22 +37,74 @@
                         StrokeShape="RoundRectangle 12">
                     <VerticalStackLayout Spacing="{StaticResource SpaceXl}">
                         <VerticalStackLayout Spacing="6">
+                            <Label Text="What should we call you?"
+                                   FontAttributes="Bold"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+                            <Entry AutomationId="OnboardingDisplayNameEntry"
+                                   Text="{Binding DisplayName, Mode=TwoWay}"
+                                   Placeholder="Name (optional)"
+                                   Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
+                                   PlaceholderColor="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}"
+                                   SemanticProperties.Description="Your name, used to personalize the app. Optional." />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout Spacing="6">
                             <Grid ColumnDefinitions="*,Auto">
-                                <Label Text="Current age"
+                                <Label Text="Birth date"
+                                       FontAttributes="Bold"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+                                <Button Grid.Column="1"
+                                        AutomationId="OnboardingSkipBirthDateButton"
+                                        Text="Skip"
+                                        FontSize="12"
+                                        Padding="12,4"
+                                        IsVisible="{Binding HasBirthDate}"
+                                        Command="{Binding SkipBirthDateCommand}"
+                                        Background="Transparent"
+                                        TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
+                                        SemanticProperties.Description="Continue without sharing a birth date." />
+                                <Button Grid.Column="1"
+                                        AutomationId="OnboardingUseBirthDateButton"
+                                        Text="Add"
+                                        FontSize="12"
+                                        Padding="12,4"
+                                        IsVisible="{Binding HasNoBirthDate}"
+                                        Command="{Binding UseBirthDateCommand}"
+                                        Background="Transparent"
+                                        TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
+                                        SemanticProperties.Description="Add your birth date." />
+                            </Grid>
+                            <DatePicker AutomationId="OnboardingBirthDatePicker"
+                                        Date="{Binding BirthDate, Mode=TwoWay}"
+                                        MaximumDate="{Binding MaximumBirthDate}"
+                                        IsVisible="{Binding HasBirthDate}"
+                                        Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
+                                        TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
+                                        SemanticProperties.Description="Your birth date" />
+                            <Label Text="{Binding DerivedAgeText}"
+                                   FontSize="12"
+                                   LineHeight="1.3"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout Spacing="6">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <Label Text="Household size"
                                        FontAttributes="Bold"
                                        TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
                                 <Label Grid.Column="1"
-                                       Text="{Binding CurrentAgeText}"
+                                       Text="{Binding HouseholdSizeText}"
                                        TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
                             </Grid>
-                            <Slider AutomationId="OnboardingCurrentAgeSlider"
-                                    Minimum="18"
-                                    Maximum="80"
-                                    Value="{Binding CurrentAge}"
+                            <Slider AutomationId="OnboardingHouseholdSizeSlider"
+                                    Minimum="1"
+                                    Maximum="{Binding MaximumHouseholdSize}"
+                                    Value="{Binding HouseholdSize, Mode=TwoWay}"
                                     MinimumTrackColor="{StaticResource FixedAccent}"
                                     MaximumTrackColor="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
                                     ThumbColor="{StaticResource FixedAccent}"
-                                    SemanticProperties.Description="Current age" />
+                                    SemanticProperties.Description="Number of people your plan supports" />
                         </VerticalStackLayout>
 
                         <VerticalStackLayout Spacing="6">
@@ -100,7 +152,7 @@
                         Command="{Binding SaveAndContinueCommand}"
                         Background="{StaticResource FixedAccent}"
                         TextColor="{StaticResource FixedWhite}"
-                        SemanticProperties.Description="Save these details and continue to withdrawal rate." />
+                        SemanticProperties.Description="Save these details and continue to your timeline." />
 
                 <controls:EducationalDisclaimerView />
             </VerticalStackLayout>

--- a/app/MyFireNumber/Views/HomePage.xaml
+++ b/app/MyFireNumber/Views/HomePage.xaml
@@ -22,6 +22,14 @@
                            SemanticProperties.Description="Financial progress" />
                     <VerticalStackLayout Grid.Column="1" Spacing="{StaticResource SpaceSm}">
                     <Label Text="MY FIRE NUMBER"
+                           IsVisible="{Binding HasNoGreeting}"
+                           TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
+                           FontAttributes="Bold"
+                           FontSize="12"
+                           CharacterSpacing="1.2" />
+                    <Label Text="{Binding Greeting}"
+                           AutomationId="HomeGreeting"
+                           IsVisible="{Binding HasGreeting}"
                            TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                            FontAttributes="Bold"
                            FontSize="12"

--- a/app/MyFireNumber/Views/ProfilePage.xaml
+++ b/app/MyFireNumber/Views/ProfilePage.xaml
@@ -284,12 +284,24 @@
                                                    Placeholder="120000"
                                                    PeriodSuffix="/yr"
                                                    Text="{Binding AnnualIncomeText, Mode=TwoWay}" />
+                        <Label AutomationId="ProfileIncomeOverrideNotice"
+                               Text="{Binding IncomeOverrideText}"
+                               IsVisible="{Binding HasIncomeOverride}"
+                               FontSize="11"
+                               LineHeight="1.3"
+                               TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
                         <controls:NumericInputView AutomationId="ProfileAnnualExpensesInput"
                                                    Header="Annual household spending"
                                                    HelpText="What your household spends each year, before retirement."
                                                    Placeholder="72000"
                                                    PeriodSuffix="/yr"
                                                    Text="{Binding AnnualExpensesText, Mode=TwoWay}" />
+                        <Label AutomationId="ProfileExpenseOverrideNotice"
+                               Text="{Binding ExpenseOverrideText}"
+                               IsVisible="{Binding HasExpenseOverride}"
+                               FontSize="11"
+                               LineHeight="1.3"
+                               TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
                     </VerticalStackLayout>
                 </Border>
 

--- a/app/MyFireNumber/Views/ProfilePage.xaml
+++ b/app/MyFireNumber/Views/ProfilePage.xaml
@@ -58,14 +58,32 @@
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Grid ColumnDefinitions="*,Auto"><Label Text="Recurring income" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Add" Command="{Binding AddIncomeCommand}" /></Grid>
                         <VerticalStackLayout BindableLayout.ItemsSource="{Binding Income}" Spacing="{StaticResource SpaceSm}">
-                            <BindableLayout.EmptyView><Label Text="No recurring income yet." /></BindableLayout.EmptyView>
+                            <BindableLayout.EmptyView><Label Text="No recurring income yet." FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" /></BindableLayout.EmptyView>
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:ProfileRecurringEditorItem">
                                     <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}" StrokeThickness="0" StrokeShape="RoundRectangle 8">
                                         <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
-                                            <Grid ColumnDefinitions="*,Auto"><Entry Text="{Binding Name, Mode=TwoWay}" Placeholder="Income name" /><Button Grid.Column="1" Text="Delete" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveIncomeCommand}" CommandParameter="{Binding .}" /></Grid>
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}"><Entry Text="{Binding AmountText, Mode=TwoWay}" Keyboard="Numeric" Placeholder="Amount" /><Picker Grid.Column="1" ItemsSource="{Binding Periods}" SelectedItem="{Binding Period, Mode=TwoWay}" /></Grid>
-                                            <Entry Text="{Binding Category, Mode=TwoWay}" Placeholder="Category (optional)" />
+                                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Income name" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding Name, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="Salary" SemanticProperties.Description="Name of this recurring income" />
+                                                </VerticalStackLayout>
+                                                <Button Grid.Column="1" Text="Delete" VerticalOptions="End" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveIncomeCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} income.'}" />
+                                            </Grid>
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Amount" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding AmountText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Recurring income amount" />
+                                                </VerticalStackLayout>
+                                                <VerticalStackLayout Grid.Column="1" Spacing="3">
+                                                    <Label Text="How often" Style="{StaticResource FormFieldLabel}" />
+                                                    <Picker Title="How often" ItemsSource="{Binding Periods}" SelectedItem="{Binding Period, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="How often this income is received" />
+                                                </VerticalStackLayout>
+                                            </Grid>
+                                            <VerticalStackLayout Spacing="3">
+                                                <Label Text="Category (optional)" Style="{StaticResource FormFieldLabel}" />
+                                                <Entry Text="{Binding Category, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="Work" SemanticProperties.Description="Category for this income" />
+                                            </VerticalStackLayout>
                                         </VerticalStackLayout>
                                     </Border>
                                 </DataTemplate>
@@ -81,14 +99,32 @@
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Grid ColumnDefinitions="*,Auto"><Label Text="Recurring expenses" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Add" Command="{Binding AddExpenseCommand}" /></Grid>
                         <VerticalStackLayout BindableLayout.ItemsSource="{Binding Expenses}" Spacing="{StaticResource SpaceSm}">
-                            <BindableLayout.EmptyView><Label Text="No recurring expenses yet." /></BindableLayout.EmptyView>
+                            <BindableLayout.EmptyView><Label Text="No recurring expenses yet." FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" /></BindableLayout.EmptyView>
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:ProfileRecurringEditorItem">
                                     <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}" StrokeThickness="0" StrokeShape="RoundRectangle 8">
                                         <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
-                                            <Grid ColumnDefinitions="*,Auto"><Entry Text="{Binding Name, Mode=TwoWay}" Placeholder="Expense name" /><Button Grid.Column="1" Text="Delete" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveExpenseCommand}" CommandParameter="{Binding .}" /></Grid>
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}"><Entry Text="{Binding AmountText, Mode=TwoWay}" Keyboard="Numeric" Placeholder="Amount" /><Picker Grid.Column="1" ItemsSource="{Binding Periods}" SelectedItem="{Binding Period, Mode=TwoWay}" /></Grid>
-                                            <Entry Text="{Binding Category, Mode=TwoWay}" Placeholder="Category (optional)" />
+                                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Expense name" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding Name, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="Housing" SemanticProperties.Description="Name of this recurring expense" />
+                                                </VerticalStackLayout>
+                                                <Button Grid.Column="1" Text="Delete" VerticalOptions="End" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveExpenseCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} expense.'}" />
+                                            </Grid>
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Amount" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding AmountText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Recurring expense amount" />
+                                                </VerticalStackLayout>
+                                                <VerticalStackLayout Grid.Column="1" Spacing="3">
+                                                    <Label Text="How often" Style="{StaticResource FormFieldLabel}" />
+                                                    <Picker Title="How often" ItemsSource="{Binding Periods}" SelectedItem="{Binding Period, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="How often this expense is paid" />
+                                                </VerticalStackLayout>
+                                            </Grid>
+                                            <VerticalStackLayout Spacing="3">
+                                                <Label Text="Category (optional)" Style="{StaticResource FormFieldLabel}" />
+                                                <Entry Text="{Binding Category, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="Home" SemanticProperties.Description="Category for this expense" />
+                                            </VerticalStackLayout>
                                         </VerticalStackLayout>
                                     </Border>
                                 </DataTemplate>
@@ -104,14 +140,32 @@
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Grid ColumnDefinitions="*,Auto"><Label Text="Debts" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Add" Command="{Binding AddDebtCommand}" /></Grid>
                         <VerticalStackLayout BindableLayout.ItemsSource="{Binding Debts}" Spacing="{StaticResource SpaceSm}">
-                            <BindableLayout.EmptyView><Label Text="No debts saved." /></BindableLayout.EmptyView>
+                            <BindableLayout.EmptyView><Label Text="No debts saved." FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" /></BindableLayout.EmptyView>
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:ProfileDebtEditorItem">
                                     <Border Padding="{StaticResource CardPaddingCompact}" Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}" StrokeThickness="0" StrokeShape="RoundRectangle 8">
                                         <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
-                                            <Grid ColumnDefinitions="*,Auto"><Entry Text="{Binding Name, Mode=TwoWay}" Placeholder="Debt name" /><Button Grid.Column="1" Text="Delete" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveDebtCommand}" CommandParameter="{Binding .}" /></Grid>
-                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}"><Entry Text="{Binding BalanceText, Mode=TwoWay}" Keyboard="Numeric" Placeholder="Balance" /><Entry Grid.Column="1" Text="{Binding RateText, Mode=TwoWay}" Keyboard="Numeric" Placeholder="Rate (%)" /></Grid>
-                                            <Entry Text="{Binding MinimumPaymentText, Mode=TwoWay}" Keyboard="Numeric" Placeholder="Minimum monthly payment" />
+                                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="{StaticResource SpaceSm}">
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Debt name" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding Name, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="Credit card" SemanticProperties.Description="Name of this debt" />
+                                                </VerticalStackLayout>
+                                                <Button Grid.Column="1" Text="Delete" VerticalOptions="End" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveDebtCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} debt.'}" />
+                                            </Grid>
+                                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Balance" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding BalanceText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="5000" SemanticProperties.Description="Current balance owed on this debt" />
+                                                </VerticalStackLayout>
+                                                <VerticalStackLayout Grid.Column="1" Spacing="3">
+                                                    <Label Text="Interest rate (%)" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding RateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="19.99" SemanticProperties.Description="Annual interest rate percentage for this debt" />
+                                                </VerticalStackLayout>
+                                            </Grid>
+                                            <VerticalStackLayout Spacing="3">
+                                                <Label Text="Minimum monthly payment" Style="{StaticResource FormFieldLabel}" />
+                                                <Entry Text="{Binding MinimumPaymentText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="150" SemanticProperties.Description="Minimum monthly payment for this debt" />
+                                            </VerticalStackLayout>
                                         </VerticalStackLayout>
                                     </Border>
                                 </DataTemplate>
@@ -126,25 +180,31 @@
                         StrokeShape="RoundRectangle 12">
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Label Text="About you" Style="{StaticResource CalculatorSectionHeading}" />
-                        <Entry AutomationId="ProfileDisplayNameEntry"
-                               Text="{Binding DisplayName, Mode=TwoWay}"
-                               Placeholder="Name (optional)"
-                               Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
-                               TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                               PlaceholderColor="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
-                        <Entry AutomationId="ProfileHouseholdNameEntry"
-                               Text="{Binding HouseholdName, Mode=TwoWay}"
-                               Placeholder="Household name (optional)"
-                               Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
-                               TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                               PlaceholderColor="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
-                        <Entry AutomationId="ProfileHouseholdSizeEntry"
-                               Text="{Binding HouseholdSizeText, Mode=TwoWay}"
-                               Placeholder="Household size (optional)"
-                               Keyboard="Numeric"
-                               Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
-                               TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                               PlaceholderColor="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Name (optional)" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileDisplayNameEntry"
+                                   Text="{Binding DisplayName, Mode=TwoWay}"
+                                   Style="{StaticResource FormEntry}"
+                                   Placeholder="Alex"
+                                   SemanticProperties.Description="Your name, used to personalize the app" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Household name (optional)" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileHouseholdNameEntry"
+                                   Text="{Binding HouseholdName, Mode=TwoWay}"
+                                   Style="{StaticResource FormEntry}"
+                                   Placeholder="The Smith household"
+                                   SemanticProperties.Description="A label for your household" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Household size (optional)" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileHouseholdSizeEntry"
+                                   Text="{Binding HouseholdSizeText, Mode=TwoWay}"
+                                   Style="{StaticResource FormEntry}"
+                                   Placeholder="2"
+                                   Keyboard="Numeric"
+                                   SemanticProperties.Description="Number of people your plan supports" />
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
 
@@ -168,8 +228,7 @@
                                         Date="{Binding BirthDate, Mode=TwoWay}"
                                         MaximumDate="{Binding MaximumBirthDate}"
                                         IsVisible="{Binding HasBirthDate}"
-                                        Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
-                                        TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
+                                        Style="{StaticResource FormDatePicker}"
                                         SemanticProperties.Description="Birth date" />
                         </VerticalStackLayout>
                         <VerticalStackLayout Spacing="4">
@@ -182,8 +241,7 @@
                             <DatePicker AutomationId="ProfilePhasedRetirementDatePicker"
                                         Date="{Binding PhasedRetirementDate, Mode=TwoWay}"
                                         IsVisible="{Binding HasPhasedRetirementDate}"
-                                        Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
-                                        TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
+                                        Style="{StaticResource FormDatePicker}"
                                         SemanticProperties.Description="Phased retirement date" />
                         </VerticalStackLayout>
                         <VerticalStackLayout Spacing="4">
@@ -196,8 +254,7 @@
                             <DatePicker AutomationId="ProfileTargetRetirementDatePicker"
                                         Date="{Binding TargetRetirementDate, Mode=TwoWay}"
                                         IsVisible="{Binding HasTargetRetirementDate}"
-                                        Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}"
-                                        TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
+                                        Style="{StaticResource FormDatePicker}"
                                         SemanticProperties.Description="Full retirement date" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
@@ -209,8 +266,14 @@
                         StrokeShape="RoundRectangle 12">
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Label Text="Household defaults" Style="{StaticResource CalculatorSectionHeading}" />
-                        <Entry AutomationId="ProfileAnnualIncomeEntry" Text="{Binding AnnualIncomeText, Mode=TwoWay}" Keyboard="Numeric" Placeholder="Annual household income" Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" PlaceholderColor="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
-                        <Entry AutomationId="ProfileAnnualExpensesEntry" Text="{Binding AnnualExpensesText, Mode=TwoWay}" Keyboard="Numeric" Placeholder="Annual household spending" Background="{AppThemeBinding Light={StaticResource SurfaceCardFlatLight}, Dark={StaticResource SurfaceCardFlatDark}}" TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" PlaceholderColor="{AppThemeBinding Light={StaticResource PlaceholderLight}, Dark={StaticResource PlaceholderDark}}" />
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Annual household income" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileAnnualIncomeEntry" Text="{Binding AnnualIncomeText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="120000" SemanticProperties.Description="Annual after-tax household income in dollars" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Annual household spending" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileAnnualExpensesEntry" Text="{Binding AnnualExpensesText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="72000" SemanticProperties.Description="Annual household spending in dollars" />
+                        </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
 
@@ -228,7 +291,7 @@
                                TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
                         <VerticalStackLayout BindableLayout.ItemsSource="{Binding Accounts}" Spacing="{StaticResource SpaceSm}">
                             <BindableLayout.EmptyView>
-                                <Label Text="No reusable accounts yet." />
+                                <Label Text="No reusable accounts yet." FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
                             </BindableLayout.EmptyView>
                             <BindableLayout.ItemTemplate>
                                 <DataTemplate x:DataType="viewModels:RetirementAccountEditorItem">
@@ -243,20 +306,47 @@
                                                 <Button Grid.Column="2" Text="Delete" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveAccountCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} account.'}" />
                                             </Grid>
                                             <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="{StaticResource SpaceSm}">
-                                                <Entry Text="{Binding Name, Mode=TwoWay}" Placeholder="Account name" />
-                                                <Picker Title="Account type" ItemsSource="{Binding AccountTypes}" SelectedItem="{Binding Type, Mode=TwoWay}" />
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Account name" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding Name, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="401(k)" SemanticProperties.Description="Account name" />
+                                                </VerticalStackLayout>
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Account type" Style="{StaticResource FormFieldLabel}" />
+                                                    <Picker Title="Account type" ItemsSource="{Binding AccountTypes}" SelectedItem="{Binding Type, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="Account type" />
+                                                </VerticalStackLayout>
                                                 <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                    <Entry Placeholder="Balance" Text="{Binding BalanceText, Mode=TwoWay}" Keyboard="Numeric" />
-                                                    <Entry Grid.Column="1" Placeholder="Annual contribution" Text="{Binding AnnualContributionText, Mode=TwoWay}" Keyboard="Numeric" />
+                                                    <VerticalStackLayout Spacing="3">
+                                                        <Label Text="Balance" Style="{StaticResource FormFieldLabel}" />
+                                                        <Entry Text="{Binding BalanceText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Current account balance in dollars" />
+                                                    </VerticalStackLayout>
+                                                    <VerticalStackLayout Grid.Column="1" Spacing="3">
+                                                        <Label Text="Annual contribution" Style="{StaticResource FormFieldLabel}" />
+                                                        <Entry Text="{Binding AnnualContributionText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Annual account contribution in dollars" />
+                                                    </VerticalStackLayout>
                                                 </Grid>
                                                 <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                    <Entry Placeholder="Expected return (%)" Text="{Binding AnnualReturnText, Mode=TwoWay}" Keyboard="Numeric" />
-                                                    <Entry Grid.Column="1" Placeholder="Available age" Text="{Binding AvailableAgeText, Mode=TwoWay}" Keyboard="Numeric" />
+                                                    <VerticalStackLayout Spacing="3">
+                                                        <Label Text="Expected return (%)" Style="{StaticResource FormFieldLabel}" />
+                                                        <Entry Text="{Binding AnnualReturnText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="5" SemanticProperties.Description="Expected annual account return percentage" />
+                                                    </VerticalStackLayout>
+                                                    <VerticalStackLayout Grid.Column="1" Spacing="3">
+                                                        <Label Text="Available age" Style="{StaticResource FormFieldLabel}" />
+                                                        <Entry Text="{Binding AvailableAgeText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="59" SemanticProperties.Description="Age when this account becomes available" />
+                                                    </VerticalStackLayout>
                                                 </Grid>
-                                                <Entry IsVisible="{Binding UsesWithdrawalRate}" Placeholder="Withdrawal rate (%)" Text="{Binding WithdrawalRateText, Mode=TwoWay}" Keyboard="Numeric" />
-                                                <Entry IsVisible="{Binding UsesPayoutSchedule}" Placeholder="Payout years" Text="{Binding PayoutYearsText, Mode=TwoWay}" Keyboard="Numeric" />
-                                                <Entry Placeholder="Withdrawal tax rate (%)" Text="{Binding WithdrawalTaxRateText, Mode=TwoWay}" Keyboard="Numeric" />
-                                                <Label Text="{Binding WithdrawalTaxHelpText}" FontSize="11" />
+                                                <VerticalStackLayout IsVisible="{Binding UsesWithdrawalRate}" Spacing="3">
+                                                    <Label Text="Withdrawal rate (%)" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding WithdrawalRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="4" SemanticProperties.Description="Annual account withdrawal rate percentage" />
+                                                </VerticalStackLayout>
+                                                <VerticalStackLayout IsVisible="{Binding UsesPayoutSchedule}" Spacing="3">
+                                                    <Label Text="Payout years" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding PayoutYearsText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="5" SemanticProperties.Description="Number of years receiving equal payouts" />
+                                                </VerticalStackLayout>
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Withdrawal tax rate (%)" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding WithdrawalTaxRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Flat estimated tax rate applied to withdrawals from this account" />
+                                                    <Label Text="{Binding WithdrawalTaxHelpText}" FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                                                </VerticalStackLayout>
                                             </VerticalStackLayout>
                                         </VerticalStackLayout>
                                     </Border>

--- a/app/MyFireNumber/Views/ProfilePage.xaml
+++ b/app/MyFireNumber/Views/ProfilePage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:MyFireNumber.Views.Controls"
              xmlns:viewModels="clr-namespace:MyFireNumber.ViewModels"
              x:Class="MyFireNumber.Views.ProfilePage"
              x:DataType="viewModels:ProfileViewModel"
@@ -79,10 +80,10 @@
                                                 <Button Grid.Column="1" Text="Delete" VerticalOptions="End" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveIncomeCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} income.'}" />
                                             </Grid>
                                             <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                <VerticalStackLayout Spacing="3">
-                                                    <Label Text="Amount" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding AmountText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Recurring income amount" />
-                                                </VerticalStackLayout>
+                                                <controls:NumericInputView Header="Amount"
+                                                                           HelpText="Recurring income amount for the period you choose."
+                                                                           Placeholder="0"
+                                                                           Text="{Binding AmountText, Mode=TwoWay}" />
                                                 <VerticalStackLayout Grid.Column="1" Spacing="3">
                                                     <Label Text="How often" Style="{StaticResource FormFieldLabel}" />
                                                     <Picker Title="How often" ItemsSource="{Binding Periods}" SelectedItem="{Binding Period, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="How often this income is received" />
@@ -120,10 +121,10 @@
                                                 <Button Grid.Column="1" Text="Delete" VerticalOptions="End" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveExpenseCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} expense.'}" />
                                             </Grid>
                                             <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                <VerticalStackLayout Spacing="3">
-                                                    <Label Text="Amount" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding AmountText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Recurring expense amount" />
-                                                </VerticalStackLayout>
+                                                <controls:NumericInputView Header="Amount"
+                                                                           HelpText="Recurring expense amount for the period you choose."
+                                                                           Placeholder="0"
+                                                                           Text="{Binding AmountText, Mode=TwoWay}" />
                                                 <VerticalStackLayout Grid.Column="1" Spacing="3">
                                                     <Label Text="How often" Style="{StaticResource FormFieldLabel}" />
                                                     <Picker Title="How often" ItemsSource="{Binding Periods}" SelectedItem="{Binding Period, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="How often this expense is paid" />
@@ -161,19 +162,22 @@
                                                 <Button Grid.Column="1" Text="Delete" VerticalOptions="End" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveDebtCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} debt.'}" />
                                             </Grid>
                                             <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                <VerticalStackLayout Spacing="3">
-                                                    <Label Text="Balance" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding BalanceText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="5000" SemanticProperties.Description="Current balance owed on this debt" />
-                                                </VerticalStackLayout>
-                                                <VerticalStackLayout Grid.Column="1" Spacing="3">
-                                                    <Label Text="Interest rate (%)" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding RateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="19.99" SemanticProperties.Description="Annual interest rate percentage for this debt" />
-                                                </VerticalStackLayout>
+                                                <controls:NumericInputView Header="Balance"
+                                                                           HelpText="Amount still owed on this debt."
+                                                                           Placeholder="5000"
+                                                                           Text="{Binding BalanceText, Mode=TwoWay}" />
+                                                <controls:NumericInputView Grid.Column="1"
+                                                                           Header="Interest rate"
+                                                                           HelpText="Annual interest rate charged on this debt."
+                                                                           Placeholder="19.99"
+                                                                           PeriodSuffix="%"
+                                                                           Text="{Binding RateText, Mode=TwoWay}" />
                                             </Grid>
-                                            <VerticalStackLayout Spacing="3">
-                                                <Label Text="Minimum monthly payment" Style="{StaticResource FormFieldLabel}" />
-                                                <Entry Text="{Binding MinimumPaymentText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="150" SemanticProperties.Description="Minimum monthly payment for this debt" />
-                                            </VerticalStackLayout>
+                                            <controls:NumericInputView Header="Minimum payment"
+                                                                       HelpText="Smallest payment you must make each month."
+                                                                       Placeholder="150"
+                                                                       PeriodSuffix="/mo"
+                                                                       Text="{Binding MinimumPaymentText, Mode=TwoWay}" />
                                         </VerticalStackLayout>
                                     </Border>
                                 </DataTemplate>
@@ -274,14 +278,18 @@
                         StrokeShape="RoundRectangle 12">
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Label Text="Household defaults" Style="{StaticResource CalculatorSectionHeading}" />
-                        <VerticalStackLayout Spacing="3">
-                            <Label Text="Annual household income" Style="{StaticResource FormFieldLabel}" />
-                            <Entry AutomationId="ProfileAnnualIncomeEntry" Text="{Binding AnnualIncomeText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="120000" SemanticProperties.Description="Annual after-tax household income in dollars" />
-                        </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="3">
-                            <Label Text="Annual household spending" Style="{StaticResource FormFieldLabel}" />
-                            <Entry AutomationId="ProfileAnnualExpensesEntry" Text="{Binding AnnualExpensesText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="72000" SemanticProperties.Description="Annual household spending in dollars" />
-                        </VerticalStackLayout>
+                        <controls:NumericInputView AutomationId="ProfileAnnualIncomeInput"
+                                                   Header="Annual household income"
+                                                   HelpText="After-tax income your household brings in each year."
+                                                   Placeholder="120000"
+                                                   PeriodSuffix="/yr"
+                                                   Text="{Binding AnnualIncomeText, Mode=TwoWay}" />
+                        <controls:NumericInputView AutomationId="ProfileAnnualExpensesInput"
+                                                   Header="Annual household spending"
+                                                   HelpText="What your household spends each year, before retirement."
+                                                   Placeholder="72000"
+                                                   PeriodSuffix="/yr"
+                                                   Text="{Binding AnnualExpensesText, Mode=TwoWay}" />
                     </VerticalStackLayout>
                 </Border>
 
@@ -295,20 +303,27 @@
                                FontSize="12"
                                LineHeight="1.3"
                                TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
-                        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                            <VerticalStackLayout Spacing="3">
-                                <Label Text="Expected return (%)" Style="{StaticResource FormFieldLabel}" />
-                                <Entry AutomationId="ProfileExpectedReturnEntry" Text="{Binding ExpectedReturnText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="7" SemanticProperties.Description="Expected annual investment return percentage" />
-                            </VerticalStackLayout>
-                            <VerticalStackLayout Grid.Column="1" Spacing="3">
-                                <Label Text="Inflation (%)" Style="{StaticResource FormFieldLabel}" />
-                                <Entry AutomationId="ProfileInflationRateEntry" Text="{Binding InflationRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="3" SemanticProperties.Description="Expected annual inflation percentage" />
-                            </VerticalStackLayout>
-                        </Grid>
-                        <VerticalStackLayout Spacing="3">
-                            <Label Text="Withdrawal rate (%)" Style="{StaticResource FormFieldLabel}" />
-                            <Entry AutomationId="ProfileWithdrawalRateEntry" Text="{Binding WithdrawalRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="4" SemanticProperties.Description="Safe withdrawal rate percentage" />
-                        </VerticalStackLayout>
+                        <controls:PercentageInputView AutomationId="ProfileExpectedReturnInput"
+                                                      Header="Expected return"
+                                                      HelpText="Expected average annual investment return before inflation."
+                                                      Placeholder="7"
+                                                      Minimum="0"
+                                                      Maximum="15"
+                                                      Text="{Binding ExpectedReturnText, Mode=TwoWay}" />
+                        <controls:PercentageInputView AutomationId="ProfileInflationRateInput"
+                                                      Header="Inflation"
+                                                      HelpText="Expected annual increase in the cost of living."
+                                                      Placeholder="3"
+                                                      Minimum="0"
+                                                      Maximum="10"
+                                                      Text="{Binding InflationRateText, Mode=TwoWay}" />
+                        <controls:PercentageInputView AutomationId="ProfileWithdrawalRateInput"
+                                                      Header="Withdrawal rate"
+                                                      HelpText="First-year percentage withdrawn from the portfolio. This is an assumption, not a promise."
+                                                      Placeholder="4"
+                                                      Minimum="2"
+                                                      Maximum="6"
+                                                      Text="{Binding WithdrawalRateText, Mode=TwoWay}" />
                     </VerticalStackLayout>
                 </Border>
 
@@ -350,36 +365,46 @@
                                                     <Picker Title="Account type" ItemsSource="{Binding AccountTypes}" SelectedItem="{Binding Type, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="Account type" />
                                                 </VerticalStackLayout>
                                                 <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                    <VerticalStackLayout Spacing="3">
-                                                        <Label Text="Balance" Style="{StaticResource FormFieldLabel}" />
-                                                        <Entry Text="{Binding BalanceText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Current account balance in dollars" />
-                                                    </VerticalStackLayout>
-                                                    <VerticalStackLayout Grid.Column="1" Spacing="3">
-                                                        <Label Text="Annual contribution" Style="{StaticResource FormFieldLabel}" />
-                                                        <Entry Text="{Binding AnnualContributionText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Annual account contribution in dollars" />
-                                                    </VerticalStackLayout>
+                                                    <controls:NumericInputView Header="Balance"
+                                                                               HelpText="What this account is worth today."
+                                                                               Placeholder="0"
+                                                                               Text="{Binding BalanceText, Mode=TwoWay}" />
+                                                    <controls:NumericInputView Grid.Column="1"
+                                                                               Header="Contribution"
+                                                                               HelpText="How much you add to this account each year."
+                                                                               Placeholder="0"
+                                                                               PeriodSuffix="/yr"
+                                                                               Text="{Binding AnnualContributionText, Mode=TwoWay}" />
                                                 </Grid>
                                                 <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                    <VerticalStackLayout Spacing="3">
-                                                        <Label Text="Expected return (%)" Style="{StaticResource FormFieldLabel}" />
-                                                        <Entry Text="{Binding AnnualReturnText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="5" SemanticProperties.Description="Expected annual account return percentage" />
-                                                    </VerticalStackLayout>
-                                                    <VerticalStackLayout Grid.Column="1" Spacing="3">
-                                                        <Label Text="Available age" Style="{StaticResource FormFieldLabel}" />
-                                                        <Entry Text="{Binding AvailableAgeText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="59" SemanticProperties.Description="Age when this account becomes available" />
-                                                    </VerticalStackLayout>
+                                                    <controls:NumericInputView Header="Expected return"
+                                                                               HelpText="Expected average annual return for this account."
+                                                                               Placeholder="5"
+                                                                               PeriodSuffix="%"
+                                                                               Text="{Binding AnnualReturnText, Mode=TwoWay}" />
+                                                    <controls:NumericInputView Grid.Column="1"
+                                                                               Header="Available age"
+                                                                               HelpText="Age when you can withdraw from this account without penalty."
+                                                                               Placeholder="59"
+                                                                               Text="{Binding AvailableAgeText, Mode=TwoWay}" />
                                                 </Grid>
-                                                <VerticalStackLayout IsVisible="{Binding UsesWithdrawalRate}" Spacing="3">
-                                                    <Label Text="Withdrawal rate (%)" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding WithdrawalRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="4" SemanticProperties.Description="Annual account withdrawal rate percentage" />
-                                                </VerticalStackLayout>
-                                                <VerticalStackLayout IsVisible="{Binding UsesPayoutSchedule}" Spacing="3">
-                                                    <Label Text="Payout years" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding PayoutYearsText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="5" SemanticProperties.Description="Number of years receiving equal payouts" />
-                                                </VerticalStackLayout>
+                                                <controls:NumericInputView IsVisible="{Binding UsesWithdrawalRate}"
+                                                                           Header="Withdrawal rate"
+                                                                           HelpText="Share of the remaining balance withdrawn each year."
+                                                                           Placeholder="4"
+                                                                           PeriodSuffix="%"
+                                                                           Text="{Binding WithdrawalRateText, Mode=TwoWay}" />
+                                                <controls:NumericInputView IsVisible="{Binding UsesPayoutSchedule}"
+                                                                           Header="Payout years"
+                                                                           HelpText="Number of years the balance is paid out over."
+                                                                           Placeholder="5"
+                                                                           Text="{Binding PayoutYearsText, Mode=TwoWay}" />
                                                 <VerticalStackLayout Spacing="3">
-                                                    <Label Text="Withdrawal tax rate (%)" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding WithdrawalTaxRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="0" SemanticProperties.Description="Flat estimated tax rate applied to withdrawals from this account" />
+                                                    <controls:NumericInputView Header="Withdrawal tax rate"
+                                                                               HelpText="Flat estimated tax rate applied to withdrawals from this account."
+                                                                               Placeholder="0"
+                                                                               PeriodSuffix="%"
+                                                                               Text="{Binding WithdrawalTaxRateText, Mode=TwoWay}" />
                                                     <Label Text="{Binding WithdrawalTaxHelpText}" FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
                                                 </VerticalStackLayout>
                                             </VerticalStackLayout>

--- a/app/MyFireNumber/Views/ProfilePage.xaml
+++ b/app/MyFireNumber/Views/ProfilePage.xaml
@@ -65,6 +65,92 @@
                         Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
                         StrokeShape="RoundRectangle 12">
                     <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Label Text="About you" Style="{StaticResource CalculatorSectionHeading}" />
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Name (optional)" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileDisplayNameEntry"
+                                   Text="{Binding DisplayName, Mode=TwoWay}"
+                                   Style="{StaticResource FormEntry}"
+                                   Placeholder="Alex"
+                                   SemanticProperties.Description="Your name, used to personalize the app" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Household name (optional)" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileHouseholdNameEntry"
+                                   Text="{Binding HouseholdName, Mode=TwoWay}"
+                                   Style="{StaticResource FormEntry}"
+                                   Placeholder="The Smith household"
+                                   SemanticProperties.Description="A label for your household" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Household size (optional)" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileHouseholdSizeEntry"
+                                   Text="{Binding HouseholdSizeText, Mode=TwoWay}"
+                                   Style="{StaticResource FormEntry}"
+                                   Placeholder="2"
+                                   Keyboard="Numeric"
+                                   SemanticProperties.Description="Number of people your plan supports" />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Padding="{StaticResource CardPadding}"
+                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
+                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
+                        StrokeShape="RoundRectangle 12">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Label Text="Your timeline" Style="{StaticResource CalculatorSectionHeading}" />
+                        <Label Text="Dates are used only to set starting ages for new plans. You can always override a scenario."
+                               FontSize="12"
+                               TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                        <VerticalStackLayout Spacing="4">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
+                                <Label Text="Birth date" FontAttributes="Bold" VerticalTextAlignment="Center" />
+                                <Button Grid.Column="1" Text="Set" Command="{Binding SetBirthDateCommand}" IsVisible="{Binding HasNoBirthDate}" />
+                                <Button Grid.Column="2" Text="Clear" Command="{Binding ClearBirthDateCommand}" IsVisible="{Binding HasBirthDate}" />
+                            </Grid>
+                            <Label Text="Not set" IsVisible="{Binding HasNoBirthDate}" />
+                            <DatePicker AutomationId="ProfileBirthDatePicker"
+                                        Date="{Binding BirthDate, Mode=TwoWay}"
+                                        MaximumDate="{Binding MaximumBirthDate}"
+                                        IsVisible="{Binding HasBirthDate}"
+                                        Style="{StaticResource FormDatePicker}"
+                                        SemanticProperties.Description="Birth date" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="4">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
+                                <Label Text="Phased retirement date" FontAttributes="Bold" VerticalTextAlignment="Center" />
+                                <Button Grid.Column="1" Text="Set" Command="{Binding SetPhasedRetirementDateCommand}" IsVisible="{Binding HasNoPhasedRetirementDate}" />
+                                <Button Grid.Column="2" Text="Clear" Command="{Binding ClearPhasedRetirementDateCommand}" IsVisible="{Binding HasPhasedRetirementDate}" />
+                            </Grid>
+                            <Label Text="Not set" IsVisible="{Binding HasNoPhasedRetirementDate}" />
+                            <DatePicker AutomationId="ProfilePhasedRetirementDatePicker"
+                                        Date="{Binding PhasedRetirementDate, Mode=TwoWay}"
+                                        IsVisible="{Binding HasPhasedRetirementDate}"
+                                        Style="{StaticResource FormDatePicker}"
+                                        SemanticProperties.Description="Phased retirement date" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Spacing="4">
+                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
+                                <Label Text="Full retirement date" FontAttributes="Bold" VerticalTextAlignment="Center" />
+                                <Button Grid.Column="1" Text="Set" Command="{Binding SetTargetRetirementDateCommand}" IsVisible="{Binding HasNoTargetRetirementDate}" />
+                                <Button Grid.Column="2" Text="Clear" Command="{Binding ClearTargetRetirementDateCommand}" IsVisible="{Binding HasTargetRetirementDate}" />
+                            </Grid>
+                            <Label Text="Not set" IsVisible="{Binding HasNoTargetRetirementDate}" />
+                            <DatePicker AutomationId="ProfileTargetRetirementDatePicker"
+                                        Date="{Binding TargetRetirementDate, Mode=TwoWay}"
+                                        IsVisible="{Binding HasTargetRetirementDate}"
+                                        Style="{StaticResource FormDatePicker}"
+                                        SemanticProperties.Description="Full retirement date" />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Padding="{StaticResource CardPadding}"
+                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
+                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
+                        StrokeShape="RoundRectangle 12">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
                         <Grid ColumnDefinitions="*,Auto"><Label Text="Recurring income" Style="{StaticResource CalculatorSectionHeading}" /><Button Grid.Column="1" Text="Add" Command="{Binding AddIncomeCommand}" /></Grid>
                         <VerticalStackLayout BindableLayout.ItemsSource="{Binding Income}" Spacing="{StaticResource SpaceSm}">
                             <BindableLayout.EmptyView><Label Text="No recurring income yet." FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" /></BindableLayout.EmptyView>
@@ -182,92 +268,6 @@
                                     </Border>
                                 </DataTemplate>
                             </BindableLayout.ItemTemplate>
-                        </VerticalStackLayout>
-                    </VerticalStackLayout>
-                </Border>
-
-                <Border Padding="{StaticResource CardPadding}"
-                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
-                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
-                        StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
-                        <Label Text="About you" Style="{StaticResource CalculatorSectionHeading}" />
-                        <VerticalStackLayout Spacing="3">
-                            <Label Text="Name (optional)" Style="{StaticResource FormFieldLabel}" />
-                            <Entry AutomationId="ProfileDisplayNameEntry"
-                                   Text="{Binding DisplayName, Mode=TwoWay}"
-                                   Style="{StaticResource FormEntry}"
-                                   Placeholder="Alex"
-                                   SemanticProperties.Description="Your name, used to personalize the app" />
-                        </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="3">
-                            <Label Text="Household name (optional)" Style="{StaticResource FormFieldLabel}" />
-                            <Entry AutomationId="ProfileHouseholdNameEntry"
-                                   Text="{Binding HouseholdName, Mode=TwoWay}"
-                                   Style="{StaticResource FormEntry}"
-                                   Placeholder="The Smith household"
-                                   SemanticProperties.Description="A label for your household" />
-                        </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="3">
-                            <Label Text="Household size (optional)" Style="{StaticResource FormFieldLabel}" />
-                            <Entry AutomationId="ProfileHouseholdSizeEntry"
-                                   Text="{Binding HouseholdSizeText, Mode=TwoWay}"
-                                   Style="{StaticResource FormEntry}"
-                                   Placeholder="2"
-                                   Keyboard="Numeric"
-                                   SemanticProperties.Description="Number of people your plan supports" />
-                        </VerticalStackLayout>
-                    </VerticalStackLayout>
-                </Border>
-
-                <Border Padding="{StaticResource CardPadding}"
-                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
-                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
-                        StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
-                        <Label Text="Your timeline" Style="{StaticResource CalculatorSectionHeading}" />
-                        <Label Text="Dates are used only to set starting ages for new plans. You can always override a scenario."
-                               FontSize="12"
-                               TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
-                        <VerticalStackLayout Spacing="4">
-                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
-                                <Label Text="Birth date" FontAttributes="Bold" VerticalTextAlignment="Center" />
-                                <Button Grid.Column="1" Text="Set" Command="{Binding SetBirthDateCommand}" IsVisible="{Binding HasNoBirthDate}" />
-                                <Button Grid.Column="2" Text="Clear" Command="{Binding ClearBirthDateCommand}" IsVisible="{Binding HasBirthDate}" />
-                            </Grid>
-                            <Label Text="Not set" IsVisible="{Binding HasNoBirthDate}" />
-                            <DatePicker AutomationId="ProfileBirthDatePicker"
-                                        Date="{Binding BirthDate, Mode=TwoWay}"
-                                        MaximumDate="{Binding MaximumBirthDate}"
-                                        IsVisible="{Binding HasBirthDate}"
-                                        Style="{StaticResource FormDatePicker}"
-                                        SemanticProperties.Description="Birth date" />
-                        </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="4">
-                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
-                                <Label Text="Phased retirement date" FontAttributes="Bold" VerticalTextAlignment="Center" />
-                                <Button Grid.Column="1" Text="Set" Command="{Binding SetPhasedRetirementDateCommand}" IsVisible="{Binding HasNoPhasedRetirementDate}" />
-                                <Button Grid.Column="2" Text="Clear" Command="{Binding ClearPhasedRetirementDateCommand}" IsVisible="{Binding HasPhasedRetirementDate}" />
-                            </Grid>
-                            <Label Text="Not set" IsVisible="{Binding HasNoPhasedRetirementDate}" />
-                            <DatePicker AutomationId="ProfilePhasedRetirementDatePicker"
-                                        Date="{Binding PhasedRetirementDate, Mode=TwoWay}"
-                                        IsVisible="{Binding HasPhasedRetirementDate}"
-                                        Style="{StaticResource FormDatePicker}"
-                                        SemanticProperties.Description="Phased retirement date" />
-                        </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="4">
-                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
-                                <Label Text="Full retirement date" FontAttributes="Bold" VerticalTextAlignment="Center" />
-                                <Button Grid.Column="1" Text="Set" Command="{Binding SetTargetRetirementDateCommand}" IsVisible="{Binding HasNoTargetRetirementDate}" />
-                                <Button Grid.Column="2" Text="Clear" Command="{Binding ClearTargetRetirementDateCommand}" IsVisible="{Binding HasTargetRetirementDate}" />
-                            </Grid>
-                            <Label Text="Not set" IsVisible="{Binding HasNoTargetRetirementDate}" />
-                            <DatePicker AutomationId="ProfileTargetRetirementDatePicker"
-                                        Date="{Binding TargetRetirementDate, Mode=TwoWay}"
-                                        IsVisible="{Binding HasTargetRetirementDate}"
-                                        Style="{StaticResource FormDatePicker}"
-                                        SemanticProperties.Description="Full retirement date" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>

--- a/app/MyFireNumber/Views/ProfilePage.xaml
+++ b/app/MyFireNumber/Views/ProfilePage.xaml
@@ -5,12 +5,28 @@
              x:Class="MyFireNumber.Views.ProfilePage"
              x:DataType="viewModels:ProfileViewModel"
              Title="Profile"
+             Shell.NavBarIsVisible="True"
              Background="{AppThemeBinding Light={StaticResource SurfacePageLight}, Dark={StaticResource SurfacePageDark}}"
              SafeAreaEdges="Container">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem AutomationId="ProfileSettingsToolbarItem"
+                     Text="Settings"
+                     Order="Primary"
+                     Priority="0"
+                     Command="{Binding OpenSettingsCommand}"
+                     SemanticProperties.Description="Open settings.">
+            <ToolbarItem.IconImageSource>
+                <FontImageSource FontFamily="FontAwesomeSolid"
+                                 Glyph="&#xf013;"
+                                 Color="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+            </ToolbarItem.IconImageSource>
+        </ToolbarItem>
+    </ContentPage.ToolbarItems>
+
     <Grid>
         <ScrollView>
             <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
-                <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="{StaticResource SpaceMd}">
+                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="{StaticResource SpaceMd}">
                     <Label Text="&#xf2bd;"
                            FontFamily="FontAwesomeSolid"
                            FontSize="28"
@@ -18,7 +34,7 @@
                            TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
                            SemanticProperties.Description="Profile" />
                     <VerticalStackLayout Grid.Column="1" Spacing="2">
-                        <Label Text="Profile"
+                        <Label Text="{Binding HeaderTitle}"
                                FontSize="30"
                                FontAttributes="Bold"
                                TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
@@ -27,14 +43,6 @@
                                FontSize="13"
                                TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
                     </VerticalStackLayout>
-                    <Button Grid.Column="2"
-                            AutomationId="ProfileSettingsButton"
-                            Text="&#xf013;"
-                            FontFamily="FontAwesomeSolid"
-                            Command="{Binding OpenSettingsCommand}"
-                            Background="Transparent"
-                            TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                            SemanticProperties.Description="Open settings." />
                 </Grid>
 
                 <Border Padding="{StaticResource CardPadding}"
@@ -273,6 +281,33 @@
                         <VerticalStackLayout Spacing="3">
                             <Label Text="Annual household spending" Style="{StaticResource FormFieldLabel}" />
                             <Entry AutomationId="ProfileAnnualExpensesEntry" Text="{Binding AnnualExpensesText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="72000" SemanticProperties.Description="Annual household spending in dollars" />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Padding="{StaticResource CardPadding}"
+                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
+                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
+                        StrokeShape="RoundRectangle 12">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Label Text="Planning assumptions" Style="{StaticResource CalculatorSectionHeading}" />
+                        <Label Text="Starting assumptions for new calculators. Existing drafts and saved plans never change."
+                               FontSize="12"
+                               LineHeight="1.3"
+                               TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                        <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
+                            <VerticalStackLayout Spacing="3">
+                                <Label Text="Expected return (%)" Style="{StaticResource FormFieldLabel}" />
+                                <Entry AutomationId="ProfileExpectedReturnEntry" Text="{Binding ExpectedReturnText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="7" SemanticProperties.Description="Expected annual investment return percentage" />
+                            </VerticalStackLayout>
+                            <VerticalStackLayout Grid.Column="1" Spacing="3">
+                                <Label Text="Inflation (%)" Style="{StaticResource FormFieldLabel}" />
+                                <Entry AutomationId="ProfileInflationRateEntry" Text="{Binding InflationRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="3" SemanticProperties.Description="Expected annual inflation percentage" />
+                            </VerticalStackLayout>
+                        </Grid>
+                        <VerticalStackLayout Spacing="3">
+                            <Label Text="Withdrawal rate (%)" Style="{StaticResource FormFieldLabel}" />
+                            <Entry AutomationId="ProfileWithdrawalRateEntry" Text="{Binding WithdrawalRateText, Mode=TwoWay}" Keyboard="Numeric" Style="{StaticResource FormEntry}" Placeholder="4" SemanticProperties.Description="Safe withdrawal rate percentage" />
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>

--- a/app/MyFireNumber/Views/SettingsPage.xaml
+++ b/app/MyFireNumber/Views/SettingsPage.xaml
@@ -210,16 +210,13 @@
                                    FontFamily="FontAwesomeSolid"
                                    VerticalTextAlignment="Center"
                                    TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
-                                   SemanticProperties.Description="Calculator defaults" />
+                                   SemanticProperties.Description="Calculator display" />
                             <Label Grid.Column="1"
-                                   Text="Calculator defaults"
+                                   Text="Calculator display"
                                    TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
                                    FontAttributes="Bold"
                                    FontSize="18" />
                         </Grid>
-                        <Label Text="Set starting assumptions for new calculators. Existing drafts and saved plans never change."
-                               TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                               LineHeight="1.3" />
                         <VerticalStackLayout Spacing="4">
                             <Label Text="Currency"
                                    TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
@@ -232,140 +229,16 @@
                                     TitleColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
                                     SemanticProperties.Description="Currency used to display calculator results" />
                         </VerticalStackLayout>
-                        <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
-                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="{StaticResource SpaceSm}">
-                                <Label Text="Expected return"
-                                       VerticalTextAlignment="Center"
-                                       TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                                       FontSize="13" />
-                                <Entry AutomationId="ExpectedReturnDefaultEntry"
-                                       Grid.Column="1"
-                                       Text="{Binding ExpectedReturnPercent}"
-                                       Keyboard="Numeric"
-                                       Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                       TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                                       PlaceholderColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
-                                       SemanticProperties.Description="Default expected annual return percentage" />
-                                <Slider AutomationId="ExpectedReturnDefaultSlider"
-                                        Grid.Row="1"
-                                        Grid.ColumnSpan="2"
-                                        Minimum="0"
-                                        Maximum="15"
-                                        Value="{Binding ExpectedReturnSlider}"
-                                        MinimumTrackColor="{StaticResource FixedAccent}"
-                                        MaximumTrackColor="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
-                                        ThumbColor="{StaticResource FixedAccent}"
-                                        SemanticProperties.Description="Adjust default expected annual return percentage" />
-                            </Grid>
-                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="{StaticResource SpaceSm}">
-                                <Label Text="Inflation"
-                                       VerticalTextAlignment="Center"
-                                       TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                                       FontSize="13" />
-                                <Entry AutomationId="InflationDefaultEntry"
-                                       Grid.Column="1"
-                                       Text="{Binding InflationRatePercent}"
-                                       Keyboard="Numeric"
-                                       Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                       TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                                       PlaceholderColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
-                                       SemanticProperties.Description="Default annual inflation percentage" />
-                                <Slider AutomationId="InflationDefaultSlider"
-                                        Grid.Row="1"
-                                        Grid.ColumnSpan="2"
-                                        Minimum="0"
-                                        Maximum="10"
-                                        Value="{Binding InflationRateSlider}"
-                                        MinimumTrackColor="{StaticResource FixedAccent}"
-                                        MaximumTrackColor="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
-                                        ThumbColor="{StaticResource FixedAccent}"
-                                        SemanticProperties.Description="Adjust default annual inflation percentage" />
-                            </Grid>
-                            <Grid RowDefinitions="Auto,Auto" ColumnDefinitions="*,96" ColumnSpacing="{StaticResource SpaceSm}">
-                                <Label Text="Withdrawal rate"
-                                       VerticalTextAlignment="Center"
-                                       TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                                       FontSize="13" />
-                                <Entry AutomationId="WithdrawalDefaultEntry"
-                                       Grid.Column="1"
-                                       Text="{Binding WithdrawalRatePercent}"
-                                       Keyboard="Numeric"
-                                       Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                       TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                                       PlaceholderColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
-                                       SemanticProperties.Description="Default safe withdrawal percentage" />
-                                <Slider AutomationId="WithdrawalDefaultSlider"
-                                        Grid.Row="1"
-                                        Grid.ColumnSpan="2"
-                                        Minimum="2"
-                                        Maximum="6"
-                                        Value="{Binding WithdrawalRateSlider}"
-                                        MinimumTrackColor="{StaticResource FixedAccent}"
-                                        MaximumTrackColor="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
-                                        ThumbColor="{StaticResource FixedAccent}"
-                                        SemanticProperties.Description="Adjust default safe withdrawal percentage" />
-                            </Grid>
-                            <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                <VerticalStackLayout Spacing="4">
-                                    <Label Text="Current age"
-                                           TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                                           FontSize="13" />
-                                    <Entry AutomationId="CurrentAgeDefaultEntry"
-                                           Text="{Binding DefaultCurrentAge}"
-                                           Keyboard="Numeric"
-                                           Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                           TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                                           PlaceholderColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
-                                           SemanticProperties.Description="Default current age" />
-                                </VerticalStackLayout>
-                                <VerticalStackLayout Grid.Column="1" Spacing="4">
-                                    <Label Text="Retirement age"
-                                           TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                                           FontSize="13" />
-                                    <Entry AutomationId="RetirementAgeDefaultEntry"
-                                           Text="{Binding DefaultRetirementAge}"
-                                           Keyboard="Numeric"
-                                           Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                           TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                                           PlaceholderColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
-                                           SemanticProperties.Description="Default retirement age" />
-                                </VerticalStackLayout>
-                            </Grid>
-                                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                    <VerticalStackLayout Spacing="4">
-                                     <Label Text="After-tax income"
-                                         TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                                         FontSize="13" />
-                                     <Entry AutomationId="AnnualIncomeDefaultEntry"
-                                         Text="{Binding DefaultAnnualIncome}"
-                                         Keyboard="Numeric"
-                                         Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                         TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                                         PlaceholderColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
-                                         SemanticProperties.Description="Default annual after-tax income" />
-                                    </VerticalStackLayout>
-                                    <VerticalStackLayout Grid.Column="1" Spacing="4">
-                                     <Label Text="Annual expenses"
-                                         TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
-                                         FontSize="13" />
-                                     <Entry AutomationId="AnnualExpensesDefaultEntry"
-                                         Text="{Binding DefaultAnnualExpenses}"
-                                         Keyboard="Numeric"
-                                         Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                         TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
-                                         PlaceholderColor="{AppThemeBinding Light={StaticResource TextMutedAltLight}, Dark={StaticResource TextMutedAltDark}}"
-                                         SemanticProperties.Description="Default annual expenses" />
-                                    </VerticalStackLayout>
-                                </Grid>
-                            <Button Text="Save defaults"
-                                    Command="{Binding SaveCalculatorDefaultsCommand}"
-                                    Background="{StaticResource FixedAccent}"
-                                    TextColor="{StaticResource FixedWhite}"
-                                    SemanticProperties.Description="Save calculator defaults for new calculators." />
-                        </VerticalStackLayout>
-                        <Label Text="{Binding DefaultsStatus}"
-                               TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
-                               FontSize="13" />
+                        <Label Text="Your age, retirement date, income, spending, and planning assumptions now live in Profile, so every calculator starts from one set of numbers."
+                               TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
+                               FontSize="13"
+                               LineHeight="1.3" />
+                        <Button AutomationId="OpenProfileFromSettingsButton"
+                                Text="Open Profile"
+                                Command="{Binding OpenProfileCommand}"
+                                Background="Transparent"
+                                TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
+                                SemanticProperties.Description="Open Profile to edit your planning details." />
                     </VerticalStackLayout>
                 </Border>
                 <Border Padding="{StaticResource CardPadding}"

--- a/app/MyFireNumber/Views/TimelineOnboardingPage.xaml
+++ b/app/MyFireNumber/Views/TimelineOnboardingPage.xaml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:MyFireNumber.Views.Controls"
+             xmlns:viewModels="clr-namespace:MyFireNumber.ViewModels"
+             x:Class="MyFireNumber.Views.TimelineOnboardingPage"
+             x:DataType="viewModels:TimelineOnboardingViewModel"
+             Title="Your timeline"
+             Shell.NavBarIsVisible="True"
+             Shell.TabBarIsVisible="False"
+             Background="{AppThemeBinding Light={StaticResource SurfacePageLight}, Dark={StaticResource SurfacePageDark}}"
+             SafeAreaEdges="All">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Skip"
+                     Command="{Binding SkipCommand}"
+                     SemanticProperties.Description="Skip your timeline and continue to withdrawal rate." />
+    </ContentPage.ToolbarItems>
+
+    <Grid>
+        <ScrollView>
+            <VerticalStackLayout Padding="{StaticResource PagePadding}" Spacing="{StaticResource SpaceLg}">
+                <VerticalStackLayout Spacing="6">
+                    <Label Text="When do you want to retire?"
+                           FontSize="28"
+                           FontAttributes="Bold"
+                           LineHeight="1.1"
+                           TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}"
+                           SemanticProperties.HeadingLevel="Level1" />
+                    <Label Text="We save these as dates on your profile, so every calculator keeps using the right ages as the years pass."
+                           LineHeight="1.35"
+                           TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                </VerticalStackLayout>
+
+                <Border Padding="{StaticResource CardPadding}"
+                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
+                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
+                        StrokeShape="RoundRectangle 12">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceXl}">
+                        <VerticalStackLayout Spacing="6">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <Label Text="Full retirement age"
+                                       FontAttributes="Bold"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+                                <Label Grid.Column="1"
+                                       Text="{Binding RetirementAgeText}"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
+                            </Grid>
+                            <Slider AutomationId="OnboardingRetirementAgeSlider"
+                                    Maximum="{Binding MaximumRetirementAge}"
+                                    Minimum="{Binding MinimumAllowedRetirementAge}"
+                                    Value="{Binding RetirementAge, Mode=TwoWay}"
+                                    MinimumTrackColor="{StaticResource FixedAccent}"
+                                    MaximumTrackColor="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
+                                    ThumbColor="{StaticResource FixedAccent}"
+                                    SemanticProperties.Description="The age you plan to stop working entirely" />
+                        </VerticalStackLayout>
+
+                        <VerticalStackLayout Spacing="6">
+                            <Grid ColumnDefinitions="*,Auto">
+                                <Label Text="Step back to part-time first?"
+                                       FontAttributes="Bold"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+                                <Button Grid.Column="1"
+                                        AutomationId="OnboardingAddPhasedRetirementButton"
+                                        Text="Add"
+                                        FontSize="12"
+                                        Padding="12,4"
+                                        IsVisible="{Binding HasNoPhasedRetirement}"
+                                        Command="{Binding AddPhasedRetirementCommand}"
+                                        Background="Transparent"
+                                        TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
+                                        SemanticProperties.Description="Add a phased retirement age." />
+                            </Grid>
+                            <Label Text="Many people cut back to part-time work before stopping completely. This is optional."
+                                   FontSize="12"
+                                   LineHeight="1.3"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                            <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding HasPhasedRetirement}">
+                                <Label Text="Phased retirement age"
+                                       FontAttributes="Bold"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
+                                <Label Grid.Column="1"
+                                       Text="{Binding PhasedRetirementAgeText}"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
+                            </Grid>
+                            <Slider AutomationId="OnboardingPhasedRetirementAgeSlider"
+                                    IsVisible="{Binding HasPhasedRetirement}"
+                                    Maximum="{Binding MaximumRetirementAge}"
+                                    Minimum="{Binding MinimumAllowedRetirementAge}"
+                                    Value="{Binding PhasedRetirementAge, Mode=TwoWay}"
+                                    MinimumTrackColor="{StaticResource FixedAccent}"
+                                    MaximumTrackColor="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
+                                    ThumbColor="{StaticResource FixedAccent}"
+                                    SemanticProperties.Description="The age you plan to move to part-time work" />
+                            <Button AutomationId="OnboardingRemovePhasedRetirementButton"
+                                    Text="Remove phased retirement"
+                                    FontSize="12"
+                                    IsVisible="{Binding HasPhasedRetirement}"
+                                    Command="{Binding RemovePhasedRetirementCommand}"
+                                    Background="Transparent"
+                                    TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
+                                    SemanticProperties.Description="Remove the phased retirement age." />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Border Padding="{StaticResource CardPadding}"
+                        Background="{AppThemeBinding Light={StaticResource SurfaceAccentSoftLight}, Dark={StaticResource SurfaceAccentSoftDark}}"
+                        Stroke="{AppThemeBinding Light={StaticResource BorderAccentAltLight}, Dark={StaticResource BorderAccentAltDark}}"
+                        StrokeShape="RoundRectangle 12">
+                    <Label AutomationId="OnboardingTimelineSummary"
+                           Text="{Binding TimelineSummary}"
+                           FontSize="13"
+                           LineHeight="1.35"
+                           TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
+                </Border>
+
+                <Button AutomationId="SaveOnboardingTimelineButton"
+                        Text="Continue"
+                        Command="{Binding SaveAndContinueCommand}"
+                        Background="{StaticResource FixedAccent}"
+                        TextColor="{StaticResource FixedWhite}"
+                        SemanticProperties.Description="Save your timeline and continue to withdrawal rate." />
+
+                <controls:EducationalDisclaimerView />
+            </VerticalStackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/app/MyFireNumber/Views/TimelineOnboardingPage.xaml.cs
+++ b/app/MyFireNumber/Views/TimelineOnboardingPage.xaml.cs
@@ -1,0 +1,12 @@
+using MyFireNumber.ViewModels;
+
+namespace MyFireNumber.Views;
+
+public partial class TimelineOnboardingPage : ContentPage
+{
+    public TimelineOnboardingPage(TimelineOnboardingViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}


### PR DESCRIPTION
Two related profile improvements, kept together since they touch the same feature area.

---

## 1. Onboarding collects enough to build a real profile

Onboarding asked only for age, income, and expenses, and wrote just income and expenses to the profile. A new user reached Home with an *incomplete* profile and was immediately prompted for the same kind of information again.

New flow: `welcome → about you → timeline → withdrawal rate → choice`

**Step 1 "Tell us about you"** (existing page, extended)
- Optional **name** and **household size**
- The current-age slider is replaced by a **birth date**, so the profile stores the canonical date and every calculator keeps deriving a correct age as years pass. Skippable, capped at today, and echoes the derived age back.
- Income and expense sliders unchanged

**Step 2 "Your timeline"** (new page)
- **Full retirement age**, plus an optional **phased retirement age** for stepping back to part-time first
- Saved as profile *dates* anchored to the birth date; the phased age can never exceed full retirement
- With no birth date, the ages still save as calculator starting points and the page says so

**Home** greets the user by name when the profile has one, so asking for it has visible payoff.

Notes:
- Every step stays skippable; profile setup is still never mandatory.
- `ProfileAgeCalculator.DateAtAge` and `RetirementAgeRange` are new pure Core helpers so the age-to-date conversion and slider bounds are unit tested. `RetirementAgeRange` fixes a real crash: someone older than the range ceiling would otherwise produce `minimum > maximum`, which `Math.Clamp` rejects.
- A storage failure during onboarding is caught so it can never dead-end a new user.

---

## 2. Every Profile field has a visible label

The Profile page identified its inputs with **placeholder text only** — 22 of them — and the two recurring-period `Picker`s had no title at all. A placeholder disappears the moment a field has a value, so after entering anything there was no way to tell what a field held. It also left assistive technology with nothing stable to announce.

**On the Android / Material 3 question:** per the [Material 3 docs](https://learn.microsoft.com/dotnet/maui/user-interface/material3), `Entry` renders as a `TextInputLayout` outlined field *with a floating label* — but only on Android, and only when the `UseMaterial3` build property is `true`. **This project does not set it**, so Android uses Material 2, where the hint disappears exactly like iOS and Mac Catalyst. Labels are needed on every platform, so no `OnPlatform` branching is warranted. Worth revisiting if `UseMaterial3` is ever enabled.

- Visible label above every Profile input, matching the pattern the calculator pages already use
- Placeholders demoted to **example values** (`0`, `19.99`, `Salary`) rather than duplicating the label
- Titles and labels on the period pickers
- `SemanticProperties.Description` on the inventory fields and each per-item Delete button
- New shared `FormFieldLabel` / `FormEntry` / `FormPicker` / `FormDatePicker` styles, so field colors resolve from theme resources in one place instead of being repeated across ~22 controls; empty-state labels themed too

---

## Verification

- **375 tests pass** (9 new: leap-day birthdays, age round-trip, range clamping, future birth dates)
- Clean builds on **Mac Catalyst, iOS, and Android**
- Scripted check confirms **0 unlabeled inputs** remain on the Profile page

Runtime UI verification was not possible — MauiDevFlow does not connect in this environment. A visual pass on the two onboarding screens and the Profile form in light and dark mode is worth doing before merge, particularly `DatePicker` rendering and label spacing.