### PR TITLE
Update GitHub Actions workflows to use latest action versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -40,10 +40,10 @@ jobs:
         working-directory: web
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './web/dist'
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/maui-android.yml
+++ b/.github/workflows/maui-android.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Detect Android changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -57,13 +57,13 @@ jobs:
 
       - name: Setup .NET SDK
         if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.android == 'true' }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 
       - name: Setup Java
         if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.android == 'true' }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: microsoft
           java-version: '21'
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload Android App Bundle
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.build_release }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: myfirenumber-android-aab
           path: ${{ steps.android-artifact.outputs.path }}

--- a/.github/workflows/maui-ios.yml
+++ b/.github/workflows/maui-ios.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Detect iOS changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Detect web changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: Setup Node
         if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.web == 'true' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -79,10 +79,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Detect core changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -96,7 +96,7 @@ jobs:
 
       - name: Setup .NET
         if: ${{ github.event_name != 'pull_request' || steps.changes.outputs.core == 'true' }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 


### PR DESCRIPTION
Upgrade all GitHub Actions in the workflows to their latest versions for improved performance and security. This change ensures compatibility with the latest features and fixes.