### PR TITLE
Enhance onboarding, profile management, and DevFlow setup

### DIFF
--- a/.github/instructions/mobile.instructions.md
+++ b/.github/instructions/mobile.instructions.md
@@ -29,8 +29,13 @@ The app already opts into DevFlow when `MauiDevFlowEnabled=true`:
 
 - `MyFireNumber.csproj` conditionally references `Microsoft.Maui.DevFlow.Agent` and defines
   `MAUI_DEVFLOW`.
-- `MauiProgram.cs` conditionally calls `AddMauiDevFlowAgent()`.
+- `MauiProgram.cs` conditionally calls `AddMauiDevFlowAgent()` for every configured target:
+  Android, iOS, Mac Catalyst, and Windows.
 - `.mauidevflow` supplies the broker port, which the CLI discovers automatically.
+
+DevFlow is experimental. Current runtime support is strongest on Mac Catalyst and iOS Simulator;
+Android requires ADB reverse port forwarding, and Windows support remains in progress. Keep the
+agent opt-in to Debug builds with `MauiDevFlowEnabled=true`; never enable it for Release builds.
 
 Use this CLI flow:
 
@@ -59,6 +64,19 @@ maui devflow wait \
 maui devflow list
 maui devflow ui status
 maui devflow ui tree --depth 4 --format compact
+```
+
+For Mac Catalyst, use `--wait-platform maccatalyst`, then launch the built app bundle directly:
+
+```bash
+dotnet build app/MyFireNumber/MyFireNumber.csproj \
+  -f net10.0-maccatalyst \
+  -p:MauiDevFlowEnabled=true
+open "app/MyFireNumber/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/My Fire #.app"
+maui devflow wait \
+  --project app/MyFireNumber/MyFireNumber.csproj \
+  --wait-platform maccatalyst \
+  --timeout 120
 ```
 
 Drive the app with stable `AutomationId` or text selectors rather than ephemeral tree IDs whenever

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ can also create signed Android App Bundles and iOS archives. See
 [Mobile Release Secrets](docs/MOBILE_RELEASE_SECRETS.md) for the required credentials and setup
 steps.
 
+For Debug-time native UI inspection and automation, see [MAUI DevFlow](docs/MAUI_DEVFLOW.md).
+
 ## 🛠️ Tech Stack
 
 - **React 19** - UI framework

--- a/app/MyFireNumber/AppShell.xaml.cs
+++ b/app/MyFireNumber/AppShell.xaml.cs
@@ -97,4 +97,34 @@ public partial class AppShell : Shell
 		};
 		await GoToAsync(route);
 	}
+
+	protected override void OnNavigating(ShellNavigatingEventArgs args)
+	{
+		base.OnNavigating(args);
+
+		if (args.Source != ShellNavigationSource.Pop
+			|| onboardingService.IsComplete
+			|| !IsOnboardingPage(CurrentPage))
+		{
+			return;
+		}
+
+		var navigationStack = Navigation.NavigationStack;
+		var hasEarlierOnboardingPage = navigationStack
+			.Take(Math.Max(0, navigationStack.Count - 1))
+			.Any(IsOnboardingPage);
+
+		if (!hasEarlierOnboardingPage)
+		{
+			args.Cancel();
+		}
+	}
+
+	private static bool IsOnboardingPage(Page page) =>
+		page is WelcomePage
+			or DefaultsOnboardingPage
+			or TimelineOnboardingPage
+			or WithdrawalRateOnboardingPage
+			or OnboardingChoicePage
+			or QuizPage;
 }

--- a/app/MyFireNumber/MauiProgram.cs
+++ b/app/MyFireNumber/MauiProgram.cs
@@ -12,7 +12,7 @@ using SkiaSharp.Views.Maui.Controls.Hosting;
 using Microsoft.Maui.Handlers;
 using Microsoft.Maui.Platform;
 #endif
-#if MAUI_DEVFLOW && !IOS
+#if MAUI_DEVFLOW
 using Microsoft.Maui.DevFlow.Agent;
 #endif
 
@@ -143,8 +143,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<OnboardingChoiceViewModel>();
 		builder.Services.AddTransient<RetirementAnnualDetailsViewModel>();
 
-#if MAUI_DEVFLOW && !IOS
-		// The current DevFlow preview fails MAUI native class registration on iOS at startup.
+#if MAUI_DEVFLOW
 		builder.AddMauiDevFlowAgent();
 #endif
 

--- a/app/MyFireNumber/MyFireNumber.csproj
+++ b/app/MyFireNumber/MyFireNumber.csproj
@@ -94,7 +94,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(MauiDevFlowEnabled)' == 'true'">
-		<PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.12.26368.2" PrivateAssets="all" />
+		<PackageReference Include="Microsoft.Maui.DevFlow.Agent" Version="0.1.0-preview.12.26368.2" />
 	</ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'Debug' and '$(MauiDevFlowEnabled)' == 'true'">

--- a/app/MyFireNumber/ViewModels/DefaultsOnboardingViewModel.cs
+++ b/app/MyFireNumber/ViewModels/DefaultsOnboardingViewModel.cs
@@ -149,10 +149,10 @@ public partial class DefaultsOnboardingViewModel : ObservableObject
             // above still apply, and Profile can be completed later.
         }
 
-        await navigationService.GoToAsync("../onboarding-timeline");
+        await navigationService.GoToAsync("onboarding-timeline");
     }
     [RelayCommand]
-    private Task SkipAsync() => navigationService.GoToAsync("../onboarding-timeline");
+    private Task SkipAsync() => navigationService.GoToAsync("onboarding-timeline");
 
     private static void RoundSliderValue(double value, Action<double> update, double increment)
     {

--- a/app/MyFireNumber/ViewModels/OnboardingChoiceViewModel.cs
+++ b/app/MyFireNumber/ViewModels/OnboardingChoiceViewModel.cs
@@ -22,7 +22,7 @@ public partial class OnboardingChoiceViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private Task TakeQuizAsync() => navigationService.GoToAsync("../quiz");
+    private Task TakeQuizAsync() => navigationService.GoToAsync("quiz");
 
     [RelayCommand]
     private async Task StartStandardFireAsync()

--- a/app/MyFireNumber/ViewModels/QuizViewModel.cs
+++ b/app/MyFireNumber/ViewModels/QuizViewModel.cs
@@ -198,8 +198,9 @@ public partial class QuizViewModel : ObservableObject
             RecentActivityKind.Calculator,
             option.CalculatorId,
             DateTime.UtcNow));
+        await navigationService.GoToAsync("//home");
         await navigationService.GoToAsync(
-            CalculatorRoutes.Build(option.CalculatorId, returnHomeAfterSave: true, routePrefix: "../"));
+            CalculatorRoutes.Build(option.CalculatorId, returnHomeAfterSave: true));
     }
 
     private bool SaveCurrentAnswer()

--- a/app/MyFireNumber/ViewModels/TimelineOnboardingViewModel.cs
+++ b/app/MyFireNumber/ViewModels/TimelineOnboardingViewModel.cs
@@ -144,11 +144,11 @@ public partial class TimelineOnboardingViewModel : ObservableObject
             }
         }
 
-        await navigationService.GoToAsync("../onboarding-withdrawal-rate");
+        await navigationService.GoToAsync("onboarding-withdrawal-rate");
     }
 
     [RelayCommand]
-    private Task SkipAsync() => navigationService.GoToAsync("../onboarding-withdrawal-rate");
+    private Task SkipAsync() => navigationService.GoToAsync("onboarding-withdrawal-rate");
 
     private static void RoundSliderValue(double value, Action<double> update, double increment)
     {

--- a/app/MyFireNumber/ViewModels/WelcomeViewModel.cs
+++ b/app/MyFireNumber/ViewModels/WelcomeViewModel.cs
@@ -21,6 +21,6 @@ public partial class WelcomeViewModel : ObservableObject
     private async Task GetStartedAsync()
     {
         onboardingService.MarkWelcomeSeen();
-        await navigationService.GoToAsync("../onboarding-defaults");
+        await navigationService.GoToAsync("onboarding-defaults");
     }
 }

--- a/app/MyFireNumber/ViewModels/WithdrawalRateOnboardingViewModel.cs
+++ b/app/MyFireNumber/ViewModels/WithdrawalRateOnboardingViewModel.cs
@@ -41,9 +41,9 @@ public partial class WithdrawalRateOnboardingViewModel : ObservableObject
         {
             WithdrawalRate = WithdrawalRatePercent / 100
         });
-        await navigationService.GoToAsync("../onboarding-choice");
+        await navigationService.GoToAsync("onboarding-choice");
     }
 
     [RelayCommand]
-    private Task SkipAsync() => navigationService.GoToAsync("../onboarding-choice");
+    private Task SkipAsync() => navigationService.GoToAsync("onboarding-choice");
 }

--- a/app/MyFireNumber/Views/DefaultsOnboardingPage.xaml
+++ b/app/MyFireNumber/Views/DefaultsOnboardingPage.xaml
@@ -66,13 +66,13 @@
                                         SemanticProperties.Description="Continue without sharing a birth date." />
                                 <Button Grid.Column="1"
                                         AutomationId="OnboardingUseBirthDateButton"
-                                        Text="Add"
-                                        FontSize="12"
-                                        Padding="12,4"
+                                        Text="Add birth date"
+                                        FontAttributes="Bold"
+                                        Padding="14,8"
                                         IsVisible="{Binding HasNoBirthDate}"
                                         Command="{Binding UseBirthDateCommand}"
-                                        Background="Transparent"
-                                        TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}"
+                                        Background="{StaticResource FixedAccent}"
+                                        TextColor="{StaticResource FixedWhite}"
                                         SemanticProperties.Description="Add your birth date." />
                             </Grid>
                             <DatePicker AutomationId="OnboardingBirthDatePicker"

--- a/app/MyFireNumber/Views/ProfilePage.xaml
+++ b/app/MyFireNumber/Views/ProfilePage.xaml
@@ -228,6 +228,96 @@
                     </VerticalStackLayout>
                 </Border>
 
+                 <Border Padding="{StaticResource CardPadding}"
+                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
+                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
+                        StrokeShape="RoundRectangle 12">
+                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <Label Text="Accounts" Style="{StaticResource CalculatorSectionHeading}" />
+                            <Button Grid.Column="1" Text="Add" Command="{Binding AddAccountCommand}" SemanticProperties.Description="Add a reusable account." />
+                        </Grid>
+                        <Label Text="Accounts stay on this device. Adding one to a scenario creates an independent copy."
+                               FontSize="12"
+                               TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding Accounts}" Spacing="{StaticResource SpaceSm}">
+                            <BindableLayout.EmptyView>
+                                <Label Text="No reusable accounts yet." FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                            </BindableLayout.EmptyView>
+                            <BindableLayout.ItemTemplate>
+                                <DataTemplate x:DataType="viewModels:RetirementAccountEditorItem">
+                                    <Border Padding="{StaticResource CardPaddingCompact}"
+                                            Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
+                                            StrokeThickness="0"
+                                            StrokeShape="RoundRectangle 8">
+                                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
+                                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
+                                                <Label Text="{Binding Name}" FontAttributes="Bold" VerticalTextAlignment="Center" />
+                                                <Button Grid.Column="1" Text="{Binding ExpansionGlyph}" FontFamily="FontAwesomeSolid" Command="{Binding ToggleExpandedCommand}" Background="Transparent" SemanticProperties.Description="{Binding Name, StringFormat='Expand or collapse {0} account.'}" />
+                                                <Button Grid.Column="2" Text="Delete" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveAccountCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} account.'}" />
+                                            </Grid>
+                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="{StaticResource SpaceSm}">
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Account name" Style="{StaticResource FormFieldLabel}" />
+                                                    <Entry Text="{Binding Name, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="401(k)" SemanticProperties.Description="Account name" />
+                                                </VerticalStackLayout>
+                                                <VerticalStackLayout Spacing="3">
+                                                    <Label Text="Account type" Style="{StaticResource FormFieldLabel}" />
+                                                    <Picker Title="Account type" ItemsSource="{Binding AccountTypes}" SelectedItem="{Binding Type, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="Account type" />
+                                                </VerticalStackLayout>
+                                                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
+                                                    <controls:NumericInputView Header="Balance"
+                                                                               HelpText="What this account is worth today."
+                                                                               Placeholder="0"
+                                                                               Text="{Binding BalanceText, Mode=TwoWay}" />
+                                                    <controls:NumericInputView Grid.Column="1"
+                                                                               Header="Contribution"
+                                                                               HelpText="How much you add to this account each year."
+                                                                               Placeholder="0"
+                                                                               PeriodSuffix="/yr"
+                                                                               Text="{Binding AnnualContributionText, Mode=TwoWay}" />
+                                                </Grid>
+                                                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
+                                                    <controls:NumericInputView Header="Expected return"
+                                                                               HelpText="Expected average annual return for this account."
+                                                                               Placeholder="5"
+                                                                               PeriodSuffix="%"
+                                                                               Text="{Binding AnnualReturnText, Mode=TwoWay}" />
+                                                    <controls:NumericInputView Grid.Column="1"
+                                                                               Header="Available age"
+                                                                               HelpText="Age when you can withdraw from this account without penalty."
+                                                                               Placeholder="59"
+                                                                               Text="{Binding AvailableAgeText, Mode=TwoWay}" />
+                                                </Grid>
+                                                <controls:NumericInputView IsVisible="{Binding UsesWithdrawalRate}"
+                                                                           Header="Withdrawal rate"
+                                                                           HelpText="Share of the remaining balance withdrawn each year."
+                                                                           Placeholder="4"
+                                                                           PeriodSuffix="%"
+                                                                           Text="{Binding WithdrawalRateText, Mode=TwoWay}" />
+                                                <controls:NumericInputView IsVisible="{Binding UsesPayoutSchedule}"
+                                                                           Header="Payout years"
+                                                                           HelpText="Number of years the balance is paid out over."
+                                                                           Placeholder="5"
+                                                                           Text="{Binding PayoutYearsText, Mode=TwoWay}" />
+                                                <VerticalStackLayout Spacing="3">
+                                                    <controls:NumericInputView Header="Withdrawal tax rate"
+                                                                               HelpText="Flat estimated tax rate applied to withdrawals from this account."
+                                                                               Placeholder="0"
+                                                                               PeriodSuffix="%"
+                                                                               Text="{Binding WithdrawalTaxRateText, Mode=TwoWay}" />
+                                                    <Label Text="{Binding WithdrawalTaxHelpText}" FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
+                                                </VerticalStackLayout>
+                                            </VerticalStackLayout>
+                                        </VerticalStackLayout>
+                                    </Border>
+                                </DataTemplate>
+                            </BindableLayout.ItemTemplate>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+
                 <Border Padding="{StaticResource CardPadding}"
                         Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
                         Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
@@ -339,95 +429,7 @@
                     </VerticalStackLayout>
                 </Border>
 
-                <Border Padding="{StaticResource CardPadding}"
-                        Background="{AppThemeBinding Light={StaticResource SurfaceCardLight}, Dark={StaticResource SurfaceCardDark}}"
-                        Stroke="{AppThemeBinding Light={StaticResource BorderSubtleLight}, Dark={StaticResource BorderSubtleDark}}"
-                        StrokeShape="RoundRectangle 12">
-                    <VerticalStackLayout Spacing="{StaticResource SpaceMd}">
-                        <Grid ColumnDefinitions="*,Auto">
-                            <Label Text="Accounts" Style="{StaticResource CalculatorSectionHeading}" />
-                            <Button Grid.Column="1" Text="Add" Command="{Binding AddAccountCommand}" SemanticProperties.Description="Add a reusable account." />
-                        </Grid>
-                        <Label Text="Accounts stay on this device. Adding one to a scenario creates an independent copy."
-                               FontSize="12"
-                               TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
-                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding Accounts}" Spacing="{StaticResource SpaceSm}">
-                            <BindableLayout.EmptyView>
-                                <Label Text="No reusable accounts yet." FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
-                            </BindableLayout.EmptyView>
-                            <BindableLayout.ItemTemplate>
-                                <DataTemplate x:DataType="viewModels:RetirementAccountEditorItem">
-                                    <Border Padding="{StaticResource CardPaddingCompact}"
-                                            Background="{AppThemeBinding Light={StaticResource SurfaceInsetLight}, Dark={StaticResource SurfaceInsetDark}}"
-                                            StrokeThickness="0"
-                                            StrokeShape="RoundRectangle 8">
-                                        <VerticalStackLayout Spacing="{StaticResource SpaceSm}">
-                                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="{StaticResource SpaceSm}">
-                                                <Label Text="{Binding Name}" FontAttributes="Bold" VerticalTextAlignment="Center" />
-                                                <Button Grid.Column="1" Text="{Binding ExpansionGlyph}" FontFamily="FontAwesomeSolid" Command="{Binding ToggleExpandedCommand}" Background="Transparent" SemanticProperties.Description="{Binding Name, StringFormat='Expand or collapse {0} account.'}" />
-                                                <Button Grid.Column="2" Text="Delete" Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveAccountCommand}" CommandParameter="{Binding .}" SemanticProperties.Description="{Binding Name, StringFormat='Delete {0} account.'}" />
-                                            </Grid>
-                                            <VerticalStackLayout IsVisible="{Binding IsExpanded}" Spacing="{StaticResource SpaceSm}">
-                                                <VerticalStackLayout Spacing="3">
-                                                    <Label Text="Account name" Style="{StaticResource FormFieldLabel}" />
-                                                    <Entry Text="{Binding Name, Mode=TwoWay}" Style="{StaticResource FormEntry}" Placeholder="401(k)" SemanticProperties.Description="Account name" />
-                                                </VerticalStackLayout>
-                                                <VerticalStackLayout Spacing="3">
-                                                    <Label Text="Account type" Style="{StaticResource FormFieldLabel}" />
-                                                    <Picker Title="Account type" ItemsSource="{Binding AccountTypes}" SelectedItem="{Binding Type, Mode=TwoWay}" Style="{StaticResource FormPicker}" SemanticProperties.Description="Account type" />
-                                                </VerticalStackLayout>
-                                                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                    <controls:NumericInputView Header="Balance"
-                                                                               HelpText="What this account is worth today."
-                                                                               Placeholder="0"
-                                                                               Text="{Binding BalanceText, Mode=TwoWay}" />
-                                                    <controls:NumericInputView Grid.Column="1"
-                                                                               Header="Contribution"
-                                                                               HelpText="How much you add to this account each year."
-                                                                               Placeholder="0"
-                                                                               PeriodSuffix="/yr"
-                                                                               Text="{Binding AnnualContributionText, Mode=TwoWay}" />
-                                                </Grid>
-                                                <Grid ColumnDefinitions="*,*" ColumnSpacing="{StaticResource SpaceSm}">
-                                                    <controls:NumericInputView Header="Expected return"
-                                                                               HelpText="Expected average annual return for this account."
-                                                                               Placeholder="5"
-                                                                               PeriodSuffix="%"
-                                                                               Text="{Binding AnnualReturnText, Mode=TwoWay}" />
-                                                    <controls:NumericInputView Grid.Column="1"
-                                                                               Header="Available age"
-                                                                               HelpText="Age when you can withdraw from this account without penalty."
-                                                                               Placeholder="59"
-                                                                               Text="{Binding AvailableAgeText, Mode=TwoWay}" />
-                                                </Grid>
-                                                <controls:NumericInputView IsVisible="{Binding UsesWithdrawalRate}"
-                                                                           Header="Withdrawal rate"
-                                                                           HelpText="Share of the remaining balance withdrawn each year."
-                                                                           Placeholder="4"
-                                                                           PeriodSuffix="%"
-                                                                           Text="{Binding WithdrawalRateText, Mode=TwoWay}" />
-                                                <controls:NumericInputView IsVisible="{Binding UsesPayoutSchedule}"
-                                                                           Header="Payout years"
-                                                                           HelpText="Number of years the balance is paid out over."
-                                                                           Placeholder="5"
-                                                                           Text="{Binding PayoutYearsText, Mode=TwoWay}" />
-                                                <VerticalStackLayout Spacing="3">
-                                                    <controls:NumericInputView Header="Withdrawal tax rate"
-                                                                               HelpText="Flat estimated tax rate applied to withdrawals from this account."
-                                                                               Placeholder="0"
-                                                                               PeriodSuffix="%"
-                                                                               Text="{Binding WithdrawalTaxRateText, Mode=TwoWay}" />
-                                                    <Label Text="{Binding WithdrawalTaxHelpText}" FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}" />
-                                                </VerticalStackLayout>
-                                            </VerticalStackLayout>
-                                        </VerticalStackLayout>
-                                    </Border>
-                                </DataTemplate>
-                            </BindableLayout.ItemTemplate>
-                        </VerticalStackLayout>
-                    </VerticalStackLayout>
-                </Border>
-
+               
                 <Label Text="{Binding ValidationMessage}" IsVisible="{Binding HasValidationMessage}" TextColor="{StaticResource FixedDanger}" />
                 <Label Text="{Binding StatusMessage}" TextColor="{AppThemeBinding Light={StaticResource TextAccentLight}, Dark={StaticResource TextAccentDark}}" />
                 <Button AutomationId="SaveProfileButton" Text="Save profile" Command="{Binding SaveCommand}" />

--- a/docs/MAUI_DEVFLOW.md
+++ b/docs/MAUI_DEVFLOW.md
@@ -1,0 +1,138 @@
+# MAUI DevFlow
+
+This repository supports [MAUI DevFlow](https://learn.microsoft.com/dotnet/maui/developer-tools/devflow/)
+for inspecting and automating the companion app during Debug development. DevFlow runs an in-app
+agent, coordinated by a local broker; it never transmits financial data to a service.
+
+> [!WARNING]
+> DevFlow is experimental. Enable it only for Debug builds. It is intentionally opt-in and is not
+> part of Release builds.
+
+## Prerequisites
+
+Install the DevFlow CLI and start its broker:
+
+```bash
+dotnet tool install -g Microsoft.Maui.Cli --prerelease
+maui devflow broker start
+maui devflow broker status
+```
+
+The project pins the matching `Microsoft.Maui.DevFlow.Agent` preview package. Its
+[`.mauidevflow`](../app/MyFireNumber/.mauidevflow) file configures the broker port used for
+automatic agent discovery.
+
+## Build with DevFlow
+
+Pass `MauiDevFlowEnabled=true` when building a Debug target:
+
+```bash
+dotnet restore app/MyFireNumber/MyFireNumber.csproj -p:MauiDevFlowEnabled=true
+
+dotnet build app/MyFireNumber/MyFireNumber.csproj \
+  -f net10.0-maccatalyst \
+  -c Debug \
+  -p:MauiDevFlowEnabled=true \
+  --no-restore
+```
+
+The opt-in property adds the agent package and defines `MAUI_DEVFLOW`. The app registers the agent
+in [`MauiProgram.cs`](../app/MyFireNumber/MauiProgram.cs) for each configured target: Android, iOS,
+Mac Catalyst, and Windows.
+
+## Mac Catalyst
+
+Build, launch, and wait for the agent:
+
+```bash
+dotnet build app/MyFireNumber/MyFireNumber.csproj \
+  -f net10.0-maccatalyst \
+  -c Debug \
+  -p:MauiDevFlowEnabled=true
+
+open "app/MyFireNumber/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/My Fire #.app"
+
+maui devflow wait \
+  --project app/MyFireNumber/MyFireNumber.csproj \
+  --wait-platform maccatalyst \
+  --timeout 120
+```
+
+Verify the connection and inspect the UI:
+
+```bash
+maui devflow list
+maui devflow ui status
+maui devflow ui tree --depth 4 --format compact
+maui devflow ui screenshot --output artifacts/maccatalyst.png --overwrite
+```
+
+## iOS Simulator
+
+Start a simulator, then run the instrumented target against its UDID:
+
+```bash
+maui apple simulator list
+maui apple simulator start "<simulator-name-or-udid>"
+
+dotnet build app/MyFireNumber/MyFireNumber.csproj \
+  -t:Run \
+  -f net10.0-ios \
+  -c Debug \
+  -p:MauiDevFlowEnabled=true \
+  -p:_DeviceName=:v2:udid="<simulator-udid>"
+
+maui devflow wait \
+  --project app/MyFireNumber/MyFireNumber.csproj \
+  --wait-platform ios \
+  --timeout 120
+```
+
+## Android
+
+Android requires ADB reverse port forwarding each time an emulator or connected device restarts.
+Use the serial reported by `adb devices`:
+
+```bash
+adb -s "<device-serial>" reverse tcp:19223 tcp:19223
+
+dotnet build app/MyFireNumber/MyFireNumber.csproj \
+  -t:Run \
+  -f net10.0-android \
+  -c Debug \
+  -p:MauiDevFlowEnabled=true
+```
+
+After the agent registers, forward its assigned port from `maui devflow list`:
+
+```bash
+adb -s "<device-serial>" reverse tcp:<agent-port> tcp:<agent-port>
+```
+
+## Windows
+
+The agent is registered for the Windows target when the project is built on Windows:
+
+```powershell
+dotnet build app/MyFireNumber/MyFireNumber.csproj `
+  -f net10.0-windows10.0.19041.0 `
+  -c Debug `
+  -p:MauiDevFlowEnabled=true
+```
+
+## Troubleshooting
+
+Run the built-in checks first:
+
+```bash
+maui devflow diagnose --platform maccatalyst
+maui devflow list
+```
+
+If Mac Catalyst crashes during startup with a `FileNotFoundException` for
+`Microsoft.Maui.DevFlow.Agent`, confirm that the agent package reference does **not** use
+`PrivateAssets="all"`. That setting prevents the assembly from being bundled with the Mac Catalyst
+app.
+
+Current DevFlow runtime support is strongest on Mac Catalyst and iOS Simulator. Android requires
+the ADB forwarding above, and Windows support remains in progress.


### PR DESCRIPTION
## Summary
- improve onboarding navigation and route consistency
- expand Profile account-management UI
- enable and document Debug-only MAUI DevFlow across configured targets

## Validation
- `dotnet build app/MyFireNumber/MyFireNumber.csproj --framework net10.0-maccatalyst --configuration Debug -p:MauiDevFlowEnabled=true --no-restore`
- `dotnet build app/MyFireNumber/MyFireNumber.csproj --framework net10.0-ios --configuration Debug -p:MauiDevFlowEnabled=true --no-restore`
- `dotnet build app/MyFireNumber/MyFireNumber.csproj --framework net10.0-android --configuration Debug -p:MauiDevFlowEnabled=true --no-restore`
- Verified the Mac Catalyst DevFlow agent registered and returned a live UI tree.